### PR TITLE
Fix starter on Android 12 Beta 1

### DIFF
--- a/starter/src/main/java/moe/shizuku/starter/ktx/IContentProvider.kt
+++ b/starter/src/main/java/moe/shizuku/starter/ktx/IContentProvider.kt
@@ -1,17 +1,22 @@
 package moe.shizuku.starter.ktx
 
+import android.content.AttributionSource
 import android.content.IContentProvider
-import android.os.Build
 import android.os.Bundle
 import android.os.RemoteException
+import moe.shizuku.starter.utils.BuildUtils
+import moe.shizuku.starter.utils.OsUtils
 
 @Throws(RemoteException::class)
 fun IContentProvider.callCompat(callingPkg: String?, featureId: String?, authority: String?, method: String?, arg: String?, extras: Bundle?): Bundle {
     return when {
-        Build.VERSION.SDK_INT >= 30 -> {
+        BuildUtils.atLeast31() -> {
+            call(AttributionSource.Builder(OsUtils.getUid()).setPackageName(callingPkg).build(), authority, method, arg, extras)
+        }
+        BuildUtils.atLeast30() -> {
             call(callingPkg, featureId, authority, method, arg, extras)
         }
-        Build.VERSION.SDK_INT >= 29 -> {
+        BuildUtils.atLeast29() -> {
             call(callingPkg, authority, method, arg, extras)
         }
         else -> {

--- a/starter/src/main/java/moe/shizuku/starter/utils/BuildUtils.java
+++ b/starter/src/main/java/moe/shizuku/starter/utils/BuildUtils.java
@@ -1,0 +1,38 @@
+package moe.shizuku.starter.utils;
+
+import android.os.Build;
+
+public class BuildUtils {
+
+    private static final int SDK = Build.VERSION.SDK_INT;
+
+    private static final int PREVIEW_SDK = SDK >= 23 ? Build.VERSION.PREVIEW_SDK_INT : 0;
+
+    public static boolean atLeast31() {
+        return SDK >= 31 || SDK == 30 && PREVIEW_SDK > 0;
+    }
+
+    public static boolean atLeast30() {
+        return SDK >= 30;
+    }
+
+    public static boolean atLeast29() {
+        return SDK >= 29;
+    }
+
+    public static boolean atLeast28() {
+        return SDK >= 28;
+    }
+
+    public static boolean atLeast26() {
+        return SDK >= 26;
+    }
+
+    public static boolean atLeast24() {
+        return SDK >= 24;
+    }
+
+    public static boolean atLeast23() {
+        return SDK >= 23;
+    }
+}

--- a/starter/src/main/java/moe/shizuku/starter/utils/OsUtils.java
+++ b/starter/src/main/java/moe/shizuku/starter/utils/OsUtils.java
@@ -1,0 +1,12 @@
+package moe.shizuku.starter.utils;
+
+public class OsUtils {
+
+    private static final int UID = android.system.Os.getuid();
+
+    public static int getUid() {
+        return UID;
+    }
+
+}
+


### PR DESCRIPTION
Android 12 changed IContentProvider, as was handled in 9b4cb804e845a52fb59dc1aa606bb3f4ad8f0810, but IContentProvider was not changed in the starter, and thus Shizuku fails to bind to services on Android 12:

```
E ShizukuServiceStarter: java.lang.NoSuchMethodError: No interface method call(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Landroid/os/Bundle;)Landroid/os/Bundle; in class Landroid/content/IContentProvider; or its super classes (declaration of 'android.content.IContentProvider' appears in /system/framework/framework.jar)
E ShizukuServiceStarter: 	at rikka.shizuku.rp.a(SourceFile:2)
E ShizukuServiceStarter: 	at moe.shizuku.starter.ServiceStarter.c(SourceFile:9)
E ShizukuServiceStarter: 	at moe.shizuku.starter.ServiceStarter.main(SourceFile:25)
E ShizukuServiceStarter: 	at com.android.internal.os.RuntimeInit.nativeFinishInit(Native Method)
E ShizukuServiceStarter: 	at com.android.internal.os.RuntimeInit.main(RuntimeInit.java:355)
```
(tested on an emulator and verified that it happens on a real device too, though I don't have one to test on)

Copying the fix from server to starter fixes the issue, and to keep it similar I copied across the utils and formatting of the class. Verified on the emulator.