### PR TITLE
Quote service arguments in starter command

### DIFF
--- a/starter/src/main/java/moe/shizuku/starter/ServiceStarter.java
+++ b/starter/src/main/java/moe/shizuku/starter/ServiceStarter.java
@@ -45,9 +45,9 @@ public class ServiceStarter {
         }
     }
 
-    private static final String USER_SERVICE_CMD_FORMAT = "(CLASSPATH=%s %s%s /system/bin " +
-            "--nice-name=%s moe.shizuku.starter.ServiceStarter " +
-            "--token=%s --package=%s --class=%s --uid=%d%s)&";
+    private static final String USER_SERVICE_CMD_FORMAT = "(CLASSPATH='%s' %s%s /system/bin " +
+            "--nice-name='%s' moe.shizuku.starter.ServiceStarter " +
+            "--token='%s' --package='%s' --class='%s' --uid=%d%s)&";
 
     public static String commandForUserService(String appProcess, String managerApkPath, String token, String packageName, String classname, String processNameSuffix, int callingUid, boolean debug) {
         String processName = String.format("%s:%s", packageName, processNameSuffix);


### PR DESCRIPTION
Wrap service arguments in the service starter command with single-quotes to fix issues when special characters are present in the arguments. For example, if an app's Shizuku service is a nested class, starting the service fails because `$` appears in the class name and gets resolved to a non-existent shell veriable.

While this is only strictly needed for the class name (and potentially the nice name, if the process name suffix includes special characters), it doesn't hurt to quote all the strings to avoid potential problems in the future.