### PR TITLE
Add retry for get provider at ServiceStarter

### DIFF
--- a/starter/src/main/java/moe/shizuku/starter/ServiceStarter.java
+++ b/starter/src/main/java/moe/shizuku/starter/ServiceStarter.java
@@ -98,7 +98,7 @@ public class ServiceStarter {
         IContentProvider provider = null;
 
         try {
-            for(int i = 0;i < 10;i++)
+            for(int i = 0;i < 50;i++)
             {
                 provider = ActivityManagerApis.getContentProviderExternal(name, userId, null, name);
                 if (provider == null)

--- a/starter/src/main/java/moe/shizuku/starter/ServiceStarter.java
+++ b/starter/src/main/java/moe/shizuku/starter/ServiceStarter.java
@@ -98,7 +98,17 @@ public class ServiceStarter {
         IContentProvider provider = null;
 
         try {
-            provider = ActivityManagerApis.getContentProviderExternal(name, userId, null, name);
+            for(int i = 0;i < 10;i++)
+            {
+                provider = ActivityManagerApis.getContentProviderExternal(name, userId, null, name);
+                if (provider == null)
+                {
+                    Thread.sleep(200);
+                    Log.w(TAG, String.format("provider is null %s %d,try times %d", name, userId,i+1));
+                }
+                else
+                    break;
+            }
             if (provider == null) {
                 Log.e(TAG, String.format("provider is null %s %d", name, userId));
                 return false;


### PR DESCRIPTION
Fix the issue where the provider is null when BindUserService is clicked immediately after the application starts.