### PR TITLE
added support for non-root autostart on boot (can be enabled whit the same toggle in settings)

### DIFF
--- a/manager/src/main/AndroidManifest.xml
+++ b/manager/src/main/AndroidManifest.xml
@@ -7,6 +7,10 @@
     <uses-permission android:name="moe.shizuku.manager.permission.MANAGER" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
+    <!--  this permission is required for autostart on non-root! -->
+    <uses-permission android:name="android.permission.WRITE_SECURE_SETTINGS" tools:ignore="ProtectedPermissions" />
+
     <uses-permission
         android:name="moe.shizuku.manager.permission.API_V23"
         tools:node="remove" />
@@ -83,6 +87,9 @@
                 <action android:name="android.intent.action.APPLICATION_PREFERENCES" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".receiver.LaunchActivity"
+            android:label="" />
         <activity
             android:name=".starter.StarterActivity"
             android:label="@string/starter" />

--- a/manager/src/main/java/moe/shizuku/manager/home/HomeActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/home/HomeActivity.kt
@@ -56,11 +56,6 @@ abstract class HomeActivity : AppBarActivity() {
 
         writeStarterFiles()
 
-        val context = applicationContext
-        val intents = Intent(context, LaunchActivity::class.java)
-        intents.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        //context.startActivity(intents)
-
         val binding = HomeActivityBinding.inflate(layoutInflater)
         setContentView(binding.root)
 

--- a/manager/src/main/java/moe/shizuku/manager/home/HomeActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/home/HomeActivity.kt
@@ -24,6 +24,7 @@ import moe.shizuku.manager.databinding.AboutDialogBinding
 import moe.shizuku.manager.databinding.HomeActivityBinding
 import moe.shizuku.manager.ktx.toHtml
 import moe.shizuku.manager.management.appsViewModel
+import moe.shizuku.manager.receiver.LaunchActivity
 import moe.shizuku.manager.settings.SettingsActivity
 import moe.shizuku.manager.starter.Starter
 import moe.shizuku.manager.utils.AppIconCache
@@ -54,6 +55,11 @@ abstract class HomeActivity : AppBarActivity() {
         super.onCreate(savedInstanceState)
 
         writeStarterFiles()
+
+        val context = applicationContext
+        val intents = Intent(context, LaunchActivity::class.java)
+        intents.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        //context.startActivity(intents)
 
         val binding = HomeActivityBinding.inflate(layoutInflater)
         setContentView(binding.root)

--- a/manager/src/main/java/moe/shizuku/manager/receiver/BootCompleteReceiver.kt
+++ b/manager/src/main/java/moe/shizuku/manager/receiver/BootCompleteReceiver.kt
@@ -3,24 +3,37 @@ package moe.shizuku.manager.receiver
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
+import android.os.Build
+import android.os.Looper
 import android.os.Process
+import android.provider.Settings.Global
 import android.util.Log
+import androidx.annotation.RequiresApi
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.Observer
 import com.topjohnwu.superuser.Shell
+import com.topjohnwu.superuser.internal.UiThreadHandler.handler
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import moe.shizuku.manager.AppConstants
 import moe.shizuku.manager.ShizukuSettings
 import moe.shizuku.manager.ShizukuSettings.LaunchMethod
+import moe.shizuku.manager.adb.AdbClient
+import moe.shizuku.manager.adb.AdbKey
+import moe.shizuku.manager.adb.AdbMdns
+import moe.shizuku.manager.adb.PreferenceAdbKeyStore
 import moe.shizuku.manager.starter.Starter
 import rikka.shizuku.Shizuku
 
+@RequiresApi(Build.VERSION_CODES.R)
 class BootCompleteReceiver : BroadcastReceiver() {
-
     override fun onReceive(context: Context, intent: Intent) {
-        if (Intent.ACTION_LOCKED_BOOT_COMPLETED != intent.action
-            && Intent.ACTION_BOOT_COMPLETED != intent.action) {
-            return
-        }
+        Log.i("shizuku", "start shizukuuuuu")
 
-        if (Process.myUid() / 100000 > 0) return
 
         // TODO Record if receiver is called
         if (ShizukuSettings.getLastLaunchMode() == LaunchMethod.ROOT) {
@@ -34,12 +47,15 @@ class BootCompleteReceiver : BroadcastReceiver() {
     }
 
     private fun start(context: Context) {
+        Log.i("shizuku", "start shizukuuuuu")
         if (!Shell.rootAccess()) {
-            //NotificationHelper.notify(context, AppConstants.NOTIFICATION_ID_STATUS, AppConstants.NOTIFICATION_CHANNEL_STATUS, R.string.notification_service_start_no_root)
-            return
+            Log.i("shizuku", "start non-root sihzuku")
+            val intents = Intent(context, LaunchActivity::class.java)
+            intents.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            context.startActivity(intents)
+        } else {
+            Starter.writeDataFiles(context)
+            Shell.su(Starter.dataCommand).exec()
         }
-
-        Starter.writeDataFiles(context)
-        Shell.su(Starter.dataCommand).exec()
     }
 }

--- a/manager/src/main/java/moe/shizuku/manager/receiver/BootCompleteReceiver.kt
+++ b/manager/src/main/java/moe/shizuku/manager/receiver/BootCompleteReceiver.kt
@@ -32,9 +32,6 @@ import rikka.shizuku.Shizuku
 @RequiresApi(Build.VERSION_CODES.R)
 class BootCompleteReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
-        Log.i("shizuku", "start shizukuuuuu")
-
-
         // TODO Record if receiver is called
         if (ShizukuSettings.getLastLaunchMode() == LaunchMethod.ROOT) {
             Log.i(AppConstants.TAG, "start on boot, action=" + intent.action)
@@ -47,7 +44,6 @@ class BootCompleteReceiver : BroadcastReceiver() {
     }
 
     private fun start(context: Context) {
-        Log.i("shizuku", "start shizukuuuuu")
         if (!Shell.rootAccess()) {
             Log.i("shizuku", "start non-root sihzuku")
             val intents = Intent(context, LaunchActivity::class.java)

--- a/manager/src/main/java/moe/shizuku/manager/receiver/LaunchActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/receiver/LaunchActivity.kt
@@ -1,0 +1,49 @@
+package moe.shizuku.manager.receiver
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
+import android.os.Build
+import android.os.Bundle
+import android.os.Looper
+import android.util.Log
+import androidx.activity.ComponentActivity
+import androidx.annotation.RequiresApi
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.Observer
+import com.topjohnwu.superuser.internal.UiThreadHandler.handler
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import moe.shizuku.manager.ShizukuSettings
+import moe.shizuku.manager.adb.AdbClient
+import moe.shizuku.manager.adb.AdbKey
+import moe.shizuku.manager.adb.AdbMdns
+import moe.shizuku.manager.adb.PreferenceAdbKeyStore
+import moe.shizuku.manager.starter.Starter
+
+fun SecureSettingsAllowed(context: Context): Boolean {
+    val packageInfo: PackageInfo = context.packageManager.getPackageInfo(context.packageName, PackageManager.GET_PERMISSIONS)
+    val list: List<String>  = packageInfo.requestedPermissions!!.filterIndexed { index, permission ->
+        (packageInfo.requestedPermissionsFlags[index] and PackageInfo.REQUESTED_PERMISSION_GRANTED) != 0
+    }
+    if (list.contains("android.permission.WRITE_SECURE_SETTINGS")) { return true } else {return false}
+}
+
+class LaunchActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        GlobalScope.launch { delay(1000)
+            Starter.writeSdcardFiles(applicationContext)
+            val context = applicationContext
+            if(SecureSettingsAllowed(context)) {
+                Log.i(application.packageName, "SecureSettingsAllowed")
+                val serviceIntent = Intent(context, StartService::class.java)
+                context.startService(serviceIntent)
+            }
+        }
+    }
+}

--- a/manager/src/main/java/moe/shizuku/manager/receiver/startService.kt
+++ b/manager/src/main/java/moe/shizuku/manager/receiver/startService.kt
@@ -1,0 +1,85 @@
+package moe.shizuku.manager.receiver
+
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.os.IBinder
+import android.os.Looper
+import android.provider.Settings.Global
+import android.util.Log
+import androidx.annotation.RequiresApi
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.Observer
+import com.topjohnwu.superuser.internal.UiThreadHandler.handler
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import moe.shizuku.manager.ShizukuSettings
+import moe.shizuku.manager.adb.AdbClient
+import moe.shizuku.manager.adb.AdbKey
+import moe.shizuku.manager.adb.AdbMdns
+import moe.shizuku.manager.adb.PreferenceAdbKeyStore
+import moe.shizuku.manager.starter.Starter
+
+private fun Launch(port: Int) {
+    Log.i("AAAA", "LAUNCHING SHIZUKU")
+    GlobalScope.launch(Dispatchers.IO) {
+        val host = "127.0.0.1"
+
+        val key = try {
+            AdbKey(PreferenceAdbKeyStore(ShizukuSettings.getPreferences()), "shizuku")
+        } catch (e: Throwable) {
+            e.printStackTrace()
+            return@launch
+        }
+        AdbClient(host, port, key).runCatching {
+            connect()
+            shellCommand(Starter.sdcardCommand) {}
+            close()
+        }.onFailure {
+            it.printStackTrace()
+        }
+    }
+
+}
+
+@RequiresApi(Build.VERSION_CODES.R)
+fun startupNonRoot(context: Context) {
+    val adbPort = MutableLiveData<Int>()
+    val adbConnect = AdbMdns(context, AdbMdns.TLS_CONNECT, adbPort)
+    val ConnectObserver = Observer<Int> { port ->
+        if (port in 0..65535) {
+            Log.i(context.packageName, "port: " + port)
+            adbConnect.stop()
+            Launch(port)
+        }
+    }
+    if (Looper.myLooper() == Looper.getMainLooper()) {
+        adbPort.observeForever(ConnectObserver)
+    } else {
+        handler.post { adbPort.observeForever(ConnectObserver) }
+    }
+    adbConnect.start()
+}
+
+
+class StartService() : Service() {
+    @RequiresApi(Build.VERSION_CODES.R)
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        Log.i(application.packageName, "startservice")
+        GlobalScope.launch {
+            delay(500)
+            val context = getApplicationContext();
+            Global.putLong(context.getContentResolver(), "adb_allowed_connection_time", 0L)
+            Global.putInt(context.getContentResolver(), "adb_wifi_enabled", 1);
+            Log.i(application.packageName, "adb_wifi_enabled")
+            startupNonRoot(context)
+        }
+        return START_STICKY  // Consider using START_STICKY to restart the service if killed
+    }
+    override fun onBind(intent: Intent?): IBinder? {
+        return null  // We don't intend to bind to this service from other components
+    }
+}


### PR DESCRIPTION
Quite a while ago i made a discussion post about a way to have shizuku autorun on non-root devices, this sadly requires a permission that is not allowed to be published on google play, so i made a functions that detects IF shizuku has WRITE_SECURE_PERMISSION or not, so for google play the permission can be removed from the manifest and shizuku will function without error, just without the autorun function working on non-root

on BootCompleteReceiver it checks if device previously connected with adb and if so then its starts a service in the background that turns on wireless debugging (and also disables adb unathourization so over time you wont have to re-pair wireless adb)

permissions are checked and granted on the first time the user pairs shizuku.

I've gotten into some issues regarding memory managments systems like the ones in MIUI that destroy any service that exists, so for these any battery saver mode needs to be disabled, and so is "pause app activity if unused" needs to be turned off, unfortunately I don't know how to work with XML layouts so I'm unable to add any disclaimer regarding this issue, also the toggle in the settings needs to be modified to make it clear that is also works now on non-root. I just don't know how to do that.

Hope this can be a usefull addition to this great app.