### PR TITLE
Fix the crash caused by null android:src in ic_default_app_icon before 26.

### DIFF
--- a/manager/src/main/res/drawable/ic_default_app_icon.xml
+++ b/manager/src/main/res/drawable/ic_default_app_icon.xml
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <bitmap xmlns:android="http://schemas.android.com/apk/res/android"
-    android:src="@null" />
+    android:src="@android:drawable/ic_menu_gallery" />


### PR DESCRIPTION
The shizuku clients installed in different multi-user environment will cause the manager to crash when listing them.

```
2021-07-02 23:06:08.282 4463-4463/moe.shizuku.privileged.api E/AndroidRuntime: FATAL EXCEPTION: main
    Process: moe.shizuku.privileged.api, PID: 4463
    android.content.res.Resources$NotFoundException: Drawable moe.shizuku.privileged.api:drawable/ic_default_app_icon with resource ID #0x7f08004f
    Caused by: android.content.res.Resources$NotFoundException: File res/drawable/ic_default_app_icon.xml from drawable resource ID #0x7f08004f
        at android.content.res.ResourcesImpl.loadDrawableForCookie(ResourcesImpl.java:725)
        at android.content.res.ResourcesImpl.loadDrawable(ResourcesImpl.java:571)
        at android.content.res.Resources.getDrawable(Resources.java:771)
        at android.content.Context.getDrawable(Context.java:525)
        at androidx.core.content.ContextCompat.getDrawable(ContextCompat.java:455)
        at androidx.appcompat.widget.ResourceManagerInternal.getDrawable(ResourceManagerInternal.java:144)
        at androidx.appcompat.widget.ResourceManagerInternal.getDrawable(ResourceManagerInternal.java:132)
        at androidx.appcompat.content.res.AppCompatResources.getDrawable(AppCompatResources.java:104)
        at androidx.appcompat.widget.AppCompatImageHelper.setImageResource(AppCompatImageHelper.java:90)
        at androidx.appcompat.widget.AppCompatImageView.setImageResource(AppCompatImageView.java:98)
        at moe.shizuku.manager.utils.AppIconCache$loadIconBitmapAsync$1.invokeSuspend(AppIconCache.kt:113)
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
        at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:104)
        at android.os.Handler.handleCallback(Handler.java:751)
        at android.os.Handler.dispatchMessage(Handler.java:95)
        at android.os.Looper.loop(Looper.java:154)
        at android.app.ActivityThread.main(ActivityThread.java:6119)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:886)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:776)
     Caused by: org.xmlpull.v1.XmlPullParserException: Binary XML file line #3: <bitmap> requires a valid 'src' attribute
        at android.graphics.drawable.BitmapDrawable.verifyRequiredAttributes(BitmapDrawable.java:765)
        at android.graphics.drawable.BitmapDrawable.inflate(BitmapDrawable.java:748)
        at android.graphics.drawable.DrawableInflater.inflateFromXml(DrawableInflater.java:130)
        at android.graphics.drawable.Drawable.createFromXmlInner(Drawable.java:1227)
        at android.graphics.drawable.Drawable.createFromXml(Drawable.java:1200)
        at android.content.res.ResourcesImpl.loadDrawableForCookie(ResourcesImpl.java:715)
        at android.content.res.ResourcesImpl.loadDrawable(ResourcesImpl.java:571) 
        at android.content.res.Resources.getDrawable(Resources.java:771) 
        at android.content.Context.getDrawable(Context.java:525) 
        at androidx.core.content.ContextCompat.getDrawable(ContextCompat.java:455) 
        at androidx.appcompat.widget.ResourceManagerInternal.getDrawable(ResourceManagerInternal.java:144) 
        at androidx.appcompat.widget.ResourceManagerInternal.getDrawable(ResourceManagerInternal.java:132) 
        at androidx.appcompat.content.res.AppCompatResources.getDrawable(AppCompatResources.java:104) 
        at androidx.appcompat.widget.AppCompatImageHelper.setImageResource(AppCompatImageHelper.java:90) 
        at androidx.appcompat.widget.AppCompatImageView.setImageResource(AppCompatImageView.java:98) 
        at moe.shizuku.manager.utils.AppIconCache$loadIconBitmapAsync$1.invokeSuspend(AppIconCache.kt:113) 
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33) 
        at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:104) 
        at android.os.Handler.handleCallback(Handler.java:751) 
        at android.os.Handler.dispatchMessage(Handler.java:95) 
        at android.os.Looper.loop(Looper.java:154) 
        at android.app.ActivityThread.main(ActivityThread.java:6119) 
        at java.lang.reflect.Method.invoke(Native Method) 
        at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:886) 
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:776) 
```