### PR TITLE
feat: scroll to wireless debugging for intents

### DIFF
--- a/manager/src/main/java/moe/shizuku/manager/adb/AdbPairingTutorialActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/adb/AdbPairingTutorialActivity.kt
@@ -47,8 +47,11 @@ class AdbPairingTutorialActivity : AppBarActivity() {
             }
 
             developerOptions.setOnClickListener {
-                val intent = Intent(Settings.ACTION_APPLICATION_DEVELOPMENT_SETTINGS)
-                intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+                val intent = Intent(Settings.ACTION_APPLICATION_DEVELOPMENT_SETTINGS).apply {
+                    putExtra(":settings:fragment_args_key", "toggle_adb_wireless")
+                    flags = Intent.FLAG_ACTIVITY_NEW_TASK
+                }
+
                 try {
                     context.startActivity(intent)
                 } catch (e: ActivityNotFoundException) {

--- a/manager/src/main/java/moe/shizuku/manager/home/AdbDialogFragment.kt
+++ b/manager/src/main/java/moe/shizuku/manager/home/AdbDialogFragment.kt
@@ -61,8 +61,11 @@ class AdbDialogFragment : DialogFragment() {
         adbMdns.start()
 
         dialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener {
-            val intent = Intent(Settings.ACTION_APPLICATION_DEVELOPMENT_SETTINGS)
-            intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+            val intent = Intent(Settings.ACTION_APPLICATION_DEVELOPMENT_SETTINGS).apply {
+                putExtra(":settings:fragment_args_key", "toggle_adb_wireless")
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK
+            }
+
             try {
                 it.context.startActivity(intent)
             } catch (e: ActivityNotFoundException) {

--- a/manager/src/main/java/moe/shizuku/manager/home/AdbPairDialogFragment.kt
+++ b/manager/src/main/java/moe/shizuku/manager/home/AdbPairDialogFragment.kt
@@ -65,8 +65,11 @@ class AdbPairDialogFragment : DialogFragment() {
         dialog.getButton(AlertDialog.BUTTON_POSITIVE).isVisible = false
 
         dialog.getButton(AlertDialog.BUTTON_NEUTRAL).setOnClickListener {
-            val intent = Intent(Settings.ACTION_APPLICATION_DEVELOPMENT_SETTINGS)
-            intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+            val intent = Intent(Settings.ACTION_APPLICATION_DEVELOPMENT_SETTINGS).apply {
+                putExtra(":settings:fragment_args_key", "toggle_adb_wireless")
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK
+            }
+
             try {
                 it.context.startActivity(intent)
             } catch (e: ActivityNotFoundException) {


### PR DESCRIPTION
## About
This PR adds extra `:settings:fragment_args_key` to intents launching `ACTION_APPLICATION_DEVELOPMENT_SETTINGS` to automatically scroll to wireless debugging.

### Screenshots

https://github.com/user-attachments/assets/0c5a0f07-ae39-479d-a53e-a4293a0f2122

### Tests
- [x] Tested on Pixel 7 Pro