### PR TITLE
Some changes to prevent Shizuku from being detected by other apps

### DIFF
--- a/manager/src/main/jni/starter.cpp
+++ b/manager/src/main/jni/starter.cpp
@@ -16,6 +16,11 @@
 #include "cgroup.h"
 #include "logging.h"
 
+#include <vector>
+#include <string>
+#include <regex>
+#include <random>
+
 #ifdef DEBUG
 #define JAVA_DEBUGGABLE
 #endif
@@ -167,6 +172,46 @@ static int switch_cgroup() {
 
 char *context = nullptr;
 
+std::string find_or_create_shizuku_file() {
+    const std::string directory = "/data/local/tmp/";
+    std::string file_path;
+
+    // Try to find existing shizuku file
+    DIR* dir = opendir(directory.c_str());
+    if (dir != nullptr) {
+        std::regex pattern("^shizuku-[A-Za-z0-9]{6}$");
+        struct dirent* entry;
+
+        while ((entry = readdir(dir)) != nullptr) {
+            if (entry->d_type == DT_REG) { // Regular file
+                std::string filename(entry->d_name);
+                if (std::regex_match(filename, pattern)) {
+                    file_path = directory + filename;
+                    break;
+                }
+            }
+        }
+        closedir(dir);
+    }
+
+    // If not found, create new one
+    if (file_path.empty()) {
+        const std::string chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+        std::random_device rd;
+        std::mt19937 generator(rd());
+        std::uniform_int_distribution<> distribution(0, chars.size() - 1);
+
+        std::string suffix;
+        for (int i = 0; i < 6; ++i) {
+            suffix += chars[distribution(generator)];
+        }
+
+        file_path = directory + "shizuku-" + suffix;
+    }
+
+    return file_path;
+}
+
 int starter_main(int argc, char *argv[]) {
     char *apk_path = nullptr;
     for (int i = 0; i < argc; ++i) {
@@ -215,11 +260,12 @@ int starter_main(int argc, char *argv[]) {
         }
     }
 
-    mkdir("/data/local/tmp/shizuku", 0707);
-    chmod("/data/local/tmp/shizuku", 0707);
+    std::string file = find_or_create_shizuku_file();
+    mkdir(file.c_str(), 0707);
+    chmod(file.c_str(), 0707);
     if (uid == 0) {
-        chown("/data/local/tmp/shizuku", 2000, 2000);
-        se::setfilecon("/data/local/tmp/shizuku", "u:object_r:shell_data_file:s0");
+        chown(file.c_str(), 2000, 2000);
+        se::setfilecon(file.c_str(), "u:object_r:shell_data_file:s0");
     }
 
     printf("info: starter begin\n");

--- a/manager/src/main/jni/starter.cpp
+++ b/manager/src/main/jni/starter.cpp
@@ -183,7 +183,7 @@ std::string find_or_create_shizuku_file() {
         struct dirent* entry;
 
         while ((entry = readdir(dir)) != nullptr) {
-            if (entry->d_type == DT_REG) { // Regular file
+            if (entry->d_type == DT_DIR) { // Regular file
                 std::string filename(entry->d_name);
                 if (std::regex_match(filename, pattern)) {
                     file_path = directory + filename;

--- a/manager/src/main/res/raw/start.sh
+++ b/manager/src/main/res/raw/start.sh
@@ -46,6 +46,8 @@ if [ -f $STARTER_PATH ]; then
     else
         echo "info: shizuku_starter exit with 0"
     fi
+    echo "info: remove starter file"
+    rm -f $STARTER_PATH
 else
     echo "Starter file not exist, please open Shizuku and try again."
 fi

--- a/manager/src/main/res/raw/start.sh
+++ b/manager/src/main/res/raw/start.sh
@@ -46,8 +46,7 @@ if [ -f $STARTER_PATH ]; then
     else
         echo "info: shizuku_starter exit with 0"
     fi
-    echo "info: remove starter file"
-    rm -f $STARTER_PATH
+    rm -f $STARTER_PATH 2>&1 > /dev/null
 else
     echo "Starter file not exist, please open Shizuku and try again."
 fi

--- a/server/src/main/java/rikka/shizuku/server/ShizukuConfigManager.java
+++ b/server/src/main/java/rikka/shizuku/server/ShizukuConfigManager.java
@@ -12,12 +12,15 @@ import androidx.annotation.Nullable;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
+import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -39,8 +42,33 @@ public class ShizukuConfigManager extends ConfigManager {
 
     private static final long WRITE_DELAY = 10 * 1000;
 
-    private static final File FILE = new File("/data/local/tmp/shizuku/shizuku.json");
-    private static final AtomicFile ATOMIC_FILE = new AtomicFile(FILE);
+    private static final AtomicFile ATOMIC_FILE;
+
+    static {
+        File FILE = null;
+        File directory = new File("/data/local/tmp/");
+        File[] files = directory.listFiles();
+
+        if (files != null) {
+            for (File file : files) {
+                if (file.getName().matches("^shizuku-[A-Za-z0-9]{6}$")) {
+                    FILE = file;
+                }
+            }
+        }
+
+        if (FILE == null) {
+            String chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+            SecureRandom random = new SecureRandom();
+            StringBuilder sb = new StringBuilder(6);
+            for (int i = 0; i < 6; i++) {
+                sb.append(chars.charAt(random.nextInt(chars.length())));
+            }
+            FILE = new File(directory, "shizuku-" + sb);
+        }
+
+        ATOMIC_FILE = new AtomicFile(FILE);
+    }
 
     public static ShizukuConfig load() {
         FileInputStream stream;

--- a/server/src/main/java/rikka/shizuku/server/ShizukuConfigManager.java
+++ b/server/src/main/java/rikka/shizuku/server/ShizukuConfigManager.java
@@ -12,15 +12,12 @@ import androidx.annotation.Nullable;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -46,25 +43,22 @@ public class ShizukuConfigManager extends ConfigManager {
 
     static {
         File FILE = null;
-        File directory = new File("/data/local/tmp/");
-        File[] files = directory.listFiles();
+        String dir = "/data/local/tmp";
+        File directory = new File(dir);
+        String[] files = directory.list();
 
         if (files != null) {
-            for (File file : files) {
-                if (file.getName().matches("^shizuku-[A-Za-z0-9]{6}$")) {
-                    FILE = file;
+            for (String file : files) {
+                if (file.matches("^shizuku-[A-Za-z0-9]{6}$")) {
+                    FILE = new File(dir + "/" + file + "/shizuku.json");
                 }
             }
+            LOGGER.d("Found: " + FILE.getAbsolutePath());
         }
 
         if (FILE == null) {
-            String chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
-            SecureRandom random = new SecureRandom();
-            StringBuilder sb = new StringBuilder(6);
-            for (int i = 0; i < 6; i++) {
-                sb.append(chars.charAt(random.nextInt(chars.length())));
-            }
-            FILE = new File(directory, "shizuku-" + sb);
+            LOGGER.i("no existing config file");
+            System.exit(255);
         }
 
         ATOMIC_FILE = new AtomicFile(FILE);


### PR DESCRIPTION
Randomize the folder name of `/data/local/tmp/shizuku`  
Automatically delete the `/data/local/tmp/starter` file