### PR TITLE
Improve common law trademark claim

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,20 +1,20 @@
 ---
 name: Bug report
-about: Report a bug of Shizuku
+about: Report a bug of Shizuku™
 title: ''
 labels: ''
 assignees: ''
 
 ---
 
-Please report bugs of Shizuku itself.
+Please report bugs of Shizuku™ itself.
 
 **Requirements:**
 
-- [ ] Shizuku version is up-to-date
-- [ ] Shizuku is downloaded from official channels (GitHub release or Google Play)
-- [ ] Shizuku is not running in a virtual environment or broken ROM (GrapheneOS)
-- [ ] (Root users) No Xposed installed / Xposed is not enabled for Shizuku
+- [ ] Shizuku™ version is up-to-date
+- [ ] Shizuku™ is downloaded from official channels (GitHub release or Google Play)
+- [ ] Shizuku™ is not running in a virtual environment or broken ROM (GrapheneOS)
+- [ ] (Root users) No Xposed installed / Xposed is not enabled for Shizuku™
 
 Change "[ ]" to "[x]" if it meets the requirements.
 
@@ -22,7 +22,7 @@ Change "[ ]" to "[x]" if it meets the requirements.
 
 **Information:**
 
-- Shizuku version:
+- Shizuku™ version:
 - Mode: [adb, root]
 - Android version:
 - Device: (optional)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Shizuku
+# Shizuku™
+
+![](./manager/src/main/res/mipmap-xxxhdpi/ic_launcher.png)
 
 ## Background
 
@@ -11,13 +13,13 @@ This method has very big disadvantages:
 3. The possibility is limited to available commands
 4. Even if ADB has sufficient permissions, the app requires root privileges to run
 
-Shizuku uses a completely different way. See detailed description below.
+Shizuku™ uses a completely different way. See detailed description below.
 
 ## User guide & Download
 
 <https://shizuku.rikka.app/>
 
-## How does Shizuku work?
+## How does Shizuku™ work?
 
 First, we need to talk about how app use system APIs. For example, if the app wants to get installed apps, we all know we should use `PackageManager#getInstalledPackages()`. This is actually an interprocess communication (IPC) process of the app process and system server process, just the Android framework did the inner works for us.
 
@@ -25,9 +27,9 @@ Android uses `binder` to do this type of IPC. `Binder` allows the server-side to
 
 Usually, if there is a "manager" (e.g., `PackageManager`) for apps to use, there should be a "service" (e.g., `PackageManagerService`) in the system server process. We can simply think if the app holds the `binder` of the "service", it can communicate with the "service". The app process will receive binders of system services on start.
 
-Shizuku guides users to run a process, Shizuku server, with root or ADB first. When the app starts, the `binder` to Shizuku server will also be sent to the app.
+Shizuku™ guides users to run a process, Shizuku™ server, with root or ADB first. When the app starts, the `binder` to Shizuku™ server will also be sent to the app.
 
-The most important feature Shizuku provides is something like be a middle man to receive requests from the app, sent them to the system server, and send back the results. You can see the `transactRemote` method in `rikka.shizuku.server.ShizukuService` class, and `moe.shizuku.api.ShizukuBinderWrapper` class for the detail.
+The most important feature Shizuku™ provides is something like be a middle man to receive requests from the app, sent them to the system server, and send back the results. You can see the `transactRemote` method in `rikka.shizuku.server.ShizukuService` class, and `moe.shizuku.api.ShizukuBinderWrapper` class for the detail.
 
 So, we reached our goal, to use system APIs with higher permission. And to the app, it is almost identical to the use of system APIs directly.
 
@@ -49,7 +51,7 @@ https://github.com/RikkaApps/Shizuku-API#migration-guide-for-existing-applicatio
 
    ADB has limited permissions and different on various system versions. You can see permissions granted to ADB [here](https://github.com/aosp-mirror/platform_frameworks_base/blob/master/packages/Shell/AndroidManifest.xml).
 
-   Before calling the API, you can use `ShizukuService#getUid` to check if Shizuku is running user ADB, or use `ShizukuService#checkPermission` to check if the server has sufficient permissions.
+   Before calling the API, you can use `ShizukuService#getUid` to check if Shizuku™ is running user ADB, or use `ShizukuService#checkPermission` to check if the server has sufficient permissions.
 
 2. Hidden API limitation from Android 9
 
@@ -57,7 +59,7 @@ https://github.com/RikkaApps/Shizuku-API#migration-guide-for-existing-applicatio
 
 3. Android 8.0 & ADB
 
-   At present, the way Shizuku service gets the app process is to combine `IActivityManager#registerProcessObserver` and `IActivityManager#registerUidObserver` (26+) to ensure that the app process will be sent when the app starts. However, on API 26, ADB lacks permissions to use `registerUidObserver`, so if you need to use Shizuku in a process that might not be started by an Activity, it is recommended to trigger the send binder by starting a transparent activity.
+   At present, the way Shizuku™ service gets the app process is to combine `IActivityManager#registerProcessObserver` and `IActivityManager#registerUidObserver` (26+) to ensure that the app process will be sent when the app starts. However, on API 26, ADB lacks permissions to use `registerUidObserver`, so if you need to use Shizuku™ in a process that might not be started by an Activity, it is recommended to trigger the send binder by starting a transparent activity.
 
 4. Direct use of `transactRemote` requires attention
 
@@ -65,7 +67,7 @@ https://github.com/RikkaApps/Shizuku-API#migration-guide-for-existing-applicatio
 
    * `SystemServiceHelper.getTransactionCode` may not get the correct transaction code, such as `android.content.pm.IPackageManager$Stub.TRANSACTION_getInstalledPackages` does not exist on API 25 and there is `android.content.pm.IPackageManager$Stub.TRANSACTION_getInstalledPackages_47` (this situation has been dealt with, but it is not excluded that there may be other circumstances). This problem is not encountered with the `ShizukuBinderWrapper` method.
 
-## Developing Shizuku itself
+## Developing Shizuku™ itself
 
 ### Build
 
@@ -78,10 +80,9 @@ The `:manager:assembleDebug` task generates a debuggable server. You can attach 
 
 All code files in this project are licensed under Apache 2.0
 
-Under Apache 2.0 section 6, specifically:
+Under Apache 2.0 section 6, you are NOT granted permission to use the following common law trademarks
 
-* You are **FORBIDDEN** to use `manager/src/main/res/mipmap*/ic_launcher*.png` image files, unless for displaying Shizuku itself.
-
-* You are **FORBIDDEN** to distribute the apk that use Shizuku as name
-or use `moe.shizuku.privileged.api` as application id or declare `moe.shizuku.manager.permission.*` permission
-to any store (IBNLT Google Play Store, F-Droid, Amazon Appstore etc.).
+* The application icons, contained in the `manager/src/main/res/mipmap*/ic_launcher*.png` image files
+* The application name, Shizuku™
+* The application ID, `moe.shizuku.privileged.api`
+* The `moe.shizuku.manager.permission.*` Android permission

--- a/manager/src/main/java/moe/shizuku/manager/shell/ShellBinderRequestHandler.kt
+++ b/manager/src/main/java/moe/shizuku/manager/shell/ShellBinderRequestHandler.kt
@@ -17,7 +17,7 @@ object ShellBinderRequestHandler {
         val binder = intent.getBundleExtra("data")?.getBinder("binder") ?: return false
         val shizukuBinder = Shizuku.getBinder()
         if (shizukuBinder == null) {
-            LOGGER.w("Binder not received or Shizuku service not running")
+            LOGGER.w("Binder not received or Shizuku™ service not running")
         }
 
         val data = Parcel.obtain()

--- a/manager/src/main/jni/starter.cpp
+++ b/manager/src/main/jni/starter.cpp
@@ -191,7 +191,7 @@ int main(int argc, char *argv[]) {
 
     uid_t uid = getuid();
     if (uid != 0 && uid != 2000) {
-        perrorf("fatal: run Shizuku from non root nor adb user (uid=%d).\n", uid);
+        perrorf("fatal: run Shizuku™ from non root nor adb user (uid=%d).\n", uid);
         exit(EXIT_FATAL_UID);
     }
 
@@ -242,7 +242,7 @@ int main(int argc, char *argv[]) {
         if (kill(pid, SIGKILL) == 0)
             printf("info: killed %d (%s)\n", pid, name);
         else if (errno == EPERM) {
-            perrorf("fatal: can't kill %d, please try to stop existing Shizuku from app first.\n", pid);
+            perrorf("fatal: can't kill %d, please try to stop existing Shizuku™ from app first.\n", pid);
             exit(EXIT_FATAL_KILL);
         } else {
             printf("warn: failed to kill %d (%s)\n", pid, name);

--- a/manager/src/main/res/layout/app_list_item.xml
+++ b/manager/src/main/res/layout/app_list_item.xml
@@ -33,7 +33,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:textAppearance="?textAppearanceBodyLarge"
-            tools:text="Shizuku" />
+            tools:text="Shizuku™" />
 
         <TextView
             android:id="@android:id/summary"

--- a/manager/src/main/res/values-ar/strings.xml
+++ b/manager/src/main/res/values-ar/strings.xml
@@ -9,7 +9,7 @@
     <string name="home_adb_dialog_view_command_copy_button">نسخ</string>
     <string name="home_adb_dialog_view_command_button_send">إرسال</string>
     <string name="home_status_service_version_update">الإصدار %2$s, %1$s&lt;br&gt;اعد تشغيل التطبيق من جديد للتحديث إلى الإصدار %3$s</string>
-    <string name="home_adb_description">بالنسبة للأجهزة التي لا تحتوي على الجذر (Root) ، تحتاج إلى استخدام adb لبدء Shizuku (يتطلب اتصال الكمبيوتر). يجب تكرار هذه العملية في كل مرة يتم فيها إعادة تشغيل الجهاز. يرجى <b><a href="%1$s"> قراءة التعليمات </a></b>.</string>
+    <string name="home_adb_description">بالنسبة للأجهزة التي لا تحتوي على الجذر (Root) ، تحتاج إلى استخدام adb لبدء Shizuku™ (يتطلب اتصال الكمبيوتر). يجب تكرار هذه العملية في كل مرة يتم فيها إعادة تشغيل الجهاز. يرجى <b><a href="%1$s"> قراءة التعليمات </a></b>.</string>
     <string name="dialog_adb_discovery_message">يرجى تمكين \"التصحيح اللاسلكي\" في \"خيارات المطور\". \"تصحيح لاسلكي\" يتم تعطيلها عندما تتغير الشبكة تلقائيا.
 \n
 \n ملاحظة، لا تعطل \"خيارات المطور\" أو \"تصحيح USB\"، أو سيتم إيقاف شيزوكو</string>
@@ -17,7 +17,7 @@
     <string name="adb_pairing">الاقتران</string>
     <string name="home_adb_dialog_view_command_message">font face=monospace&gt;%1$s&lt;/font&gt;&lt;br&gt;&lt;br&gt;* هناك بعض الاعتبارات الأخرى، يرجى تأكيد أنك قرأت التعليمات أولا.</string>
     <string name="home_wireless_adb_title">البدء باستخدام التصحيح اللاسلكي</string>
-    <string name="home_wireless_adb_description">على أندرويد 11 وما فوق ، يمكنك تفعيل التصحيح اللاسلكي وبدء Shizuku مباشرة من جهازك ، دون الاحتياج إتصال بالكمبيوتر.&lt;p&gt;يرجى الإطلاع أولاً على التعليمات المفصلة خطوة بخطوة.</string>
+    <string name="home_wireless_adb_description">على أندرويد 11 وما فوق ، يمكنك تفعيل التصحيح اللاسلكي وبدء Shizuku™ مباشرة من جهازك ، دون الاحتياج إتصال بالكمبيوتر.&lt;p&gt;يرجى الإطلاع أولاً على التعليمات المفصلة خطوة بخطوة.</string>
     <string name="dialog_adb_discovery">البحث عن خدمة التصحيح اللاسلكي</string>
     <string name="dialog_adb_invalid_port">المنفذ هو عدد صحيح يتراوح من 1 إلى 65535.</string>
     <string name="home_wireless_adb_view_guide_button">‌دليل خطوة بخطوة</string>
@@ -31,30 +31,30 @@
     <string name="settings_user_interface">المظهر</string>
     <string name="settings_language">اللغة</string>
     <string name="settings_title">الإعدادات</string>
-    <string name="rish_description">باستخدام %1$s ، في أي تطبيق طرفي ، يمكنك الاتصال والتفاعل مع عمليات تشغيل shell بواسطة Shizuku. &lt;p&gt; حول الاستخدام التفصيلي %1$s ، انقر لعرض المستند.</string>
+    <string name="rish_description">باستخدام %1$s ، في أي تطبيق طرفي ، يمكنك الاتصال والتفاعل مع عمليات تشغيل shell بواسطة Shizuku™. &lt;p&gt; حول الاستخدام التفصيلي %1$s ، انقر لعرض المستند.</string>
     <string name="terminal_tutorial_3_description">بعض النصائح: امنح إذن التنفيذ لـ %1$s وأضفه إلى%2$s ، ستتمكن من استخدام %1$s مباشرةً.</string>
-    <string name="terminal_tutorial_3">أخيرًا ، انقل الملفات إلى مكان يمكن لتطبيقك الطرفي الوصول إليه ، وستتمكن من استخدام %1$s لتشغيل الأوامر من خلال Shizuku.</string>
-    <string name="terminal_tutorial_2_description">على سبيل المثال ، إذا كنت تريد استخدام Shizuku في %1$s ، فيجب استبدال %2$s بـ %3$s (%4$s هو اسم الحزمة %1$s).</string>
+    <string name="terminal_tutorial_3">أخيرًا ، انقل الملفات إلى مكان يمكن لتطبيقك الطرفي الوصول إليه ، وستتمكن من استخدام %1$s لتشغيل الأوامر من خلال Shizuku™.</string>
+    <string name="terminal_tutorial_2_description">على سبيل المثال ، إذا كنت تريد استخدام Shizuku™ في %1$s ، فيجب استبدال %2$s بـ %3$s (%4$s هو اسم الحزمة %1$s).</string>
     <string name="terminal_tutorial_2">بعد ذلك ، استخدم أي محرر نصوص لفتح %1$s وقم بتعديله.</string>
     <string name="terminal_export_files">تصدير الملفات</string>
     <string name="terminal_tutorial_1_description">إذا كانت هناك ملفات بنفس الاسم في المجلد المحدد ، فسيتم حذفها.
 \n
-\nتستخدم وظيفة التصدير SAF (إطار عمل الوصول إلى التخزين). يُذكر أن MIUI قد يخرب وظائف SAF. إذا كنت من تستخدمي MIUI ، فقد تضطر إلى استخراج الملف من APK Shizuku أو تنزيله من GitHub.</string>
+\nتستخدم وظيفة التصدير SAF (إطار عمل الوصول إلى التخزين). يُذكر أن MIUI قد يخرب وظائف SAF. إذا كنت من تستخدمي MIUI ، فقد تضطر إلى استخراج الملف من APK Shizuku™ أو تنزيله من GitHub.</string>
     <string name="terminal_tutorial_1">أولاً ، قم بتصدير الملفات إلى أي مكان تريده. ستجد ملفين, %1$s و %2$s.</string>
-    <string name="home_terminal_description">قم بتشغيل الأوامر من خلال Shizuku في تطبيقات المحطة التي تريدها</string>
-    <string name="home_terminal_title">استخدم Shizuku في تطبيقات المحطة</string>
-    <string name="app_management_item_summary_requires_root">* يطلب Shizuku الجذر (الروت) للعمل</string>
+    <string name="home_terminal_description">قم بتشغيل الأوامر من خلال Shizuku™ في تطبيقات المحطة التي تريدها</string>
+    <string name="home_terminal_title">استخدم Shizuku™ في تطبيقات المحطة</string>
+    <string name="app_management_item_summary_requires_root">* يطلب Shizuku™ الجذر (الروت) للعمل</string>
     <string name="app_management_dialog_adb_is_limited_message">من المحتمل جدًا أن تحدد الشركة المصنعة للجهاز إذن adb. &lt;p&gt; قد يكون هناك حل لنظامك في &lt;b&gt;&lt;a href=\"%1$s\"&gt;هذا المستند&lt;/a&gt;&lt;/b&gt;.</string>
     <string name="app_management_dialog_adb_is_limited_title">إذن الADB محدود</string>
-    <string name="home_adb_is_limited_description">قامت الشركة المصنعة لجهازك بتقييد أذونات adb ولن تعمل التطبيقات التي تستخدم Shizuku بشكل صحيح.
+    <string name="home_adb_is_limited_description">قامت الشركة المصنعة لجهازك بتقييد أذونات adb ولن تعمل التطبيقات التي تستخدم Shizuku™ بشكل صحيح.
 \n
 \nعادة ، يمكن رفع هذا القيد عن طريق تعديل بعض الخيارات في \"خيارات المطور\". يرجى قراءة التعليمات للحصول على تفاصيل حول كيفية القيام بذلك.
 \n
-\nقد تحتاج إلى إعادة تشغيل Shizuku حتى تدخل العملية حيز التنفيذ.</string>
+\nقد تحتاج إلى إعادة تشغيل Shizuku™ حتى تدخل العملية حيز التنفيذ.</string>
     <string name="home_adb_is_limited_title">أنت بحاجة إلى اتخاذ خطوة إضافية</string>
-    <string name="home_learn_more_description">تعلم كيف تطور مع Shizuku</string>
-    <string name="home_learn_more_title">معلومات عن Shizuku</string>
-    <string name="home_app_management_empty">ستظهر هنا التطبيقات التي تتطلب Shizuku.</string>
+    <string name="home_learn_more_description">تعلم كيف تطور مع Shizuku™</string>
+    <string name="home_learn_more_title">معلومات عن Shizuku™</string>
+    <string name="home_app_management_empty">ستظهر هنا التطبيقات التي تتطلب Shizuku™.</string>
     <string name="home_app_management_view_authorized_apps">انقر لإدارة التطبيقات المصرح بها</string>
     <plurals name="home_app_management_authorized_apps_count">
         <item quantity="zero">تطبيق %d معتمد</item>
@@ -67,21 +67,21 @@
     <string name="home_app_management_title">الإدارة التطبيقية</string>
     <string name="home_root_button_restart">إعادة البدء بالتشغيل</string>
     <string name="home_root_button_start">البدء بالتشغيل</string>
-    <string name="home_root_description_sui">إذا كنت تستخدم Magisk ، فيمكنك تجربة %1$s. بالنسبة لمستخدمي الجذر (الروت) ، سيحل في مكان Shizuku. ملاحظة ، تحتاج التطبيقات الحالية إلى التغيير بسيط لاستخدام %2$s.</string>
-    <string name="home_root_description">بالإضافة إلى ذلك ، يمكن بدء تشغيل Shizuku تلقائياً عند حالة التشغيل بعد القفل. إذا لم يكن الأمر كذلك ، فيرجى التحقق مما إذا كان نظامك أو أدوات الجهات الخارجية (تطبيقات خارجية) قد حد أو عطل Shizuku.
+    <string name="home_root_description_sui">إذا كنت تستخدم Magisk ، فيمكنك تجربة %1$s. بالنسبة لمستخدمي الجذر (الروت) ، سيحل في مكان Shizuku™. ملاحظة ، تحتاج التطبيقات الحالية إلى التغيير بسيط لاستخدام %2$s.</string>
+    <string name="home_root_description">بالإضافة إلى ذلك ، يمكن بدء تشغيل Shizuku™ تلقائياً عند حالة التشغيل بعد القفل. إذا لم يكن الأمر كذلك ، فيرجى التحقق مما إذا كان نظامك أو أدوات الجهات الخارجية (تطبيقات خارجية) قد حد أو عطل Shizuku.
 \n&lt;br&gt; يمكنك الرجوع إلى %s.</string>
     <string name="home_root_title">ابدأ (للأجهزة المجذرة)</string>
     <string name="adb_pairing_tutorial_content_network_limation_not_foreground">بعض الأنظمة (مثل MIUI) لا تسمح للتطبيقات بالوصول إلى الشبكة عندما لا تكون مرئية ، حتى إذا كان التطبيق يستخدم الخدمة الأمامية كمعيار. يرجى تعطيل ميزات تحسين البطارية لـShizuku على هذه الأنظمة.</string>
-    <string name="adb_pairing_tutorial_content_network">يحتاج Shizuku للوصول إلى الشبكة المحلية. يتم التحكم بها عن طريق إذن الشبكة.</string>
-    <string name="adb_pairing_tutorial_content_finish">إرجع إلى Shizuku وقم بتشغيل Shizuku.</string>
+    <string name="adb_pairing_tutorial_content_network">يحتاج Shizuku™ للوصول إلى الشبكة المحلية. يتم التحكم بها عن طريق إذن الشبكة.</string>
+    <string name="adb_pairing_tutorial_content_finish">إرجع إلى Shizuku™ وقم بتشغيل Shizuku™.</string>
     <string name="adb_pairing_tutorial_content_left_is_clickable">يرجى ملاحظة أن الجزء الأيسر من خيار \"التصحيح اللاسلكي\" قابل للنقر عليه ، وسيؤدي النقر عليه إلى فتح صفحة جديدة. تفعيل \"التصحيح اللاسلكي\" من المفتاح الأيمن قد يكون غير صحيح.</string>
     <string name="adb_pairing_tutorial_content_miui_2">بخلاف ذلك ، قد لا تتمكن من إدخال رمز الاقتران من الإشعار.</string>
     <string name="adb_pairing_tutorial_content_miui">قد يحتاج مستخدمو MIUI إلى تبديل نمط الإعلام إلى \"Android\" من \"Notification\" - \"Notification Shade\" في إعدادات النظام.</string>
-    <string name="adb_pairing_tutorial_content_notification_blocked">تحتاج عملية الاقتران إلى التفاعل مع إشعار من Shizuku. يرجى السماح لشيزوكو بنشر الإخطارات.</string>
-    <string name="adb_pairing_tutorial_content_enter_pairing_code">أدخل الرمز في إشعار Shizuku المرسل لإكمال الاقتران.</string>
+    <string name="adb_pairing_tutorial_content_notification_blocked">تحتاج عملية الاقتران إلى التفاعل مع إشعار من Shizuku™. يرجى السماح لشيزوكو بنشر الإخطارات.</string>
+    <string name="adb_pairing_tutorial_content_enter_pairing_code">أدخل الرمز في إشعار Shizuku™ المرسل لإكمال الاقتران.</string>
     <string name="adb_pairing_tutorial_content_steps">أدخل \"خيارات المطور\" - \"التصحيح اللاسلكي\". انقر على \"إقران الجهاز برمز الإقران\" ، وسترى رمزًا مكونًا من ستة أرقام.</string>
-    <string name="adb_pairing_tutorial_content_notification">سيساعدك إشعار من Shizuku على إكمال الاقتران.</string>
-    <string name="adb_pairing_tutorial_title">قم بإقران Shizuku بجهازك</string>
+    <string name="adb_pairing_tutorial_content_notification">سيساعدك إشعار من Shizuku™ على إكمال الاقتران.</string>
+    <string name="adb_pairing_tutorial_title">قم بإقران Shizuku™ بجهازك</string>
     <string name="notification_settings">إعداد الإشعارات</string>
     <string name="development_settings">خيارات للمطور</string>
     <string name="adb_pair_required">يرجى المرور بخطوة الاقتران أولاً.</string>
@@ -98,31 +98,31 @@
     <string name="paring_code_is_wrong">رمز الاقتران خاطئ.</string>
     <string name="dialog_adb_pairing_paring_code">كود الاقتران</string>
     <string name="dialog_adb_discovery_message_toggle_wireless_debugging">يرجى محاولة تعطيل \"التصحيح اللاسلكي\" وتمكينه إذا استمر في البحث.</string>
-    <string name="dialog_stop_message">سيتم إيقاف خدمة Shizuku.</string>
-    <string name="action_stop">إيقاف Shizuku</string>
-    <string name="notification_service_starting">بدأت خدمة Shizuku…</string>
+    <string name="dialog_stop_message">سيتم إيقاف خدمة Shizuku™.</string>
+    <string name="action_stop">إيقاف Shizuku™</string>
+    <string name="notification_service_starting">بدأت خدمة Shizuku™…</string>
     <string name="notification_adb_pairing_service_found_title">تم العثور على خدمة الاقتران</string>
-    <string name="permission_label">الوصول إلى Shizuku</string>
-    <string name="permission_description">اسمح للتطبيق باستخدام Shizuku.</string>
+    <string name="permission_label">الوصول إلى Shizuku™</string>
+    <string name="permission_description">اسمح للتطبيق باستخدام Shizuku™.</string>
     <string name="permission_warning_template">هل تريد السماح لـ <b>%1$s</b> بـ %2$s؟</string>
-    <string name="dialog_requesting_legacy_button_open_shizuku">افتح Shizuku</string>
+    <string name="dialog_requesting_legacy_button_open_shizuku">افتح Shizuku™</string>
     <string name="settings_start_on_boot">ابدأ عند التشغيل من حالة القفل (تحتاج جذر/روت)</string>
     <string name="action_about">حول</string>
     <string name="notification_adb_pairing_succeed_title">تم الاقتران بنجاح</string>
-    <string name="dialog_requesting_legacy_message">يحتوي &lt;b&gt; %1$s &lt;/b&gt; على دعم Shizuku الحديث ، لكنه يتطلب شيزوكو القديم. قد يكون هذا بسبب عدم تشغيل Shizuku ، يرجى التحقق في تطبيق Shizuku. &lt;p&gt; تم إيقاف Legacy Shizuku منذ آذار (مارس) 2019.</string>
+    <string name="dialog_requesting_legacy_message">يحتوي &lt;b&gt; %1$s &lt;/b&gt; على دعم Shizuku™ الحديث ، لكنه يتطلب شيزوكو القديم. قد يكون هذا بسبب عدم تشغيل Shizuku™ ، يرجى التحقق في تطبيق Shizuku. &lt;p&gt; تم إيقاف Legacy Shizuku منذ آذار (مارس) 2019.</string>
     <string name="settings_translation_summary">ساعدنا في ترجمة %s إلى لغتك</string>
-    <string name="settings_start_on_boot_summary">بالنسبة للأجهزة المجذرة (تستخدم الروت) ، يمكن لـShizuku البدء تلقائيًا عند التشغيل من حالة القفل</string>
+    <string name="settings_start_on_boot_summary">بالنسبة للأجهزة المجذرة (تستخدم الروت) ، يمكن لـShizuku™ البدء تلقائيًا عند التشغيل من حالة القفل</string>
     <string name="settings_use_system_color">استخدم لون سمة النظام</string>
     <string name="notification_service_start_no_root">فشل في طلب إذن الجذر (الروت).</string>
     <string name="notification_adb_pairing_searching_for_service_title">البحث عن خدمة الاقتران</string>
-    <string name="notification_adb_pairing_succeed_text">يمكنك بدء خدمة Shizuku الآن.</string>
+    <string name="notification_adb_pairing_succeed_text">يمكنك بدء خدمة Shizuku™ الآن.</string>
     <string name="toast_copied_to_clipboard_with_text">تم نسخ <b>%s</b> إلى الحافظة.</string>
     <string name="notification_channel_service_status">بدء حالة الخدمة</string>
-    <string name="notification_service_start_failed">فشل بدء تشغيل خدمة Shizuku.</string>
+    <string name="notification_service_start_failed">فشل بدء تشغيل خدمة Shizuku™.</string>
     <string name="notification_working">يعمل…</string>
     <string name="start_with_root_failed">لا يمكن بدء الخدمة لأنه لم يتم منح إذن الجذر (الروت) أو قد يكون هذا الجهاز ليس مزوّدًا بحق الوصول إلى الجذر (الروت).</string>
-    <string name="dialog_requesting_legacy_title">يطلب %1$s تطبيق Shizuku القديم</string>
-    <string name="dialog_legacy_not_support_message">تم إهمال Legacy Shizuku منذ آذار (مارس) 2019. أيضًا ، لا يعمل Shizuku القديم على أنظمة Android الأحدث. &lt;p&gt; يُرجى مطالبة مطور &lt;b&gt; %1$s &lt;/b&gt; بالتحديث.</string>
+    <string name="dialog_requesting_legacy_title">يطلب %1$s تطبيق Shizuku™ القديم</string>
+    <string name="dialog_legacy_not_support_message">تم إهمال Legacy Shizuku™ منذ آذار (مارس) 2019. أيضًا ، لا يعمل Shizuku™ القديم على أنظمة Android الأحدث. &lt;p&gt; يُرجى مطالبة مطور &lt;b&gt; %1$s &lt;/b&gt; بالتحديث.</string>
     <string name="settings_translation_contributors">المساهمون في الترجمة</string>
     <string name="settings_translation">شارك في الترجمة</string>
     <string name="about_view_source_code">عرض التعليمات البرمجية المصدر في %s</string>
@@ -138,5 +138,5 @@
     <string name="dialog_cannot_open_browser_title">لا يمكن بدء المتصفح</string>
     <string name="toast_copied_to_clipboard">%s
 \n تم نسخه إلى الحافظة.</string>
-    <string name="dialog_legacy_not_support_title">%1$s لا يدعم النسخة الحديثة من Shizuku</string>
+    <string name="dialog_legacy_not_support_title">%1$s لا يدعم النسخة الحديثة من Shizuku™</string>
 </resources>

--- a/manager/src/main/res/values-az/strings.xml
+++ b/manager/src/main/res/values-az/strings.xml
@@ -2,11 +2,11 @@
 <resources>
     <string name="translation_contributors">By3lish</string>
     <string name="home_adb_dialog_view_command_copy_button">Kopyala</string>
-    <string name="dialog_requesting_legacy_button_open_shizuku">Shizukunu aç</string>
-    <string name="dialog_requesting_legacy_message">&lt;b&gt;%1$s&lt;/b&gt; müasir Shizuku dəstəyinə malikdir, lakin o, köhnə Şizuku tələb edir. Bu, Shizuku işləmədiyinə görə ola bilər, lütfən, Shizuku proqramında yoxlayın.&lt;p&gt;Legacy Shizuku 2019-cu ilin mart ayından etibarən köhnəlib</string>
+    <string name="dialog_requesting_legacy_button_open_shizuku">Shizuku™nu aç</string>
+    <string name="dialog_requesting_legacy_message">&lt;b&gt;%1$s&lt;/b&gt; müasir Shizuku™ dəstəyinə malikdir, lakin o, köhnə Şizuku tələb edir. Bu, Shizuku™ işləmədiyinə görə ola bilər, lütfən, Shizuku™ proqramında yoxlayın.&lt;p&gt;Legacy Shizuku™ 2019-cu ilin mart ayından etibarən köhnəlib</string>
     <string name="dialog_requesting_legacy_title">%1$s köhnə Şizuku tələb edir</string>
-    <string name="dialog_legacy_not_support_message">Köhnə Shizuku 2019-cu ilin mart ayından ləğv edilib. Həmçinin, köhnə Shizuku daha yeni Android sistemlərində işləmir.&lt;p&gt;Lütfən, &lt;b&gt;%1$s&lt;/b&gt; tərtibatçısından yeniləməsini xahiş edin.</string>
-    <string name="dialog_legacy_not_support_title">%1$s müasir Shizukunu dəstəkləmir</string>
+    <string name="dialog_legacy_not_support_message">Köhnə Shizuku™ 2019-cu ilin mart ayından ləğv edilib. Həmçinin, köhnə Shizuku™ daha yeni Android sistemlərində işləmir.&lt;p&gt;Lütfən, &lt;b&gt;%1$s&lt;/b&gt; tərtibatçısından yeniləməsini xahiş edin.</string>
+    <string name="dialog_legacy_not_support_title">%1$s müasir Shizuku™nu dəstəkləmir</string>
     <string name="toast_copied_to_clipboard_with_text"><b>%s</b> kopyalandı.</string>
     <string name="toast_copied_to_clipboard">%s
 \nkopyalandı.</string>
@@ -16,11 +16,11 @@
     <string name="grant_dialog_button_deny">Ləğv et</string>
     <string name="grant_dialog_button_allow_always">Hər zaman icazə ver</string>
     <string name="permission_warning_template"><b>%1$s</b> - ya %2$s üçün icazə verilsin\?</string>
-    <string name="permission_description">Proqramın Shizukudan istifadə etməsinə icazə verin</string>
-    <string name="permission_label">Shizukuya daxil olun</string>
+    <string name="permission_description">Proqramın Shizuku™dan istifadə etməsinə icazə verin</string>
+    <string name="permission_label">Shizuku™ya daxil olun</string>
     <string name="notification_adb_pairing_retry">Yenidən cəhd edin</string>
     <string name="notification_adb_pairing_failed_title">Qoşulma uğursuz oldu</string>
-    <string name="notification_adb_pairing_succeed_text">Siz indi Shizuku xidmətini başlata bilərsiniz.</string>
+    <string name="notification_adb_pairing_succeed_text">Siz indi Shizuku™ xidmətini başlata bilərsiniz.</string>
     <string name="notification_adb_pairing_succeed_title">Qoşulma uğurludur</string>
     <string name="notification_adb_pairing_working_title">Axtarış davam edir</string>
     <string name="notification_adb_pairing_stop_searching">Axtarışı dayandırın</string>
@@ -30,15 +30,15 @@
     <string name="notification_channel_adb_pairing">Simsiz debaq qoşulur...</string>
     <string name="notification_working">İşləyir…</string>
     <string name="notification_service_start_no_root">Root icazəsini tələb etmək alınmadı.</string>
-    <string name="notification_service_start_failed">Shizuku servisini başlatmaq mümkün olmadı</string>
-    <string name="notification_service_starting">Shizuku servisi başladılır…</string>
+    <string name="notification_service_start_failed">Shizuku™ servisini başlatmaq mümkün olmadı</string>
+    <string name="notification_service_starting">Shizuku™ servisi başladılır…</string>
     <string name="notification_channel_service_status">Xidmətin başlama statusu</string>
-    <string name="dialog_stop_message">Shizuku xidməti dayandırılacaq.</string>
+    <string name="dialog_stop_message">Shizuku™ xidməti dayandırılacaq.</string>
     <string name="action_stop">Shizikunu dayandır</string>
     <string name="about_view_source_code">Qaynaq kodlarına buradan baxın %s</string>
     <string name="action_about">Haqqında</string>
     <string name="settings_use_system_color">Sistem teması rəngindən istifadə edin</string>
-    <string name="settings_start_on_boot_summary">Rootlu cihazlar üçün, Shizuku boot zamanı avtomatik başlaya bilir</string>
+    <string name="settings_start_on_boot_summary">Rootlu cihazlar üçün, Shizuku™ boot zamanı avtomatik başlaya bilir</string>
     <string name="settings_start_on_boot">Boot anında başlatın (Root lazımdır)</string>
     <string name="settings_translation_summary">%s dilini öz dilinizə tərcümə etməkdə bizə kömək edin</string>
     <string name="settings_translation">Tərcümədə iştirak et</string>
@@ -49,23 +49,23 @@
     <string name="settings_user_interface">Görünüş</string>
     <string name="settings_language">Dil</string>
     <string name="settings_title">Parametrlər</string>
-    <string name="rish_description">%1$s ilə istənilən terminal proqramında siz Shizuku tərəfindən hazırlanmış shell-lərə qoşula və onlarla əlaqə saxlaya bilərsiniz. &lt;p&gt;Ətraflı istifadə %1$s haqqında sənədə baxmaq üçün toxunun.</string>
+    <string name="rish_description">%1$s ilə istənilən terminal proqramında siz Shizuku™ tərəfindən hazırlanmış shell-lərə qoşula və onlarla əlaqə saxlaya bilərsiniz. &lt;p&gt;Ətraflı istifadə %1$s haqqında sənədə baxmaq üçün toxunun.</string>
     <string name="terminal_tutorial_3_description">Bəzi məsləhətlər: %1$s-a icra icazəsi verin və onu %2$s-a əlavə edin, siz birbaşa %1$s-dan istifadə edə biləcəksiniz.</string>
-    <string name="terminal_tutorial_3">Nəhayət, faylları terminal proqramınızın daxil ola biləcəyi yerə köçürün, Shizuku vasitəsilə əmrləri yerinə yetirmək üçün %1$s-dan istifadə edə biləcəksiniz.</string>
-    <string name="terminal_tutorial_2_description">Məsələn, %1$s-da Shizuku-dan istifadə etmək istəyirsinizsə, %2$s-ı %3$s ilə əvəz etməlisiniz (%4$s %1$s paketinin adıdır).</string>
+    <string name="terminal_tutorial_3">Nəhayət, faylları terminal proqramınızın daxil ola biləcəyi yerə köçürün, Shizuku™ vasitəsilə əmrləri yerinə yetirmək üçün %1$s-dan istifadə edə biləcəksiniz.</string>
+    <string name="terminal_tutorial_2_description">Məsələn, %1$s-da Shizuku™-dan istifadə etmək istəyirsinizsə, %2$s-ı %3$s ilə əvəz etməlisiniz (%4$s %1$s paketinin adıdır).</string>
     <string name="terminal_tutorial_2">Sonra %1$s-ı açmaq və redaktə etmək üçün istənilən mətn redaktorundan istifadə edin.</string>
     <string name="terminal_export_files">Faylları ixrac edin</string>
     <string name="terminal_tutorial_1_description">Seçilmiş qovluqda eyni adlı fayllar varsa, onlar silinəcək.
 \n
-\nİxrac funksiyası SAF (Storage Access Framework) istifadə edir. MIUI-nin SAF funksiyalarını pozduğu bildirilir. MIUI istifadə edirsinizsə, faylı Shizuku-nun apk-dan çıxarmalı və ya GitHub-dan yükləməli ola bilərsiniz.</string>
+\nİxrac funksiyası SAF (Storage Access Framework) istifadə edir. MIUI-nin SAF funksiyalarını pozduğu bildirilir. MIUI istifadə edirsinizsə, faylı Shizuku™-nun apk-dan çıxarmalı və ya GitHub-dan yükləməli ola bilərsiniz.</string>
     <string name="terminal_tutorial_1">Birincisi, faylları istədiyiniz yerə ixrac edin. Siz iki fayl tapacaqsınız, %1$s və %2$s.</string>
-    <string name="home_terminal_description">İstədiyiniz terminal proqramlarında Shizuku vasitəsilə əmrləri işə salın</string>
+    <string name="home_terminal_description">İstədiyiniz terminal proqramlarında Shizuku™ vasitəsilə əmrləri işə salın</string>
     <string name="home_terminal_title">Shizikunu terminal proqramlarında istifadə edin</string>
-    <string name="app_management_item_summary_requires_root">* Shizuku rootla işləməsini tələb edir</string>
+    <string name="app_management_item_summary_requires_root">* Shizuku™ rootla işləməsini tələb edir</string>
     <string name="app_management_dialog_adb_is_limited_message">Çox güman ki, cihazınızın istehsalçısı adb icazəsini məhdudlaşdırır.&lt;p&gt;Sisteminiz üçün &lt;b&gt;&lt;a href=\"%1$s\"&gt;bu sənəddə&lt;/a&gt;&lt;/b&gt; həll yolu ola bilər.</string>
     <string name="app_management_dialog_adb_is_limited_title">adb icazəsi məhduddur</string>
-    <string name="home_learn_more_description">Necə Shizuku dəstəkli proqram hazırlaya biləcəyinizi öyrənin və ya Shizuku dəstəkli proqramları əldə edin</string>
-    <string name="home_learn_more_title">Shizuku haqqında</string>
+    <string name="home_learn_more_description">Necə Shizuku™ dəstəkli proqram hazırlaya biləcəyinizi öyrənin və ya Shizuku™ dəstəkli proqramları əldə edin</string>
+    <string name="home_learn_more_title">Shizuku™ haqqında</string>
     <string name="home_app_management_view_authorized_apps">İcazə verilmiş proqramları idarə etmək üçün toxunun</string>
     <plurals name="home_app_management_authorized_apps_count">
         <item quantity="one">İcazə verilmiş %d proqram</item>
@@ -74,20 +74,20 @@
     <string name="home_app_management_title">tətbiqin idarə edilməsi</string>
     <string name="home_root_button_restart">Yenidən Başlat</string>
     <string name="home_root_button_start">Başlat</string>
-    <string name="home_root_description_sui">Magisk istifadə edirsinizsə, %1$s istifadə edə bilərsiniz. Root istifadəçiləri üçün o, nəticədə Shizuku əvəz edəcək. Qeyd edək ki, %2$s-dan istifadə etmək üçün mövcud proqramlar bir az dəyişməlidir.</string>
-    <string name="home_root_description">Bundan əlavə, Shizuku yüklənərkən avtomatik olaraq işə salına bilər. Əks-təqdirdə , sisteminizin və ya üçüncü tərəf alətlərin Shizuku-nu məhdudlaşdırıb-məhdudlaşdırdığını yoxlayın.&lt;br&gt;Siz %s-ə müraciət edə bilərsiniz.</string>
+    <string name="home_root_description_sui">Magisk istifadə edirsinizsə, %1$s istifadə edə bilərsiniz. Root istifadəçiləri üçün o, nəticədə Shizuku™ əvəz edəcək. Qeyd edək ki, %2$s-dan istifadə etmək üçün mövcud proqramlar bir az dəyişməlidir.</string>
+    <string name="home_root_description">Bundan əlavə, Shizuku™ yüklənərkən avtomatik olaraq işə salına bilər. Əks-təqdirdə , sisteminizin və ya üçüncü tərəf alətlərin Shizuku™-nu məhdudlaşdırıb-məhdudlaşdırdığını yoxlayın.&lt;br&gt;Siz %s-ə müraciət edə bilərsiniz.</string>
     <string name="home_root_title">Başlat (root edilmiş cihazlar üçün)</string>
-    <string name="adb_pairing_tutorial_content_network_limation_not_foreground">Bəzi sistemlər (məsələn, MIUI) proqramlar görünmədikdə şəbəkəyə daxil olmağa icazə vermir, hətta proqram standart olaraq ön plan xidmətindən istifadə edir. Zəhmət olmasa Shizuku üçün batareyanın optimallaşdırılması xüsusiyyətlərini deaktiv edin</string>
-    <string name="adb_pairing_tutorial_content_network">Shizuku lokal şəbəkəyə daxil olmalıdır. Şəbəkə icazəsi ilə idarə olunur.</string>
+    <string name="adb_pairing_tutorial_content_network_limation_not_foreground">Bəzi sistemlər (məsələn, MIUI) proqramlar görünmədikdə şəbəkəyə daxil olmağa icazə vermir, hətta proqram standart olaraq ön plan xidmətindən istifadə edir. Zəhmət olmasa Shizuku™ üçün batareyanın optimallaşdırılması xüsusiyyətlərini deaktiv edin</string>
+    <string name="adb_pairing_tutorial_content_network">Shizuku™ lokal şəbəkəyə daxil olmalıdır. Şəbəkə icazəsi ilə idarə olunur.</string>
     <string name="adb_pairing_tutorial_content_finish">Shizikuya geri dön və Shizikunu başlat</string>
     <string name="adb_pairing_tutorial_content_left_is_clickable">Nəzərə alın ki, \"Simsiz debaq\" seçiminin sol hissəsi tıklana bilər, ona toxunmaq yeni səhifə açacaq. Yalnız sağdakı açara basmaq düzgün deyil.</string>
     <string name="adb_pairing_tutorial_content_miui_2">Əks təqdirdə siz bildirişdə olan cütləşdirmə kodunu daxil edə bilməyəcəksiniz</string>
     <string name="adb_pairing_tutorial_content_miui">MIUI istifadəçiləri sistem parametrlərində bildiriş tərzini \"Bildiriş\" - \"Bildiriş kölgəsi\"ndən \"Android\"ə keçirməli ola bilərlər</string>
-    <string name="adb_pairing_tutorial_content_notification_blocked">Cütləşmə prosesi Shizukudan gələn bildirişi görməyinizi tələb edir. Zəhmət olmasa, Shizuku-ya bildirişlər göndərməyə icazə verin.</string>
+    <string name="adb_pairing_tutorial_content_notification_blocked">Cütləşmə prosesi Shizuku™dan gələn bildirişi görməyinizi tələb edir. Zəhmət olmasa, Shizuku™-ya bildirişlər göndərməyə icazə verin.</string>
     <string name="adb_pairing_tutorial_content_enter_pairing_code">Cütləşdirməni tamamlamaq üçün bildirişdəki kodu daxil edin</string>
     <string name="adb_pairing_tutorial_content_steps">\"Tərtibatçı seçimləri\" - \"Simsiz debaq\" daxil olun. \"Cihazı cütləşdirmə kodu ilə cütləşdir\" klikləyin, altı rəqəmli kod görəcəksiniz.</string>
-    <string name="adb_pairing_tutorial_content_notification">Shizukudan gələn bildiriş cütləşdirməni tamamlamağınız üçün sizə kömək edə bilər</string>
-    <string name="adb_pairing_tutorial_title">Shizuku-nu cihazınızla cütləşdirin</string>
+    <string name="adb_pairing_tutorial_content_notification">Shizuku™dan gələn bildiriş cütləşdirməni tamamlamağınız üçün sizə kömək edə bilər</string>
+    <string name="adb_pairing_tutorial_title">Shizuku™-nu cihazınızla cütləşdirin</string>
     <string name="notification_settings">Bildiriş seçimləri</string>
     <string name="development_settings">Tərtibatçı seçimləri</string>
     <string name="adb_pair_required">Lütfən, əvvəlcə cütləşmə mərhələsini keçin.</string>
@@ -110,17 +110,17 @@
     <string name="dialog_adb_port">Port</string>
     <string name="dialog_adb_discovery_message">Lütfən, \"Tərtibatçı seçimləri\"ndə \"Simsiz Debaq\" funksiyasını aktivləşdirin. Şəbəkə dəyişdikdə \"Simsiz Debaq\" avtomatik olaraq söndürülür.
 \n
-\nQeyd edək ki, Tərtibatçı seçimlərini, USB Debaqı və ya Shizuku-nu söndürməyin</string>
+\nQeyd edək ki, Tərtibatçı seçimlərini, USB Debaqı və ya Shizuku™-nu söndürməyin</string>
     <string name="dialog_adb_discovery">Simsiz debaq cihazı axtarılır</string>
     <string name="home_wireless_adb_view_guide_button">Addım-Addım Təlimat</string>
     <string name="home_wireless_adb_description_pre_11">Android 11 - dən aşağı android versiyalarında simsiz debaq üçün kompüterə bağlanmaq mütləqdir</string>
-    <string name="home_wireless_adb_description">Android 11 və ya daha yuxarı versiyalarda siz Simsiz debaqı aktivləşdirə və kompüterə qoşulmadan Shizuku-nu birbaşa cihazınızdan başlada bilərsiniz.&lt;p&gt;Lütfən, əvvəlcə addım-addım təlimata baxın.</string>
+    <string name="home_wireless_adb_description">Android 11 və ya daha yuxarı versiyalarda siz Simsiz debaqı aktivləşdirə və kompüterə qoşulmadan Shizuku™-nu birbaşa cihazınızdan başlada bilərsiniz.&lt;p&gt;Lütfən, əvvəlcə addım-addım təlimata baxın.</string>
     <string name="home_wireless_adb_title">Simsiz debaq ilə başladın</string>
     <string name="home_adb_dialog_view_command_button_send">Göndər</string>
     <string name="home_adb_dialog_view_command_message">&lt;font face=monospace&gt;%1$s&lt;/font&gt;&lt;br&gt;&lt;br&gt;* Bəzi başqa mülahizələr də var, lütfən, əvvəlcə yardımı oxuduğunuzu təsdiqləyin.</string>
     <string name="home_adb_button_view_command">Əmirə baxın</string>
     <string name="home_adb_button_view_help">Yardım</string>
-    <string name="home_adb_description">Root olmayan cihazlarda Shizuku-nu işə salmaq üçün adb-dən istifadə etməlisiniz (kompüter bağlantısı tələb olunur). Cihaz hər dəfə yenidən işə salındıqda bu proses təkrarlanmalıdır. Lütfən, <b><a href="%1$s">yardımı oxuyun</a></b>.</string>
+    <string name="home_adb_description">Root olmayan cihazlarda Shizuku™-nu işə salmaq üçün adb-dən istifadə etməlisiniz (kompüter bağlantısı tələb olunur). Cihaz hər dəfə yenidən işə salındıqda bu proses təkrarlanmalıdır. Lütfən, <b><a href="%1$s">yardımı oxuyun</a></b>.</string>
     <string name="home_adb_title">Kompüterə qoşularaq başlayın</string>
     <string name="home_status_service_version_update">Versiya %2$s, %1$s &lt;br&gt; %3$s Versiyasına güncəlləmək üçün proqramı yenidən başladın</string>
     <string name="home_status_service_version">Versiya %2$s, %1$s</string>

--- a/manager/src/main/res/values-b+es+419/strings.xml
+++ b/manager/src/main/res/values-b+es+419/strings.xml
@@ -6,9 +6,9 @@
     <string name="dialog_adb_pairing_title">Emparejar con dispositivo</string>
     <string name="dialog_adb_discovery_message">Habilite \"Depuración inalámbrica\" en \"Opciones de desarrollador\". La \"depuración inalámbrica\" se desactiva automáticamente cuando cambia la red.
 \n
-\nTenga en cuenta que no desactive las \"Opciones de desarrollador\" o la \"Depuración USB\", o Shizuku se detendrá.</string>
+\nTenga en cuenta que no desactive las \"Opciones de desarrollador\" o la \"Depuración USB\", o Shizuku™ se detendrá.</string>
     <string name="home_status_service_version_update">Versión %2$s, %1$s&lt;br&gt;Vuelva a empezar para actualizar a la versión %3$s</string>
-    <string name="dialog_requesting_legacy_button_open_shizuku">Abrir Shizuku</string>
+    <string name="dialog_requesting_legacy_button_open_shizuku">Abrir Shizuku™</string>
     <string name="action_about">Acerca de</string>
     <string name="development_settings">Opciones de desarrollador</string>
     <string name="adb_pairing_requires_multi_window_reason">El sistema requiere que el cuadro de diálogo de emparejamiento esté siempre visible, el uso del modo de pantalla dividida es la única forma de permitir que esta aplicación y el cuadro de diálogo del sistema estén visibles al mismo tiempo.</string>
@@ -22,7 +22,7 @@
     <string name="home_adb_dialog_view_command_message">&lt;font face=monospace&gt;%1$s&lt;/font&gt;&lt;br&gt;&lt;br&gt;* Esto tiene otras consideraciones, por favor confirme que ha leído la información de ayuda primero.</string>
     <string name="home_adb_button_view_command">Ver comando</string>
     <string name="home_adb_button_view_help">Ver ayuda</string>
-    <string name="home_adb_description">Para dispositivos sin root, usted necesita ADB para ejecutar Shizuku (requiere una conexión a un ordenador). Este proceso se debe repetir cada vez que el dispositivo sea reiniciando. &lt;b&gt;&lt;a href=\"%1$s\"&gt;obtener más ayuda&lt;/a&gt;&lt;/b&gt;.</string>
+    <string name="home_adb_description">Para dispositivos sin root, usted necesita ADB para ejecutar Shizuku™ (requiere una conexión a un ordenador). Este proceso se debe repetir cada vez que el dispositivo sea reiniciando. &lt;b&gt;&lt;a href=\"%1$s\"&gt;obtener más ayuda&lt;/a&gt;&lt;/b&gt;.</string>
     <string name="home_adb_title">Empiece por conectarse a su computador</string>
     <string name="home_status_service_version">Versión %2$s, %1$s</string>
     <string name="home_status_service_not_running">%1$s no está activo</string>
@@ -30,11 +30,11 @@
     <string name="translation_contributors">—Peter Cuevas</string>
     <string name="grant_dialog_button_deny">Negar</string>
     <string name="grant_dialog_button_allow_always">Permitir todo el tiempo</string>
-    <string name="notification_service_start_failed">Error al iniciar el servicio Shizuku.</string>
-    <string name="notification_service_starting">El servicio de Shizuku se está iniciando…</string>
-    <string name="action_stop">Detener Shizuku</string>
+    <string name="notification_service_start_failed">Error al iniciar el servicio Shizuku™.</string>
+    <string name="notification_service_starting">El servicio de Shizuku™ se está iniciando…</string>
+    <string name="action_stop">Detener Shizuku™</string>
     <string name="about_view_source_code">Ver código fuente en %s</string>
-    <string name="settings_start_on_boot_summary">Para dispositivos root, Shizuku puede iniciarse automáticamente al arrancar</string>
+    <string name="settings_start_on_boot_summary">Para dispositivos root, Shizuku™ puede iniciarse automáticamente al arrancar</string>
     <string name="settings_start_on_boot">Iniciar en el arranque (root)</string>
     <string name="settings_translation">Participe en la traducción</string>
     <string name="settings_translation_contributors">Colaboradores de traducción</string>
@@ -43,7 +43,7 @@
     <string name="settings_user_interface">Apariencia</string>
     <string name="settings_language">Idioma</string>
     <string name="settings_title">Configuraciones</string>
-    <string name="home_learn_more_title">Aprende sobre Shizuku</string>
+    <string name="home_learn_more_title">Aprende sobre Shizuku™</string>
     <string name="home_app_management_view_authorized_apps">Toque para administrar aplicaciones autorizadas</string>
     <string name="home_app_management_title">Gestión de aplicaciones</string>
     <string name="home_root_button_restart">Reiniciar</string>
@@ -55,60 +55,60 @@
     <string name="dialog_wireless_adb_not_enabled">La depuración inalámbrica no está habilitada.
 \nTenga en cuenta que antes de Android 11, para habilitar la depuración inalámbrica, la conexión a la computadora es imprescindible.</string>
     <string name="cannot_connect_port">No se puede conectar al servicio de depuración inalámbrico.</string>
-    <string name="dialog_requesting_legacy_message">&lt;b&gt;%1$s&lt;/b&gt; tiene soporte para Shizuku moderno, pero está solicitando Shizuku heredado. Esto podría deberse a que Shizuku no se está ejecutando, por favor, compruébalo en la aplicación Shizuku.&lt;p&gt;Shizuku heredado está obsoleto desde marzo de 2019.</string>
-    <string name="dialog_requesting_legacy_title">%1$s está solicitando Shizuku heredado</string>
+    <string name="dialog_requesting_legacy_message">&lt;b&gt;%1$s&lt;/b&gt; tiene soporte para Shizuku™ moderno, pero está solicitando Shizuku™ heredado. Esto podría deberse a que Shizuku™ no se está ejecutando, por favor, compruébalo en la aplicación Shizuku™.&lt;p&gt;Shizuku™ heredado está obsoleto desde marzo de 2019.</string>
+    <string name="dialog_requesting_legacy_title">%1$s está solicitando Shizuku™ heredado</string>
     <string name="dialog_cannot_open_browser_title">No se puede iniciar el navegador</string>
     <string name="starter">Inicio</string>
     <string name="permission_warning_template">¿Permitir a <b>%1$s</b> a %2$s\?</string>
-    <string name="permission_label">acceder a Shizuku</string>
+    <string name="permission_label">acceder a Shizuku™</string>
     <string name="notification_working">Trabajando…</string>
     <string name="notification_service_start_no_root">No se ha podido solicitar el permiso de root.</string>
     <string name="notification_channel_service_status">Estado de inicio del servicio</string>
-    <string name="dialog_stop_message">El servicio de Shizuku se detendrá.</string>
+    <string name="dialog_stop_message">El servicio de Shizuku™ se detendrá.</string>
     <string name="settings_startup">Inicio</string>
     <plurals name="home_app_management_authorized_apps_count">
         <item quantity="one">Aplicación %d autorizada</item>
         <item quantity="other">Aplicaciones %d autorizadas</item>
     </plurals>
-    <string name="home_root_description_sui">Si estás usando Magisk, puedes probar %1$s. Para los usuarios root, eventualmente reemplazará a Shizuku. Tenga en cuenta que las aplicaciones existentes deben cambiar un poco para utilizar %2$s.</string>
-    <string name="dialog_legacy_not_support_title">%1$s no soporta el Shizuku moderno</string>
+    <string name="home_root_description_sui">Si estás usando Magisk, puedes probar %1$s. Para los usuarios root, eventualmente reemplazará a Shizuku™. Tenga en cuenta que las aplicaciones existentes deben cambiar un poco para utilizar %2$s.</string>
+    <string name="dialog_legacy_not_support_title">%1$s no soporta el Shizuku™ moderno</string>
     <string name="toast_copied_to_clipboard_with_text"><b>%s</b> se ha copiado en el portapapeles.</string>
     <string name="toast_copied_to_clipboard">%s
 \nse ha copiado en el portapapeles.</string>
-    <string name="permission_description">Permitir que la aplicación utilice Shizuku.</string>
-    <string name="app_management_item_summary_requires_root">* requiere que Shizuku se ejecute con la root</string>
+    <string name="permission_description">Permitir que la aplicación utilice Shizuku™.</string>
+    <string name="app_management_item_summary_requires_root">* requiere que Shizuku™ se ejecute con la root</string>
     <string name="app_management_dialog_adb_is_limited_title">El permiso de adb es limitado</string>
-    <string name="home_learn_more_description">Aprenda a desarrollar con Shizuku o consiga aplicaciones con Shizuku</string>
+    <string name="home_learn_more_description">Aprenda a desarrollar con Shizuku™ o consiga aplicaciones con Shizuku™</string>
     <string name="start_with_root_failed">No se puede iniciar el servicio porque el permiso de root no está concedido o este dispositivo no está rooteado.</string>
     <string name="app_management_dialog_adb_is_limited_message">Es muy posible que el fabricante de tu dispositivo limite el permiso de adb.&lt;p&gt;Puede que haya una solución para tu sistema en &lt;b&gt;&lt;a href=\"%1$s\"&gt;este documento&lt;/a&gt;&lt;/b&gt;.</string>
-    <string name="dialog_legacy_not_support_message">El Shizuku heredado está obsoleto desde marzo de 2019. Además, el Shizuku heredado no funciona en los sistemas Android más nuevos.&lt;p&gt;Por favor, pide al desarrollador de &lt;b&gt;%1$s&lt;/b&gt; que se actualice.</string>
-    <string name="home_root_description">Además, Shizuku puede iniciarse automáticamente al arrancar. Si no es así, por favor compruebe si su sistema o herramientas de terceros han restringido Shizuku.&lt;br&gt;Puede consultar %s.</string>
+    <string name="dialog_legacy_not_support_message">El Shizuku™ heredado está obsoleto desde marzo de 2019. Además, el Shizuku™ heredado no funciona en los sistemas Android más nuevos.&lt;p&gt;Por favor, pide al desarrollador de &lt;b&gt;%1$s&lt;/b&gt; que se actualice.</string>
+    <string name="home_root_description">Además, Shizuku™ puede iniciarse automáticamente al arrancar. Si no es así, por favor compruebe si su sistema o herramientas de terceros han restringido Shizuku™.&lt;br&gt;Puede consultar %s.</string>
     <string name="dialog_adb_pairing_message">Por favor, inicie el emparejamiento mediante los siguientes pasos: \"Opciones de desarrollador\" - \"Depuración inalámbrica\" - \"Emparejar el dispositivo con el código de emparejamiento\".
 \n
 \nUna vez iniciado el proceso de emparejamiento, podrá introducir el código de emparejamiento.</string>
     <string name="adb_pairing">‎Emparejamiento‎</string>
     <string name="settings_translation_summary">Ayúdanos a traducir %s a tu idioma</string>
     <string name="terminal_tutorial_3_description">Algunos consejos: conceda permiso de ejecución a %1$s y agréguelo a %2$s , podrá usar %1$s directamente.</string>
-    <string name="terminal_tutorial_3">Finalmente, mueva los archivos a un lugar donde su aplicación de terminal pueda acceder, podrá usar %1$s para ejecutar comandos a través de Shizuku.</string>
-    <string name="terminal_tutorial_2_description">Por ejemplo, si desea usar Shizuku en %1$s, debe reemplazar %2$s con %3$s (%4$s es el nombre del paquete de %1$s).</string>
+    <string name="terminal_tutorial_3">Finalmente, mueva los archivos a un lugar donde su aplicación de terminal pueda acceder, podrá usar %1$s para ejecutar comandos a través de Shizuku™.</string>
+    <string name="terminal_tutorial_2_description">Por ejemplo, si desea usar Shizuku™ en %1$s, debe reemplazar %2$s con %3$s (%4$s es el nombre del paquete de %1$s).</string>
     <string name="terminal_tutorial_2">Luego, use cualquier editor de texto para abrir y editar %1$s.</string>
     <string name="terminal_export_files">Exportar archivos</string>
     <string name="terminal_tutorial_1_description">Si hay archivos con el mismo nombre en la carpeta seleccionada, se eliminarán.
 \n
-\nLa función de exportación utiliza SAF (Storage Access Framework). Se informa que MIUI rompe las funciones de SAF. Si está utilizando MIUI, es posible que deba extraer el archivo de la apk de Shizuku o descargarlo de GitHub.</string>
-    <string name="home_terminal_title">Utilice Shizuku en apps de terminal</string>
-    <string name="home_terminal_description">Ejecute comandos a través de Shizuku en las aplicaciones de terminal que le gusten</string>
+\nLa función de exportación utiliza SAF (Storage Access Framework). Se informa que MIUI rompe las funciones de SAF. Si está utilizando MIUI, es posible que deba extraer el archivo de la apk de Shizuku™ o descargarlo de GitHub.</string>
+    <string name="home_terminal_title">Utilice Shizuku™ en apps de terminal</string>
+    <string name="home_terminal_description">Ejecute comandos a través de Shizuku™ en las aplicaciones de terminal que le gusten</string>
     <string name="terminal_tutorial_1">Primero, exporte archivos a cualquier lugar que desee. Encontrará dos archivos,%1$s y %2$s.</string>
-    <string name="rish_description">Con %1$s, en cualquier aplicación de terminal, puede conectarse e interactuar con el shell que ejecuta Shizuku. &lt;p&gt;Acerca del uso detallado %1$s, toca para ver el documento.</string>
-    <string name="adb_pairing_tutorial_content_notification">Shizuku te enviará una notificación para completar la vinculación</string>
-    <string name="home_wireless_adb_description">A partir de Android 11 o menor, puedes activar la opción de depuración inalámbrica y ejecutar Shizuku desde tu dispositivo, sin necesidad de conectar a una computadora.&lt;p&gt;Por favor revisa la primera guía de paso a paso.</string>
+    <string name="rish_description">Con %1$s, en cualquier aplicación de terminal, puede conectarse e interactuar con el shell que ejecuta Shizuku™. &lt;p&gt;Acerca del uso detallado %1$s, toca para ver el documento.</string>
+    <string name="adb_pairing_tutorial_content_notification">Shizuku™ te enviará una notificación para completar la vinculación</string>
+    <string name="home_wireless_adb_description">A partir de Android 11 o menor, puedes activar la opción de depuración inalámbrica y ejecutar Shizuku™ desde tu dispositivo, sin necesidad de conectar a una computadora.&lt;p&gt;Por favor revisa la primera guía de paso a paso.</string>
     <string name="home_wireless_adb_view_guide_button">Guía paso a paso</string>
     <string name="adb_pairing_tutorial_content_enter_pairing_code">Digita el código en la notificación para completar el emparejamiento.</string>
     <string name="notification_adb_pairing_input_paring_code">Ingresar código de emparejamiento</string>
-    <string name="adb_pairing_tutorial_title">Vincula Shizuku con tu dispositivo</string>
+    <string name="adb_pairing_tutorial_title">Vincula Shizuku™ con tu dispositivo</string>
     <string name="home_wireless_adb_description_pre_11">Versiones anteriores a Android 11, es necesario conectar a una computadora para activar la depuración inalámbrica.</string>
     <string name="notification_settings">Opciones de Notificacion</string>
     <string name="notification_adb_pairing_failed_title">¡Hubo un problema al emparejar!</string>
     <string name="notification_adb_pairing_retry">Reintentar</string>
-    <string name="adb_pairing_tutorial_content_notification_blocked">The pairing process needs you to interact with a notificación from Shizuku. Please allow Shizuku to post notifications.El proceso de emparejamiento necesita que interactúes con una notificación de Shizuku. Permita que Shizuku publique notificaciones.El proceso de emparejamiento necesita que interactúes con una notificación de Shizuku. Permita que Shizuku publique notificaciones.</string>
+    <string name="adb_pairing_tutorial_content_notification_blocked">The pairing process needs you to interact with a notificación from Shizuku™. Please allow Shizuku™ to post notifications.El proceso de emparejamiento necesita que interactúes con una notificación de Shizuku™. Permita que Shizuku™ publique notificaciones.El proceso de emparejamiento necesita que interactúes con una notificación de Shizuku™. Permita que Shizuku™ publique notificaciones.</string>
 </resources>

--- a/manager/src/main/res/values-ca/strings.xml
+++ b/manager/src/main/res/values-ca/strings.xml
@@ -2,9 +2,9 @@
 <resources>
     <string name="dialog_adb_discovery_message">Activeu \"Depuració sense fil\" a \"Opcions de desenvolupador\". La \"depuració sense fil\" es desactiva automàticament quan canvia la xarxa.
 \n
-\nTingueu en compte que no desactiveu les \"Opcions de desenvolupador\" ni la \"depuració USB\", o Shizuku s\'aturarà.</string>
+\nTingueu en compte que no desactiveu les \"Opcions de desenvolupador\" ni la \"depuració USB\", o Shizuku™ s\'aturarà.</string>
     <string name="home_wireless_adb_description_pre_11">Abans d\'Android 11, cal connectar-se a un ordinador per habilitar la depuració sense fil.</string>
-    <string name="dialog_requesting_legacy_button_open_shizuku">Obre Shizuku</string>
+    <string name="dialog_requesting_legacy_button_open_shizuku">Obre Shizuku™</string>
     <string name="paring_code_is_wrong">El codi de vinculació és incorrecte.</string>
     <string name="dialog_adb_pairing_paring_code">Codi d\'aparellament</string>
     <string name="dialog_adb_pairing_discovery">S\'està buscant el servei d\'aparellament</string>

--- a/manager/src/main/res/values-cs/strings.xml
+++ b/manager/src/main/res/values-cs/strings.xml
@@ -1,29 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="dialog_requesting_legacy_button_open_shizuku">Otevřít Shizuku</string>
-    <string name="dialog_requesting_legacy_message">&lt;b&gt;%1$s &lt;/b&gt; má podporu pro moderní Shizuku, ale vyžaduje starší Shizuku. Mohlo by to být proto, že Shizuku není spuštěno, zkontrolujte aplikaci Shizuku. &lt;p&gt; Podpora staršího Shizuku je od března 2019 ukončena.</string>
-    <string name="dialog_requesting_legacy_title">%1$s vyžaduje starší Shizuku</string>
-    <string name="dialog_legacy_not_support_message">Podpora starší verze Shizuku je od března 2019. Starší verze Shizuku také nefunguje na novějších systémech Android. &lt;p&gt; O aktualizaci požádejte vývojáře &lt;b&gt;%1$s &lt;/b&gt;.</string>
-    <string name="dialog_legacy_not_support_title">%1$s nepodporuje moderní Shizuku</string>
+    <string name="dialog_requesting_legacy_button_open_shizuku">Otevřít Shizuku™</string>
+    <string name="dialog_requesting_legacy_message">&lt;b&gt;%1$s &lt;/b&gt; má podporu pro moderní Shizuku™, ale vyžaduje starší Shizuku™. Mohlo by to být proto, že Shizuku™ není spuštěno, zkontrolujte aplikaci Shizuku™. &lt;p&gt; Podpora staršího Shizuku™ je od března 2019 ukončena.</string>
+    <string name="dialog_requesting_legacy_title">%1$s vyžaduje starší Shizuku™</string>
+    <string name="dialog_legacy_not_support_message">Podpora starší verze Shizuku™ je od března 2019. Starší verze Shizuku™ také nefunguje na novějších systémech Android. &lt;p&gt; O aktualizaci požádejte vývojáře &lt;b&gt;%1$s &lt;/b&gt;.</string>
+    <string name="dialog_legacy_not_support_title">%1$s nepodporuje moderní Shizuku™</string>
     <string name="toast_copied_to_clipboard_with_text">&lt;b&gt;%s&lt;/b&gt; byl zkopírován do schránky.</string>
     <string name="toast_copied_to_clipboard">%s
 \nbyl zkopírován do schránky.</string>
     <string name="dialog_cannot_open_browser_title">Prohlížeč nelze spustit</string>
     <string name="start_with_root_failed">Službu nelze spustit, protože není uděleno oprávnění k rootu nebo toto zařízení není rootováno.</string>
     <string name="starter">Spouštěč</string>
-    <string name="permission_description">povolí aplikaci používat systémová rozhraní API s vyššími oprávněními (Shizuku).</string>
-    <string name="permission_label">přístup k Shizuku</string>
-    <string name="permission_group_description">přístup k Shizuku</string>
+    <string name="permission_description">povolí aplikaci používat systémová rozhraní API s vyššími oprávněními (Shizuku™).</string>
+    <string name="permission_label">přístup k Shizuku™</string>
+    <string name="permission_group_description">přístup k Shizuku™</string>
     <string name="notification_working">Pracuji…</string>
     <string name="notification_service_start_no_root">Nepodařilo se požádat o oprávnění root.</string>
-    <string name="notification_service_start_failed">Spuštění služby Shizuku se nezdařilo.</string>
-    <string name="notification_service_starting">Služba Shizuku se spouští…</string>
+    <string name="notification_service_start_failed">Spuštění služby Shizuku™ se nezdařilo.</string>
+    <string name="notification_service_starting">Služba Shizuku™ se spouští…</string>
     <string name="notification_channel_service_status">Stav spuštění služby</string>
-    <string name="dialog_stop_message">Služba Shizuku bude zastavena.</string>
-    <string name="action_stop">Zastavit Shizuku</string>
+    <string name="dialog_stop_message">Služba Shizuku™ bude zastavena.</string>
+    <string name="action_stop">Zastavit Shizuku™</string>
     <string name="about_view_source_code">Zobrazit zdrojový kód na %su</string>
-    <string name="action_about">O Shizuku</string>
-    <string name="settings_start_on_boot_summary">U rootovaných zařízení je Shizuku schopen automaticky spustit při spuštění</string>
+    <string name="action_about">O Shizuku™</string>
+    <string name="settings_start_on_boot_summary">U rootovaných zařízení je Shizuku™ schopen automaticky spustit při spuštění</string>
     <string name="settings_start_on_boot">Spustit při spuštění (root)</string>
     <string name="settings_translation_summary">Pomozte nám přeložit %s do vašeho jazyka</string>
     <string name="settings_translation">Podílet se na překladu</string>
@@ -34,11 +34,11 @@
     <string name="settings_user_interface">Vzhled</string>
     <string name="settings_language">Jazyk</string>
     <string name="settings_title">Nastavení</string>
-    <string name="app_management_item_summary_requires_root">* vyžaduje spustit Shizuku s rootem</string>
+    <string name="app_management_item_summary_requires_root">* vyžaduje spustit Shizuku™ s rootem</string>
     <string name="app_management_dialog_adb_is_limited_message">Je vysoce možné, že výrobce vašeho zařízení omezuje oprávnění adb. &lt;p&gt; V &lt;b&gt; &lt;a href=\"%1$s\"&gt; tomto dokumentu &lt;/a&gt; &lt;/b&gt; může být pro váš systém řešení.</string>
     <string name="app_management_dialog_adb_is_limited_title">Oprávnění adb je omezené</string>
-    <string name="home_learn_more_description">Naučte se, jak vyvíjet aplikace s pomocí Shizuku</string>
-    <string name="home_learn_more_title">Naučte se Shizuku</string>
+    <string name="home_learn_more_description">Naučte se, jak vyvíjet aplikace s pomocí Shizuku™</string>
+    <string name="home_learn_more_title">Naučte se Shizuku™</string>
     <string name="home_app_management_view_authorized_apps">Klepnutím můžete spravovat autorizované aplikace</string>
     <plurals name="home_app_management_authorized_apps_count">
         <item quantity="one">Autorizovaná %d aplikace</item>
@@ -48,7 +48,7 @@
     <string name="home_app_management_title">Správa aplikací</string>
     <string name="home_root_button_restart">Restartovat</string>
     <string name="home_root_button_start">Spustit</string>
-    <string name="home_root_description">Kromě toho lze Shizuku spustit automaticky při spuštění. Pokud ne, zkontrolujte, zda váš systém nebo nástroje třetích stran neomezují Shizuku. &lt;br&gt; Můžete se podívat na %s.</string>
+    <string name="home_root_description">Kromě toho lze Shizuku™ spustit automaticky při spuštění. Pokud ne, zkontrolujte, zda váš systém nebo nástroje třetích stran neomezují Shizuku™. &lt;br&gt; Můžete se podívat na %s.</string>
     <string name="home_adb_title">Spustit připojením k počítači</string>
     <string name="home_status_service_version_update">Verze %2$s, %1$s&lt;br&gt;Znovu spusťte pro aktualizaci na verzi %3$s</string>
     <string name="home_status_service_version">Verze %2$s, %1$s</string>
@@ -70,7 +70,7 @@
     <string name="dialog_adb_port">Port</string>
     <string name="dialog_adb_discovery_message">Povolte „Bezdrátové ladění“ v „Možnosti pro vývojáře“. „Bezdrátové ladění“ je při změně sítě automaticky deaktivováno.
 \n
-\nNezapínejte „Možnosti pro vývojáře“ nebo „Ladění USB“, jinak bude Shizuku zastaven.</string>
+\nNezapínejte „Možnosti pro vývojáře“ nebo „Ladění USB“, jinak bude Shizuku™ zastaven.</string>
     <string name="paring_code_is_wrong">Chybný kód pro párování.</string>
     <string name="dialog_adb_pairing_paring_code">Kód pro párování</string>
     <string name="dialog_adb_pairing_discovery">Hledání zařízení pro párování</string>
@@ -85,13 +85,13 @@
     <string name="home_adb_dialog_view_command_message">&lt;font face=monospace&gt;%1$s&lt;/font&gt;&lt;br&gt;&lt;br&gt;* Existuje několik dalších úvah, nejprve si prosím přečtěte nápovědu.</string>
     <string name="home_adb_button_view_command">Zobrazit příkaz</string>
     <string name="home_adb_button_view_help">Přečíst nápovědu</string>
-    <string name="home_adb_description">U zařízení bez root musíte ke spuštění Shizuku použít adb (vyžaduje připojení k počítači). Tento proces je třeba opakovat při každém restartu zařízení. Přečtěte si prosím &lt;b&gt; &lt;a href=\"%1$s\"&gt; nápovědu &lt;/a&gt; &lt;/b&gt;.</string>
+    <string name="home_adb_description">U zařízení bez root musíte ke spuštění Shizuku™ použít adb (vyžaduje připojení k počítači). Tento proces je třeba opakovat při každém restartu zařízení. Přečtěte si prosím &lt;b&gt; &lt;a href=\"%1$s\"&gt; nápovědu &lt;/a&gt; &lt;/b&gt;.</string>
     <string name="grant_dialog_button_deny">Zakázat</string>
     <string name="grant_dialog_button_allow_always">Povolit vždy</string>
     <string name="permission_warning_template">Povolit aplikaci &lt;/b&gt;%1$s&lt;/b&gt; %2$s\?</string>
-    <string name="home_terminal_title">Použít Shizuku v terminálových aplikacích</string>
-    <string name="home_terminal_description">Spouštějte příkazy přes Shizuku v terminálových aplikacích které máte rádi</string>
-    <string name="adb_pairing_tutorial_title">Spárovat Shizuku s vaším zařízením</string>
+    <string name="home_terminal_title">Použít Shizuku™ v terminálových aplikacích</string>
+    <string name="home_terminal_description">Spouštějte příkazy přes Shizuku™ v terminálových aplikacích které máte rádi</string>
+    <string name="adb_pairing_tutorial_title">Spárovat Shizuku™ s vaším zařízením</string>
     <string name="adb_pairing_tutorial_content_steps">Otevřete \"Vývojářská Nastavení\" - \"Bezdrátové ladění\". Klikněte na \"Spárovat zařízení s párovacím kódem\", uvidíte šesti-místný kód.</string>
     <string name="adb_pairing_tutorial_content_enter_pairing_code">Zadejte ten kód do oznámení aby jste dokončili párování.</string>
     <string name="adb_pairing_tutorial_content_miui_2">Jinak, možná nebudete moct zadat párovací kód do oznámení.</string>
@@ -102,8 +102,8 @@
     <string name="terminal_export_files">Exportovat soubory</string>
     <string name="terminal_tutorial_1">Prvně, Exportujte soubory kamkoliv chcete. Najdete dva soubory, %1$s a %2$s.</string>
     <string name="terminal_tutorial_2">Pak, použijte jakýkoliv textový editor k otevření a upravení %1$s.</string>
-    <string name="terminal_tutorial_2_description">Jako příklad, pokud chcete použít Shizuku v %1$su, musíte změnit %2$s na %3$s (%4$s je jméno balíčku %1$su).</string>
-    <string name="terminal_tutorial_3">Nakonec, přesuňte ty soubory někam kde k nim vaše terminálová aplikace může přistupovat a budete moci používat %1$s aby jste pouštěli příkazy přes Shizuku.</string>
+    <string name="terminal_tutorial_2_description">Jako příklad, pokud chcete použít Shizuku™ v %1$su, musíte změnit %2$s na %3$s (%4$s je jméno balíčku %1$su).</string>
+    <string name="terminal_tutorial_3">Nakonec, přesuňte ty soubory někam kde k nim vaše terminálová aplikace může přistupovat a budete moci používat %1$s aby jste pouštěli příkazy přes Shizuku™.</string>
     <string name="dialog_adb_discovery_message_toggle_wireless_debugging">Prosím zkuste zakázat a znovu povolit \"Bezdrátové ladění\" pokud nepřestává hledat.</string>
     <string name="notification_channel_adb_pairing">Párování bezdrátového ladění</string>
     <string name="notification_adb_pairing_input_paring_code">Vložte párovací kód</string>
@@ -111,26 +111,26 @@
     <string name="notification_adb_pairing_working_title">Párování probíhá</string>
     <string name="notification_adb_pairing_stop_searching">Přestaňte hledat</string>
     <string name="notification_adb_pairing_succeed_title">Párování bylo úspěšné</string>
-    <string name="notification_adb_pairing_succeed_text">Nyní můžete spustit službu Shizuku.</string>
+    <string name="notification_adb_pairing_succeed_text">Nyní můžete spustit službu Shizuku™.</string>
     <string name="notification_adb_pairing_failed_title">Párování selhalo</string>
     <string name="notification_adb_pairing_retry">Zkusit znovu</string>
-    <string name="home_wireless_adb_description">Na verzi Android 11 nebo vyšší můžete povolit Bezdrátové ladění a spustit Shizuku přímo z vašeho zařízení, bez připojení k počítači. Přečtěte si prosím prvně návod krok-za-krokem před spuštěním.</string>
-    <string name="adb_pairing_tutorial_content_notification">Notifikace od Shizuku vám pomůže dokončit párování.</string>
-    <string name="adb_pairing_tutorial_content_notification_blocked">Proces párování vyžaduje interakci s oznámením od Shizuku. Prosím povolte Shizuku posílat oznámení.</string>
-    <string name="home_root_description_sui">Pokud používáte Magisk můžete zkusit %1$s. Pro uživatele s rootem to eventuálně nahradí Shizuku. Existující aplikace musí být trochu změněny aby mohly používat %2$s.</string>
-    <string name="adb_pairing_tutorial_content_finish">Běžte zpátky do Shizuku a spusťte Shizuku.</string>
-    <string name="adb_pairing_tutorial_content_network">Shizuku potřebuje přístup k lokální síti, který je spravován oprávněním k síti.</string>
+    <string name="home_wireless_adb_description">Na verzi Android 11 nebo vyšší můžete povolit Bezdrátové ladění a spustit Shizuku™ přímo z vašeho zařízení, bez připojení k počítači. Přečtěte si prosím prvně návod krok-za-krokem před spuštěním.</string>
+    <string name="adb_pairing_tutorial_content_notification">Notifikace od Shizuku™ vám pomůže dokončit párování.</string>
+    <string name="adb_pairing_tutorial_content_notification_blocked">Proces párování vyžaduje interakci s oznámením od Shizuku™. Prosím povolte Shizuku™ posílat oznámení.</string>
+    <string name="home_root_description_sui">Pokud používáte Magisk můžete zkusit %1$s. Pro uživatele s rootem to eventuálně nahradí Shizuku™. Existující aplikace musí být trochu změněny aby mohly používat %2$s.</string>
+    <string name="adb_pairing_tutorial_content_finish">Běžte zpátky do Shizuku™ a spusťte Shizuku™.</string>
+    <string name="adb_pairing_tutorial_content_network">Shizuku™ potřebuje přístup k lokální síti, který je spravován oprávněním k síti.</string>
     <string name="adb_pairing_tutorial_content_network_limation_not_foreground">Některé systémy (například MIUI) nepovolují aplikacím přístup k síti když nejsou viditelné, i když používají služby na popředí. Prosím zakažte optimalizace baterie na takových systémech.</string>
     <string name="home_adb_is_limited_title">Je třeba udělat jeden krok navíc</string>
-    <string name="home_adb_is_limited_description">Výrobce vašeho zařízení omezil přístup k adb a aplikace používající Shizuku by kvůli tomu nefungovaly správně.
+    <string name="home_adb_is_limited_description">Výrobce vašeho zařízení omezil přístup k adb a aplikace používající Shizuku™ by kvůli tomu nefungovaly správně.
 \n
 \nToto omezení může většinou být zakázáno pouze změněním některých možností ve \"Vývojářských Nastaveních\". Prosím přečtěte si stránku podpory pro informace jak toto udělat.
 \n
-\nMožná budete muset restartovat Shizuku pro tuto operaci aby měla efekt.</string>
+\nMožná budete muset restartovat Shizuku™ pro tuto operaci aby měla efekt.</string>
     <string name="adb_pairing_tutorial_content_miui">Uživatelé MIUI možná budou muset přepnout styl oznámení na \"Android\" z \"Oznámení\" - \"Lišta Oznámení\" v nastavení systému.</string>
     <string name="terminal_tutorial_1_description">Pokir jsou be vybrané složce soubory se stejným jménem budou smazány.
 \n
-\nFunkce exportu používá SAF (Storage Access Framework - \"Rámcový přístup k úložišti\"). Je nahlašováno že MIUI rozbíjí funkce SAF. Pokud používáte MIUI, možná budete muset extraktovat ty soubory z apk Shizuku nebo je stáhnout z GitHubu.</string>
+\nFunkce exportu používá SAF (Storage Access Framework - \"Rámcový přístup k úložišti\"). Je nahlašováno že MIUI rozbíjí funkce SAF. Pokud používáte MIUI, možná budete muset extraktovat ty soubory z apk Shizuku™ nebo je stáhnout z GitHubu.</string>
     <string name="notification_adb_pairing_searching_for_service_title">Hledání párovací služby</string>
     <string name="adb_pairing_tutorial_content_left_is_clickable">Prosím pamatujte, levá strana možnosti \"Bezdrátové ladění\" se dá rozkliknout, což otevře novou stranu. Pouhé přepnutí přepínače napravo je nesprávné.</string>
 </resources>

--- a/manager/src/main/res/values-de/strings.xml
+++ b/manager/src/main/res/values-de/strings.xml
@@ -6,7 +6,7 @@
     <string name="home_adb_dialog_view_command_copy_button">Kopieren</string>
     <string name="home_adb_dialog_view_command_message">&lt;font face=monospace&gt;%1$s&lt;/font&gt;&lt;br&gt;&lt;br&gt;* Es gibt noch einige andere Überlegungen, bitte vergewissern, dass Sie zuerst die Hilfe gelesen haben.</string>
     <string name="home_adb_button_view_command">Befehl anzeigen</string>
-    <string name="home_adb_description">Bei Geräten ohne Root müssen Sie adb verwenden, um Shizuku zu starten (erfordert Computerverbindung). Dieser Vorgang muss bei jedem Neustart des Geräts wiederholt werden. Bitte <b><a href="%1$s">die Hilfe lesen</a></b>.</string>
+    <string name="home_adb_description">Bei Geräten ohne Root müssen Sie adb verwenden, um Shizuku™ zu starten (erfordert Computerverbindung). Dieser Vorgang muss bei jedem Neustart des Geräts wiederholt werden. Bitte <b><a href="%1$s">die Hilfe lesen</a></b>.</string>
     <string name="home_adb_button_view_help">Hilfe lesen</string>
     <string name="home_adb_title">Verbindung mit dem Compter herstellen</string>
     <string name="home_status_service_version_update">Version %2$s, %1$s&lt;br&gt;Erneut starten, um auf Version %3$s zu aktualisieren</string>
@@ -16,7 +16,7 @@
     <string name="app_management_dialog_adb_is_limited_title">ADB-Berechtigungen sind begrenzt</string>
     <string name="about_view_source_code">Quelltext auf %s anzeigen</string>
     <string name="action_about">Über</string>
-    <string name="action_stop">Shizuku anhalten</string>
+    <string name="action_stop">Shizuku™ anhalten</string>
     <string name="settings_black_night_theme_summary">Das rein schwarze Thema verwenden, wenn der Nachtmodus aktiviert ist</string>
     <string name="settings_black_night_theme">Schwarzes Thema</string>
     <plurals name="home_app_management_authorized_apps_count">
@@ -25,51 +25,51 @@
     </plurals>
     <string name="dialog_wireless_adb_not_enabled">Kabelloses Debugging ist nicht aktiviert.
 \nHinweis: Vor Android 11 ist für die Aktivierung des kabellosen Debugging eine Computerverbindung erforderlich.</string>
-    <string name="home_root_description">Außerdem kann Shizuku beim Booten automatisch gestartet werden. Wenn nicht, überprüfen Sie bitte, ob Ihr System oder Tools von Drittanbietern Shizuku eingeschränkt haben.&lt;br&gt;Sie können auf %s verweisen.</string>
+    <string name="home_root_description">Außerdem kann Shizuku™ beim Booten automatisch gestartet werden. Wenn nicht, überprüfen Sie bitte, ob Ihr System oder Tools von Drittanbietern Shizuku™ eingeschränkt haben.&lt;br&gt;Sie können auf %s verweisen.</string>
     <string name="development_settings">Entwickleroptionen</string>
     <string name="adb_pairing_requires_multi_window">Bitte zuerst in den Modus \"Geteilter Bildschirm\" (Mehrfenster) gehen.</string>
     <string name="dialog_adb_discovery_message">Bitte \"Wireless Debugging\" in den \"Entwickleroptionen\" aktivieren. \"Wireless Debugging\" wird automatisch deaktiviert, wenn sich das Netzwerk ändert.
 \n
-\nHinweis: \"Entwickleroptionen\" oder \"USB-Debugging\" nicht deaktivieren, sonst wird Shizuku gestoppt.</string>
+\nHinweis: \"Entwickleroptionen\" oder \"USB-Debugging\" nicht deaktivieren, sonst wird Shizuku™ gestoppt.</string>
     <string name="grant_dialog_button_deny">Verweigern</string>
     <string name="grant_dialog_button_allow_always">Immer zulassen</string>
     <string name="permission_warning_template"><b>%1$s</b> erlauben %2$s zu verwenden\?</string>
     <string name="translation_contributors">" "</string>
-    <string name="notification_service_start_failed">Shizuku-Dienst starten fehlgeschlagen.</string>
+    <string name="notification_service_start_failed">Shizuku™-Dienst starten fehlgeschlagen.</string>
     <string name="notification_channel_service_status">Status des Dienststarts</string>
     <string name="app_management_dialog_adb_is_limited_message">Es ist sehr wahrscheinlich, dass Ihr Gerätehersteller die Berechtigung von adb einschränkt. &lt;p&gt;Vielleicht finden Sie in &lt;b&gt;&lt;a href=\"%1$s\"&gt;diesem Dokument&lt;/a&gt;&lt;/b&gt; eine Lösung für Ihr System.</string>
-    <string name="home_root_description_sui">Wenn Sie Magisk verwenden, können Sie %1$s ausprobieren. Für Root-Nutzer wird es irgendwann Shizuku ersetzen. Beachten Sie, dass bestehende Apps ein wenig geändert werden müssen, um %2$s zu verwenden.</string>
+    <string name="home_root_description_sui">Wenn Sie Magisk verwenden, können Sie %1$s ausprobieren. Für Root-Nutzer wird es irgendwann Shizuku™ ersetzen. Beachten Sie, dass bestehende Apps ein wenig geändert werden müssen, um %2$s zu verwenden.</string>
     <string name="adb_pairing">Kopplung</string>
     <string name="dialog_adb_port">Port</string>
-    <string name="dialog_requesting_legacy_button_open_shizuku">Shizuku öffnen</string>
-    <string name="dialog_requesting_legacy_title">%1$s bittet um Legacy Shizuku</string>
-    <string name="dialog_legacy_not_support_message">Legacy Shizuku ist seit März 2019 veraltet. Außerdem funktioniert Legacy Shizuku nicht auf neueren Android-Systemen.&lt;p&gt;Bitte bitten Sie den Entwickler von &lt;b&gt;%1$s&lt;/b&gt; es zu aktualisieren.</string>
-    <string name="dialog_requesting_legacy_message">&lt;b&gt;%1$s&lt;/b&gt; hat moderne Shizuku-Unterstützung, aber es fordert Legacy Shizuku an. Dies könnte daran liegen, dass Shizuku nicht läuft. Bitte in der Shizuku-App überprüfen.&lt;p&gt;Legacy Shizuku wird seit März 2019 nicht mehr unterstützt.</string>
-    <string name="dialog_legacy_not_support_title">%1$s unterstützt das moderne Shizuku nicht</string>
+    <string name="dialog_requesting_legacy_button_open_shizuku">Shizuku™ öffnen</string>
+    <string name="dialog_requesting_legacy_title">%1$s bittet um Legacy Shizuku™</string>
+    <string name="dialog_legacy_not_support_message">Legacy Shizuku™ ist seit März 2019 veraltet. Außerdem funktioniert Legacy Shizuku™ nicht auf neueren Android-Systemen.&lt;p&gt;Bitte bitten Sie den Entwickler von &lt;b&gt;%1$s&lt;/b&gt; es zu aktualisieren.</string>
+    <string name="dialog_requesting_legacy_message">&lt;b&gt;%1$s&lt;/b&gt; hat moderne Shizuku™-Unterstützung, aber es fordert Legacy Shizuku™ an. Dies könnte daran liegen, dass Shizuku™ nicht läuft. Bitte in der Shizuku™-App überprüfen.&lt;p&gt;Legacy Shizuku™ wird seit März 2019 nicht mehr unterstützt.</string>
+    <string name="dialog_legacy_not_support_title">%1$s unterstützt das moderne Shizuku™ nicht</string>
     <string name="toast_copied_to_clipboard_with_text"><b>%s</b> wurde in Zwischenablage kopiert.</string>
     <string name="toast_copied_to_clipboard">%s
 \nwurde in Zwischenablage kopiert.</string>
     <string name="dialog_cannot_open_browser_title">Browser starten nicht möglich</string>
     <string name="start_with_root_failed">Dienst starten nicht möglich, da keine Root-Rechte erteilt wurden oder das Gerät nicht gerootet ist.</string>
     <string name="starter">Starter</string>
-    <string name="permission_description">Der App erlauben, Shizuku zu verwenden.</string>
-    <string name="permission_label">Shizuku-Zugriff</string>
+    <string name="permission_description">Der App erlauben, Shizuku™ zu verwenden.</string>
+    <string name="permission_label">Shizuku™-Zugriff</string>
     <string name="notification_working">Läuft…</string>
     <string name="notification_service_start_no_root">Root-Rechte anfordern fehlgeschlagen.</string>
-    <string name="notification_service_starting">Shizuku-Dienst startetet…</string>
-    <string name="dialog_stop_message">Shizuku-Dienst wird angehalten.</string>
+    <string name="notification_service_starting">Shizuku™-Dienst startetet…</string>
+    <string name="dialog_stop_message">Shizuku™-Dienst wird angehalten.</string>
     <string name="settings_translation">An der Übersetzung mitarbeiten</string>
     <string name="settings_translation_contributors">Zur Übersetzung beigetragen</string>
     <string name="settings_translation_summary">Uns helfen, %s in Ihre Sprache zu übersetzen</string>
-    <string name="settings_start_on_boot_summary">Bei gerooteten Geräten kann Shizuku beim Booten automatisch starten</string>
+    <string name="settings_start_on_boot_summary">Bei gerooteten Geräten kann Shizuku™ beim Booten automatisch starten</string>
     <string name="settings_start_on_boot">Beim Hochfahren starten (Root)</string>
     <string name="settings_startup">Beim Starten</string>
     <string name="settings_user_interface">Aussehen</string>
     <string name="settings_language">Sprache</string>
     <string name="settings_title">Einstellungen</string>
-    <string name="app_management_item_summary_requires_root">* erfordert, dass Shizuku mit Root läuft</string>
-    <string name="home_learn_more_description">Lernen Sie, wie Apps mit Shizuku entwickelt werden</string>
-    <string name="home_learn_more_title">Shizuku kennenlernen</string>
+    <string name="app_management_item_summary_requires_root">* erfordert, dass Shizuku™ mit Root läuft</string>
+    <string name="home_learn_more_description">Lernen Sie, wie Apps mit Shizuku™ entwickelt werden</string>
+    <string name="home_learn_more_title">Shizuku™ kennenlernen</string>
     <string name="home_app_management_view_authorized_apps">Tippen, um autorisierte Apps zu verwalten</string>
     <string name="home_app_management_title">App-Verwaltung</string>
     <string name="home_root_button_restart">Neustart</string>
@@ -88,50 +88,50 @@
     <string name="dialog_adb_pairing_discovery">Nach Kopplungsdienst suchen</string>
     <string name="dialog_adb_pairing_title">Mit Gerät koppeln</string>
     <string name="dialog_adb_invalid_port">Port ist eine ganze Zahl zwischen 0 und 65536.</string>
-    <string name="terminal_tutorial_3">Zum Schluss verschieben Sie die Dateien an einen Ort, auf den Ihre Terminal-App zugreifen kann, damit Sie mit %1$s Befehle über Shizuku ausführen können.</string>
-    <string name="terminal_tutorial_2_description">Wenn Sie beispielsweise Shizuku in %1$s verwenden möchten, sollten Sie %2$s durch %3$s ersetzen (%4$s ist der Paketname von %1$s).</string>
+    <string name="terminal_tutorial_3">Zum Schluss verschieben Sie die Dateien an einen Ort, auf den Ihre Terminal-App zugreifen kann, damit Sie mit %1$s Befehle über Shizuku™ ausführen können.</string>
+    <string name="terminal_tutorial_2_description">Wenn Sie beispielsweise Shizuku™ in %1$s verwenden möchten, sollten Sie %2$s durch %3$s ersetzen (%4$s ist der Paketname von %1$s).</string>
     <string name="terminal_tutorial_2">Dann einen beliebigen Texteditor verwenden, um %1$s zu öffnen und zu bearbeiten.</string>
     <string name="terminal_export_files">Dateien exportieren</string>
     <string name="terminal_tutorial_1_description">Wenn es im ausgewählten Ordner Dateien mit demselben Namen gibt, werden diese gelöscht.
 \n
-\nDie Exportfunktion verwendet SAF (Storage Access Framework). Es wird berichtet, dass MIUI die Funktionen von SAF unterbricht. Wenn Sie MIUI verwenden, müssen Sie möglicherweise die Datei aus der apk von Shizuku extrahieren oder von GitHub herunterladen.</string>
+\nDie Exportfunktion verwendet SAF (Storage Access Framework). Es wird berichtet, dass MIUI die Funktionen von SAF unterbricht. Wenn Sie MIUI verwenden, müssen Sie möglicherweise die Datei aus der apk von Shizuku™ extrahieren oder von GitHub herunterladen.</string>
     <string name="terminal_tutorial_1">Zuerst Dateien an einen beliebigen Ort exportieren. Sie werden zwei Dateien finden, %1$s und %2$s.</string>
-    <string name="home_terminal_description">Befehle über Shizuku in Terminal-Apps ausführen, die Sie mögen</string>
-    <string name="home_terminal_title">Shizuku in Terminal-Apps verwenden</string>
+    <string name="home_terminal_description">Befehle über Shizuku™ in Terminal-Apps ausführen, die Sie mögen</string>
+    <string name="home_terminal_title">Shizuku™ in Terminal-Apps verwenden</string>
     <string name="terminal_tutorial_3_description">Einige Tipps: %1$s die Ausführungsberechtigung erteilen und zu %2$s hinzufügen, dann können Sie %1$s direkt verwenden.</string>
-    <string name="home_wireless_adb_description">Unter Android 11 oder höher können Sie Wireless Debugging aktivieren und Shizuku direkt von Ihrem Gerät aus starten, ohne eine Verbindung zu einem Computer herzustellen.&lt;p&gt;Bitte zuerst die Schritt-für-Schritt-Anleitung ansehen.</string>
+    <string name="home_wireless_adb_description">Unter Android 11 oder höher können Sie Wireless Debugging aktivieren und Shizuku™ direkt von Ihrem Gerät aus starten, ohne eine Verbindung zu einem Computer herzustellen.&lt;p&gt;Bitte zuerst die Schritt-für-Schritt-Anleitung ansehen.</string>
     <string name="notification_adb_pairing_service_found_title">Kopplungsdienst gefunden</string>
-    <string name="adb_pairing_tutorial_title">Shizuku mit Ihrem Gerät koppeln</string>
+    <string name="adb_pairing_tutorial_title">Shizuku™ mit Ihrem Gerät koppeln</string>
     <string name="adb_pairing_tutorial_content_steps">\"Entwickleroptionen\" - \"Kabelloses Debugging\" wählen. Auf \"Gerät mit Pairing-Code koppeln\", ein sechsstelligen Code ist zusehen.</string>
     <string name="adb_pairing_tutorial_content_enter_pairing_code">Code aus der Benachrichtigung eingeben, um die Kopplung abzuschließen.</string>
     <string name="adb_pairing_tutorial_content_miui_2">Andernfalls können Sie den Kopplungscode möglicherweise nicht über die Meldung eingeben.</string>
     <string name="notification_adb_pairing_stop_searching">Suche beenden</string>
     <string name="notification_adb_pairing_searching_for_service_title">Nach Kopplungsdienst suchen</string>
     <string name="notification_adb_pairing_succeed_title">Erfolgreich gekoppelt</string>
-    <string name="notification_adb_pairing_succeed_text">Sie können den Shizuku-Dienst jetzt starten.</string>
+    <string name="notification_adb_pairing_succeed_text">Sie können den Shizuku™-Dienst jetzt starten.</string>
     <string name="notification_adb_pairing_failed_title">Koppeln fehlgeschlagen</string>
     <string name="notification_adb_pairing_retry">Wiederholen</string>
     <string name="notification_channel_adb_pairing">Kabellose Debugging-Kopplung</string>
     <string name="notification_adb_pairing_input_paring_code">Kopplungscode eingeben</string>
     <string name="notification_adb_pairing_working_title">Koppeln läuft</string>
-    <string name="adb_pairing_tutorial_content_notification">Eine Benachrichtigung von Shizuku wird Ihnen helfen, die Kopplung abzuschließen.</string>
+    <string name="adb_pairing_tutorial_content_notification">Eine Benachrichtigung von Shizuku™ wird Ihnen helfen, die Kopplung abzuschließen.</string>
     <string name="home_wireless_adb_description_pre_11">Vor Android 11 ist eine Verbindung zu einem Computer erforderlich, um Wireless Debugging zu aktivieren.</string>
     <string name="home_wireless_adb_view_guide_button">Schritt-für-Schritt-Anleitung</string>
     <string name="adb_pairing_tutorial_content_miui">MIUI-Nutzer müssen in den Systemeinstellungen unter \"Benachrichtigung\" - \"Benachrichtigungsleiste\" möglicherweise den Benachrichtigungsstil auf \"Android\" umstellen.</string>
-    <string name="adb_pairing_tutorial_content_finish">Zurück zu Shizuku und Shizuku starten.</string>
-    <string name="rish_description">Mit %1$s können Sie in jeder Terminal-App eine Verbindung zur Shell von Shizuku herstellen und mit ihr interagieren. &lt;p&gt;Zur detaillierten Verwendung von %1$s tippen, um das Dokument anzuzeigen.</string>
-    <string name="adb_pairing_tutorial_content_notification_blocked">Für den Kopplungssprozess müssen Sie mit einer Benachrichtigung von Shizuku interagieren. Bitte Shizuku erlauben, Benachrichtigungen zu posten.</string>
+    <string name="adb_pairing_tutorial_content_finish">Zurück zu Shizuku™ und Shizuku™ starten.</string>
+    <string name="rish_description">Mit %1$s können Sie in jeder Terminal-App eine Verbindung zur Shell von Shizuku™ herstellen und mit ihr interagieren. &lt;p&gt;Zur detaillierten Verwendung von %1$s tippen, um das Dokument anzuzeigen.</string>
+    <string name="adb_pairing_tutorial_content_notification_blocked">Für den Kopplungssprozess müssen Sie mit einer Benachrichtigung von Shizuku™ interagieren. Bitte Shizuku™ erlauben, Benachrichtigungen zu posten.</string>
     <string name="notification_settings">Benachrichtigungsoptionen</string>
-    <string name="adb_pairing_tutorial_content_network">Shizuku muss auf das lokale Netzwerk zugreifen. Dies wird durch die Netzwerkberechtigung gesteuert.</string>
-    <string name="adb_pairing_tutorial_content_network_limation_not_foreground">Einige Systeme (z. B. MIUI) verbieten Apps den Netzwerkzugriff, wenn sie nicht sichtbar sind, selbst wenn die App standardmäßig einen Vordergrunddienst verwendet. Bitte auf solchen Systemen die Akku-Optimierungsfunktionen für Shizuku deaktivieren.</string>
+    <string name="adb_pairing_tutorial_content_network">Shizuku™ muss auf das lokale Netzwerk zugreifen. Dies wird durch die Netzwerkberechtigung gesteuert.</string>
+    <string name="adb_pairing_tutorial_content_network_limation_not_foreground">Einige Systeme (z. B. MIUI) verbieten Apps den Netzwerkzugriff, wenn sie nicht sichtbar sind, selbst wenn die App standardmäßig einen Vordergrunddienst verwendet. Bitte auf solchen Systemen die Akku-Optimierungsfunktionen für Shizuku™ deaktivieren.</string>
     <string name="settings_use_system_color">Verwende Farbe des Systemdesigns</string>
-    <string name="home_adb_is_limited_description">Ihr Gerätehersteller hat ADB-Berechtigungen eingeschränkt. Dadurch werden Apps, die Shizuku verwenden, nicht ordnungsgemäß funktionieren.
+    <string name="home_adb_is_limited_description">Ihr Gerätehersteller hat ADB-Berechtigungen eingeschränkt. Dadurch werden Apps, die Shizuku™ verwenden, nicht ordnungsgemäß funktionieren.
 \n
 \nMeist kann diese Einschränkung aufgehoben werden, wenn bestimmte Einstellungen in den \"Entwicklereinstellungen\" angepasst werden. Bitte lesen Sie die Hilfeseite, um mehr darüber zu erfahren.
 \n
-\nEventuell müssen Sie Shizuku neustarten, damit die Änderungen angewandt werden.</string>
+\nEventuell müssen Sie Shizuku™ neustarten, damit die Änderungen angewandt werden.</string>
     <string name="home_adb_is_limited_title">Sie müssen einen zusätzlichen Schritt durchführen</string>
-    <string name="home_app_management_empty">Apps, die Shizuku angefordert oder deklariert haben, werden hier angezeigt.</string>
+    <string name="home_app_management_empty">Apps, die Shizuku™ angefordert oder deklariert haben, werden hier angezeigt.</string>
     <string name="adb_pairing_tutorial_content_left_is_clickable">Bitte beachte, dass der linke Teil der \"Wireless debugging\"-Option anklickbar ist; wird es angetippt öffnet es eine neue Seite. Lediglich den Schalter auf der rechten Seite umzulegen ist falsch.</string>
     <string name="dialog_adb_discovery_message_toggle_wireless_debugging">Bitte versuche \"Wireless debugging\" aus- und einzuschalten, falls es weiterhin sucht.</string>
 </resources>

--- a/manager/src/main/res/values-el/strings.xml
+++ b/manager/src/main/res/values-el/strings.xml
@@ -12,7 +12,7 @@
     <string name="home_wireless_adb_description_pre_11">Πριν από το Android 11, είναι απαραίτητη η σύνδεση με έναν υπολογιστή για την ενεργοποίηση του ασύρματου εντοπισμού σφαλμάτων.</string>
     <string name="home_adb_button_view_command">Προβολή εντολής</string>
     <string name="home_adb_button_view_help">Ανάγνωση βοήθειας</string>
-    <string name="home_adb_description">Για συσκευές χωρίς πρόσβαση root, πρέπει να χρησιμοποιήσετε το adb για την εκκίνηση του Shizuku (απαιτεί σύνδεση σε υπολογιστή). Αυτή η διαδικασία θα πρέπει να επαναλαμβάνεται κάθε φορά που επανεκκινείται η συσκευή. <b><a href="%1$s">Διαβάστε τη βοήθεια</a></b>.</string>
+    <string name="home_adb_description">Για συσκευές χωρίς πρόσβαση root, πρέπει να χρησιμοποιήσετε το adb για την εκκίνηση του Shizuku™ (απαιτεί σύνδεση σε υπολογιστή). Αυτή η διαδικασία θα πρέπει να επαναλαμβάνεται κάθε φορά που επανεκκινείται η συσκευή. <b><a href="%1$s">Διαβάστε τη βοήθεια</a></b>.</string>
     <string name="home_adb_title">Έναρξη μέσω σύνδεσης με υπολογιστή</string>
     <string name="home_status_service_version_update">Έκδοση %2$s, %1$s&lt;br&gt;Κάντε ξανά εκκίνηση για ενημέρωση στην έκδοση %3$s</string>
     <string name="home_status_service_not_running">Το %1$s δεν εκτελείται</string>

--- a/manager/src/main/res/values-eo/strings.xml
+++ b/manager/src/main/res/values-eo/strings.xml
@@ -4,7 +4,7 @@
     <string name="settings_user_interface">Aspekto</string>
     <string name="settings_language">Lingvo</string>
     <string name="settings_title">Agordoj</string>
-    <string name="home_learn_more_title">Lerni Shizuku</string>
+    <string name="home_learn_more_title">Lerni Shizuku™</string>
     <plurals name="home_app_management_authorized_apps_count">
         <item quantity="one">Rajtigis %d aplikaĵon</item>
         <item quantity="other">Rajtigis %d aplikaĵojn</item>

--- a/manager/src/main/res/values-es-rCL/strings.xml
+++ b/manager/src/main/res/values-es-rCL/strings.xml
@@ -6,11 +6,11 @@
     <string name="home_adb_dialog_view_command_message">&lt;font face=monospace&gt;%1$s&lt;/font&gt;&lt;br&gt;&lt;br&gt;* Esto tiene otras consideraciones, por favor confirme que ha leído la información de ayuda primero.</string>
     <string name="home_adb_button_view_help">Ver ayuda</string>
     <string name="home_adb_button_view_command">Ver comando</string>
-    <string name="home_adb_description">Para dispositivos sin root, usted necesita ADB para ejecutar Shizuku (requiere una conexión a un ordenador). Este proceso se debe repetir cada vez que el dispositivo sea reiniciando. &lt;b&gt;&lt;a href=\"%1$s\"&gt;obtener más ayuda&lt;/a&gt;&lt;/b&gt;.</string>
+    <string name="home_adb_description">Para dispositivos sin root, usted necesita ADB para ejecutar Shizuku™ (requiere una conexión a un ordenador). Este proceso se debe repetir cada vez que el dispositivo sea reiniciando. &lt;b&gt;&lt;a href=\"%1$s\"&gt;obtener más ayuda&lt;/a&gt;&lt;/b&gt;.</string>
     <string name="home_status_service_version">Versión %2$s, %1$s</string>
     <string name="home_status_service_not_running">%1$s no está activo</string>
     <string name="home_status_service_is_running">%1$s está activo</string>
-    <string name="dialog_requesting_legacy_button_open_shizuku">Abrir Shizuku</string>
+    <string name="dialog_requesting_legacy_button_open_shizuku">Abrir Shizuku™</string>
     <string name="action_about">Acerca de</string>
     <string name="development_settings">Opciones de desarrollador</string>
     <string name="adb_pairing_requires_multi_window_reason">El sistema requiere que el cuadro de diálogo de emparejamiento esté siempre visible, el uso del modo de pantalla dividida es la única forma de permitir que esta aplicación y el cuadro de diálogo del sistema estén visibles al mismo tiempo.</string>

--- a/manager/src/main/res/values-es/strings.xml
+++ b/manager/src/main/res/values-es/strings.xml
@@ -6,8 +6,8 @@
     <string name="home_status_service_not_running">%1$s no se está ejecutando</string>
     <string name="home_status_service_is_running">%1$s se está ejecutando</string>
     <string name="translation_contributors">NoelFeijooIglesias</string>
-    <string name="home_wireless_adb_description">En Android 11 o superior, se puede habilitar Depuración inalámbrica e iniciar Shizuku directamente desde el dispositivo sin la necesidad de una computadora.&lt;p&gt;Por favor revisa la Guía paso a paso.</string>
-    <string name="home_adb_description">Para dispositivos sin acceso root, se necesita ADB para ejecutar Shizuku (requiere conexión a una computadora). Este proceso debe repetirse cada vez que el dispositivo sea reiniciado.Favor <b><a href="%1$s">leer la guía</a></b>.</string>
+    <string name="home_wireless_adb_description">En Android 11 o superior, se puede habilitar Depuración inalámbrica e iniciar Shizuku™ directamente desde el dispositivo sin la necesidad de una computadora.&lt;p&gt;Por favor revisa la Guía paso a paso.</string>
+    <string name="home_adb_description">Para dispositivos sin acceso root, se necesita ADB para ejecutar Shizuku™ (requiere conexión a una computadora). Este proceso debe repetirse cada vez que el dispositivo sea reiniciado.Favor <b><a href="%1$s">leer la guía</a></b>.</string>
     <string name="home_adb_button_view_help">Leer ayuda</string>
     <string name="home_adb_button_view_command">Ver comando</string>
     <string name="home_adb_dialog_view_command_message">"&lt;font face=monospace&gt;%1$s&lt;/font&gt;&lt;br&gt;&lt;br&gt;* Existen  otras consideraciones, por favor confirme que ha leído antes la ayuda."</string>
@@ -18,21 +18,21 @@
     <string name="dialog_adb_discovery">Buscando servicio de depuración inalámbrica</string>
     <string name="adb_pairing">Emparejar</string>
     <string name="home_root_title">Iniciar (dispositivo rooteado)</string>
-    <string name="home_root_description_sui">Si esta usando Magisk, puedes probar %1$s. Para usuarios de root, esto eventualmente reemplazará Shizuku. Nota, aplicaciones existentes necesitan cambiar un poco para usar %2$s.</string>
+    <string name="home_root_description_sui">Si esta usando Magisk, puedes probar %1$s. Para usuarios de root, esto eventualmente reemplazará Shizuku™. Nota, aplicaciones existentes necesitan cambiar un poco para usar %2$s.</string>
     <string name="home_root_button_start">Iniciar</string>
     <string name="home_root_button_restart">Reiniciar</string>
     <string name="home_app_management_title">Gestión de aplicaciones</string>
     <string name="home_app_management_view_authorized_apps">Toque para administrar aplicaciones autorizadas</string>
-    <string name="home_learn_more_description">Aprende a desarrollar con Shizuku</string>
-    <string name="app_management_item_summary_requires_root">* requiere que Shizuku se ejecute con root</string>
+    <string name="home_learn_more_description">Aprende a desarrollar con Shizuku™</string>
+    <string name="app_management_item_summary_requires_root">* requiere que Shizuku™ se ejecute con root</string>
     <string name="app_management_dialog_adb_is_limited_message">Es muy posible que el fabricante de su dispositivo haya limitado el permiso de ADB.&lt;p&gt;Puede que encuentre una solución para su sistema en &lt;b&gt;&lt;a href=\"%1$s\"&gt;este documento&lt;/a&gt;&lt;/b&gt;.</string>
-    <string name="home_adb_is_limited_description">El fabricante de su dispositivo ha restringido los permisos ADB y las aplicaciones que usan Shizuku no funcionarán correctamente.
+    <string name="home_adb_is_limited_description">El fabricante de su dispositivo ha restringido los permisos ADB y las aplicaciones que usan Shizuku™ no funcionarán correctamente.
 \n
 \nUsualmente, estas limitaciones pueden deshacerse con algunos ajustes en \"Opciones para desarrolladores\". Por favor lea la ayuda para mas detalles sobre como hacerlo.
 \n
-\nTal vez necesite reiniciar Shizuku para que la operación surta efecto.</string>
-    <string name="home_terminal_title">Usar Shizuku en la consola de comandos</string>
-    <string name="home_terminal_description">Ejecute comandos atravez de Shizuku en las aplicaciones de terminal que mas le gusten</string>
+\nTal vez necesite reiniciar Shizuku™ para que la operación surta efecto.</string>
+    <string name="home_terminal_title">Usar Shizuku™ en la consola de comandos</string>
+    <string name="home_terminal_description">Ejecute comandos atravez de Shizuku™ en las aplicaciones de terminal que mas le gusten</string>
     <string name="home_adb_is_limited_title">Necesitas dar un paso más</string>
     <string name="dialog_adb_pairing_title">Emparejar con dispositivo</string>
     <string name="dialog_adb_pairing_discovery">Buscando servicio de emparejamiento</string>
@@ -46,43 +46,43 @@
     <string name="adb_pair_required">Por favor, ve al paso de emparejamiento primero.</string>
     <string name="development_settings">Opciones para desarrolladores</string>
     <string name="notification_settings">Opciones de notificación</string>
-    <string name="adb_pairing_tutorial_title">Vincular Shizuku con tu dispositivo</string>
+    <string name="adb_pairing_tutorial_title">Vincular Shizuku™ con tu dispositivo</string>
     <string name="adb_pairing_tutorial_content_steps">Entre en \"Opciones para desarrolladores\" - \"Depuración inalámbrica\". Toque en \"Vincular dispositivo con código de sincronización\", usted verá un código de seis dígitos.</string>
     <string name="adb_pairing_tutorial_content_enter_pairing_code">Introduzca el código para completar el emparejamiento.</string>
     <string name="adb_pairing_tutorial_content_miui">Usuarios de MIUI podrían necesitar cambiar el estilo de notificaciones por \"Android\" en \"Notificaciones\" - \"Barra de notificaciones\" dentro de los ajustes de sistema.</string>
     <string name="adb_pairing_tutorial_content_miui_2">De otra manera, tal vez no puedas introducir el código de vinculación en la notificación.</string>
-    <string name="adb_pairing_tutorial_content_network">Shizuku necesita acceder a la red local. Esto es controlado por el permiso de acceso a la red.</string>
-    <string name="adb_pairing_tutorial_content_finish">Vuelva a Shizuku e inicielo.</string>
+    <string name="adb_pairing_tutorial_content_network">Shizuku™ necesita acceder a la red local. Esto es controlado por el permiso de acceso a la red.</string>
+    <string name="adb_pairing_tutorial_content_finish">Vuelva a Shizuku™ e inicielo.</string>
     <string name="home_wireless_adb_description_pre_11">Para versiones anteriores a Android 11, se necesita conectar a una computadora para habilitar la Depuración inalámbrica.</string>
     <string name="dialog_adb_discovery_message">Por favor activa \"Depuración inalámbrica\" en \"Opciones de Desarrollador\". \" Depuración inalámbrica\" se desactiva automáticamente cuando la red cambia.
 \n
-\nNota, no deshabilite las \"Opciones de Desarrollador\" o \"Depuración USB\", de lo contrario, Shizuku se detendrá.</string>
+\nNota, no deshabilite las \"Opciones de Desarrollador\" o \"Depuración USB\", de lo contrario, Shizuku™ se detendrá.</string>
     <string name="dialog_adb_discovery_message_toggle_wireless_debugging">Por favor, intente deshabilitar y volver a habilitar \"Depuración inalámbrica\" si es que no deja de seguir en búsqueda.</string>
     <string name="dialog_wireless_adb_not_enabled">La Depuración inalámbrica no esta habilitada.
 \nNota, versiones anteriores a Android 11, para habilitar depuración inalámbrica, la conexión a una computadora es requerida.</string>
     <string name="dialog_adb_pairing_message">Por favor empiece el vinculamiento con los siguientes pasos: \"Opciones para desarrolladores\" - \"Depuración inalámbrica\" - \"Vincular dispositivo con código de sincronización\".
 \n
 \nDespués de que el proceso de vinculación empiece, usted podrá introducir el código de sincronización\".</string>
-    <string name="adb_pairing_tutorial_content_notification">Una notificación de Shizuku te ayudará a completar la vinculación.</string>
-    <string name="adb_pairing_tutorial_content_notification_blocked">El proceso de vinculación requiere que usted interactúe con las notificaciones de Shizuku. Por favor, permita que Shizuku pueda lanzar notificaciones.</string>
+    <string name="adb_pairing_tutorial_content_notification">Una notificación de Shizuku™ te ayudará a completar la vinculación.</string>
+    <string name="adb_pairing_tutorial_content_notification_blocked">El proceso de vinculación requiere que usted interactúe con las notificaciones de Shizuku™. Por favor, permita que Shizuku™ pueda lanzar notificaciones.</string>
     <string name="adb_pairing_tutorial_content_left_is_clickable">Nótese que, la parte izquierda de la opción \"Depuración inalámbrica\" es cliqueable, si lo toca accederá a mas opciones. Solo tocar el interruptor de la derecha no es suficiente.</string>
-    <string name="adb_pairing_tutorial_content_network_limation_not_foreground">Algunos sistemas (como MIUI) deshabilitan el acceso a la red de aplicaciones cuando estas no están visibles, aún cuando estas usen servicios en segundo plano como estándar. Por favor deshabilite la Optimización de batería para Shizuku en estos sistemas.</string>
-    <string name="home_root_description">Además, Shizuku puede iniciarse automáticamente al arrancar el sistema. Si no es así, por favor compruebe si su sistema o si herramientas de terceros no han restringido Shizuku. &lt;br&gt;Puede consultar en %s.</string>
-    <string name="home_learn_more_title">Aprenda sobre Shizuku</string>
+    <string name="adb_pairing_tutorial_content_network_limation_not_foreground">Algunos sistemas (como MIUI) deshabilitan el acceso a la red de aplicaciones cuando estas no están visibles, aún cuando estas usen servicios en segundo plano como estándar. Por favor deshabilite la Optimización de batería para Shizuku™ en estos sistemas.</string>
+    <string name="home_root_description">Además, Shizuku™ puede iniciarse automáticamente al arrancar el sistema. Si no es así, por favor compruebe si su sistema o si herramientas de terceros no han restringido Shizuku™. &lt;br&gt;Puede consultar en %s.</string>
+    <string name="home_learn_more_title">Aprenda sobre Shizuku™</string>
     <string name="app_management_dialog_adb_is_limited_title">El permiso de ADB es limitado</string>
     <string name="settings_translation">Participar en la traducción</string>
     <string name="settings_translation_contributors">Colaboradores de la traducción</string>
     <string name="settings_black_night_theme_summary">Use el tema Noche cerrada si el modo nocturno está habilitado</string>
     <string name="settings_black_night_theme">Tema Noche cerrada</string>
     <string name="settings_title">Configuración</string>
-    <string name="rish_description">Con %1$s, en cualquier consola de comandos , puede conectarse e interactuar con el shell que ejecuta Shizuku. &lt;p&gt;Acerca del uso detallado %1$s, toque para ver el documento.</string>
+    <string name="rish_description">Con %1$s, en cualquier consola de comandos , puede conectarse e interactuar con el shell que ejecuta Shizuku™. &lt;p&gt;Acerca del uso detallado %1$s, toque para ver el documento.</string>
     <string name="terminal_tutorial_1_description">Si hay archivos con el mismo nombre en la carpeta seleccionada, se eliminarán.
-\n La función de exportación utiliza SAF (Storage Access Framework). Se informa que MIUI rompe las funciones de SAF. Si está utilizando MIUI, es posible que deba extraer el archivo de la aplicación de Shizuku o descargarlo de GitHub.</string>
-    <string name="dialog_requesting_legacy_button_open_shizuku">Abrir Shizuku</string>
-    <string name="dialog_requesting_legacy_message">&lt;b&gt;%1$s&lt;/b&gt; tiene compatibilidad moderna con Shizuku, pero solicita Shizuku heredada. Esto podría deberse a que Shizuku no se está ejecutando, verifique en la aplicación Shizuku. &lt;p&gt; Legacy Shizuku está obsoleto desde marzo de 2019.</string>
-    <string name="dialog_requesting_legacy_title">%1$s está solicitando el legado de Shizuku</string>
-    <string name="dialog_legacy_not_support_message">Legacy Shizuku ha quedado obsoleto desde marzo de 2019. Además, Legacy Shizuku no funciona en los sistemas Android más nuevos.&lt;p&gt;Pida al desarrollador de &lt;b&gt;%1$s&lt;/b&gt; que actualice.</string>
-    <string name="dialog_legacy_not_support_title">%1$s no soporta Shizuku moderno</string>
+\n La función de exportación utiliza SAF (Storage Access Framework). Se informa que MIUI rompe las funciones de SAF. Si está utilizando MIUI, es posible que deba extraer el archivo de la aplicación de Shizuku™ o descargarlo de GitHub.</string>
+    <string name="dialog_requesting_legacy_button_open_shizuku">Abrir Shizuku™</string>
+    <string name="dialog_requesting_legacy_message">&lt;b&gt;%1$s&lt;/b&gt; tiene compatibilidad moderna con Shizuku™, pero solicita Shizuku™ heredada. Esto podría deberse a que Shizuku™ no se está ejecutando, verifique en la aplicación Shizuku™. &lt;p&gt; Legacy Shizuku™ está obsoleto desde marzo de 2019.</string>
+    <string name="dialog_requesting_legacy_title">%1$s está solicitando el legado de Shizuku™</string>
+    <string name="dialog_legacy_not_support_message">Legacy Shizuku™ ha quedado obsoleto desde marzo de 2019. Además, Legacy Shizuku™ no funciona en los sistemas Android más nuevos.&lt;p&gt;Pida al desarrollador de &lt;b&gt;%1$s&lt;/b&gt; que actualice.</string>
+    <string name="dialog_legacy_not_support_title">%1$s no soporta Shizuku™ moderno</string>
     <string name="toast_copied_to_clipboard_with_text"><b>%s</b>fue copiado al blog de notas.</string>
     <string name="toast_copied_to_clipboard">%s
 \nse copió en clipboard.</string>
@@ -92,11 +92,11 @@
     <string name="grant_dialog_button_deny">Denegar</string>
     <string name="grant_dialog_button_allow_always">Permitir siempre</string>
     <string name="permission_warning_template">Permitir <b>%1$s</b> en %2$s\?</string>
-    <string name="permission_description">Permitir que la aplicación use Shizuku.</string>
-    <string name="permission_label">acceso Shizuku</string>
+    <string name="permission_description">Permitir que la aplicación use Shizuku™.</string>
+    <string name="permission_label">acceso Shizuku™</string>
     <string name="notification_adb_pairing_retry">Reintentar</string>
     <string name="notification_adb_pairing_failed_title">Fallo de emparejamiento</string>
-    <string name="notification_adb_pairing_succeed_text">Puede iniciar el servicio Shizuku ahora.</string>
+    <string name="notification_adb_pairing_succeed_text">Puede iniciar el servicio Shizuku™ ahora.</string>
     <string name="notification_adb_pairing_succeed_title">Emparejado completo</string>
     <string name="notification_adb_pairing_working_title">Emparejamiento en proceso</string>
     <string name="notification_adb_pairing_stop_searching">Detener búsqueda</string>
@@ -106,27 +106,27 @@
     <string name="notification_channel_adb_pairing">Emparejamiento de depuración inalámbrica</string>
     <string name="notification_working">En proceso…</string>
     <string name="notification_service_start_no_root">Fallo al pedir permisos root.</string>
-    <string name="notification_service_start_failed">El inicio del servicio Shizuku a fallado.</string>
-    <string name="notification_service_starting">El servicio Shizuku está iniciandose…</string>
+    <string name="notification_service_start_failed">El inicio del servicio Shizuku™ a fallado.</string>
+    <string name="notification_service_starting">El servicio Shizuku™ está iniciandose…</string>
     <string name="notification_channel_service_status">Estado de inicio del servicio</string>
-    <string name="dialog_stop_message">El servicio Shizuku se detendrá.</string>
-    <string name="action_stop">Detener Shizuku</string>
+    <string name="dialog_stop_message">El servicio Shizuku™ se detendrá.</string>
+    <string name="action_stop">Detener Shizuku™</string>
     <string name="about_view_source_code">Ver código fuente en %s</string>
     <string name="action_about">Acerca de</string>
     <string name="settings_use_system_color">Usar el color del tema del sistema</string>
-    <string name="settings_start_on_boot_summary">Para dispositivos rooteados, Shizuku puede iniciarse automáticamente en el arranque</string>
+    <string name="settings_start_on_boot_summary">Para dispositivos rooteados, Shizuku™ puede iniciarse automáticamente en el arranque</string>
     <string name="settings_start_on_boot">Iniciar en el arranque (root)</string>
     <string name="settings_translation_summary">Ayúdanos a traducir %s a tu idioma</string>
     <string name="settings_startup">Empezando</string>
     <string name="settings_user_interface">Apariencia</string>
     <string name="settings_language">Idioma</string>
     <string name="terminal_tutorial_3_description">Algunos consejos: otorgue permiso de ejecución a %1$s y agréguelo a %2$s, podrá usar %1$s directamente.</string>
-    <string name="terminal_tutorial_3">Finalmente, mueva los archivos a algún lugar donde su aplicación de terminal pueda acceder, podrá usar %1$s para ejecutar comandos a través de Shizuku.</string>
-    <string name="terminal_tutorial_2_description">Por ejemplo, si desea usar Shizuku en %1$s, debe reemplazar %2$s con %3$s (%4$s es el nombre del paquete de %1$s).</string>
+    <string name="terminal_tutorial_3">Finalmente, mueva los archivos a algún lugar donde su aplicación de terminal pueda acceder, podrá usar %1$s para ejecutar comandos a través de Shizuku™.</string>
+    <string name="terminal_tutorial_2_description">Por ejemplo, si desea usar Shizuku™ en %1$s, debe reemplazar %2$s con %3$s (%4$s es el nombre del paquete de %1$s).</string>
     <string name="terminal_tutorial_2">Luego, use cualquier editor de texto para abrir y editar %1$s.</string>
     <string name="terminal_export_files">Exportar archivos</string>
     <string name="terminal_tutorial_1">Primero, exporte archivos a cualquier lugar que desee. Encontrará dos archivos, %1$s y %2$s.</string>
-    <string name="home_app_management_empty">Las aplicaciones que han solicitado o declarado Shizuku se mostrarán aquí.</string>
+    <string name="home_app_management_empty">Las aplicaciones que han solicitado o declarado Shizuku™ se mostrarán aquí.</string>
     <plurals name="home_app_management_authorized_apps_count">
         <item quantity="one">Autorizado el %d de la aplicacion</item>
         <item quantity="many">Autorizadas %d aplicaciones</item>

--- a/manager/src/main/res/values-fa/strings.xml
+++ b/manager/src/main/res/values-fa/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name" translatable="false">Shizuku</string>
+    <string name="app_name" translatable="false">Shizuku™</string>
     <!-- To translators: you can leave your here -->
     <string name="translation_contributors">@Fardin_Ahmadyy</string>
     <!-- Home - Status -->
@@ -10,7 +10,7 @@
     <string name="home_status_service_version_update"><![CDATA[نسخه %2$s، %1$s<br>برای به‌روزرسانی به نسخه %3$s برنامه را راه‌اندازی مجدد نمایید]]></string>
     <!-- Home - Adb -->
     <string name="home_adb_title"><![CDATA[با اتصال به رایانه شروع کنید]]></string>
-    <string name="home_adb_description"><![CDATA[برای دستگاه‌های بدون دسترسی ریسه، باید از adb برای راه‌اندازی Shizuku استفاده کنید (نیاز به اتصال به رایانه دارد). این فرآیند باید هر بار که دستگاه راه اندازی مجدد می شود تکرار شود. لطفاً <b><a href=\"%1$s\">راهنما را بخوانید</a></b>.]]></string>
+    <string name="home_adb_description"><![CDATA[برای دستگاه‌های بدون دسترسی ریسه، باید از adb برای راه‌اندازی Shizuku™ استفاده کنید (نیاز به اتصال به رایانه دارد). این فرآیند باید هر بار که دستگاه راه اندازی مجدد می شود تکرار شود. لطفاً <b><a href=\"%1$s\">راهنما را بخوانید</a></b>.]]></string>
     <string name="home_adb_button_view_help">خواندن راهنما</string>
     <string name="home_adb_button_view_command">مشاهده دستور</string>
     <string name="home_adb_dialog_view_command_message"><![CDATA[<font face="monospace">%1$s</font><br><br>* ملاحظات دیگری نیز وجود دارد، لطفاً تأیید کنید که ابتدا راهنما را خوانده اید.]]></string>
@@ -18,12 +18,12 @@
     <string name="home_adb_dialog_view_command_button_send">ارسال</string>
     <!-- Home - Wireless Adb -->
     <string name="home_wireless_adb_title"><![CDATA[از طریق اشکال زدایی بی سیم شروع کنید]]></string>
-    <string name="home_wireless_adb_description"><![CDATA[در اندروید ۱۱ یا بالاتر، می‌توانید اشکال‌زدایی بی‌سیم را فعال کنید و Shizuku را مستقیماً از دستگاه خود بدون اتصال به رایانه شروع کنید.<p>لطفاً ابتدا راهنمای گام به گام را مطالعه کنید.]]></string>
+    <string name="home_wireless_adb_description"><![CDATA[در اندروید ۱۱ یا بالاتر، می‌توانید اشکال‌زدایی بی‌سیم را فعال کنید و Shizuku™ را مستقیماً از دستگاه خود بدون اتصال به رایانه شروع کنید.<p>لطفاً ابتدا راهنمای گام به گام را مطالعه کنید.]]></string>
     <string name="home_wireless_adb_description_pre_11"><![CDATA[قبل از اندروید ۱۱، برای فعال کردن اشکال‌زدایی بی‌سیم، اتصال به رایانه لازم است.]]></string>
     <string name="home_wireless_adb_view_guide_button">راهنمای گام به گام</string>
     <!-- Adb -->
     <string name="dialog_adb_discovery">جستجوی خدمات اشکال زدایی بی سیم</string>
-    <string name="dialog_adb_discovery_message">لطفاً \"اشکال‌زدایی بی‌سیم\" را در \"گزینه‌های توسعه دهنده\" فعال کنید. وقتی شبکه تغییر می‌کند، \"اشکال‌زدایی بی‌سیم\" به‌طور خودکار غیرفعال می‌شود.\n\nتوجه داشته باشید، \"گزینه‌های توسعه دهنده\" یا \"اشکال‌زدایی USB\" را غیرفعال نکنید، در غیر این صورت Shizuku متوقف خواهد شد.</string>
+    <string name="dialog_adb_discovery_message">لطفاً \"اشکال‌زدایی بی‌سیم\" را در \"گزینه‌های توسعه دهنده\" فعال کنید. وقتی شبکه تغییر می‌کند، \"اشکال‌زدایی بی‌سیم\" به‌طور خودکار غیرفعال می‌شود.\n\nتوجه داشته باشید، \"گزینه‌های توسعه دهنده\" یا \"اشکال‌زدایی USB\" را غیرفعال نکنید، در غیر این صورت Shizuku™ متوقف خواهد شد.</string>
     <string name="dialog_adb_discovery_message_toggle_wireless_debugging">لطفاً در صورتی که به جستجو ادامه داد \"اشکال‌زدایی بی‌سیم\" را غیرفعال و فعال کنید.</string>
     <string name="dialog_adb_port">درگاه</string>
     <string name="dialog_adb_invalid_port">درگاه یک عدد صحیح از ۱ تا ۶۵۵۳۵ است.</string>
@@ -41,21 +41,21 @@
     <string name="adb_pair_required">لطفاً ابتدا مرحله مرتبط کردن را طی کنید.</string>
     <string name="development_settings">گزینه های توسعه دهنده</string>
     <string name="notification_settings">گزینه های اعلان</string>
-    <string name="adb_pairing_tutorial_title">برنامه Shizuku را با دستگاه خود جفت کنید</string>
-    <string name="adb_pairing_tutorial_content_notification">یک اعلان از Shizuku به شما امکان می دهد مرتبط کردن را تکمیل کنید.</string>
+    <string name="adb_pairing_tutorial_title">برنامه Shizuku™ را با دستگاه خود جفت کنید</string>
+    <string name="adb_pairing_tutorial_content_notification">یک اعلان از Shizuku™ به شما امکان می دهد مرتبط کردن را تکمیل کنید.</string>
     <string name="adb_pairing_tutorial_content_steps">وارد \"گزینه‌های توسعه دهنده\" - \"اشکال‌زدایی بی‌سیم\" شوید.  روی \"مرتبط کردن دستگاه با کد مرتبط‌سازی\" ضربه بزنید، یک رمز شش رقمی خواهید دید.</string>
     <string name="adb_pairing_tutorial_content_enter_pairing_code">برای تکمیل مرتبط سازی، رمز شش رقمی را در اعلان وارد کنید.</string>
-    <string name="adb_pairing_tutorial_content_notification_blocked">فرآیند مرتبط شدن به شما نیاز دارد که با اعلان Shizuku تعامل داشته باشید. لطفاً به Shizuku اجازه دهید تا اعلان‌ها را ارسال کند.</string>
+    <string name="adb_pairing_tutorial_content_notification_blocked">فرآیند مرتبط شدن به شما نیاز دارد که با اعلان Shizuku™ تعامل داشته باشید. لطفاً به Shizuku™ اجازه دهید تا اعلان‌ها را ارسال کند.</string>
     <string name="adb_pairing_tutorial_content_miui">کاربران MIUI ممکن است نیاز داشته باشند که در تنظیمات دستگاه، سبک اعلان را به \"اندروید\" از \"اعلان ها\" - \"سایه اعلان\" تغییر دهند.</string>
     <string name="adb_pairing_tutorial_content_miui_2">در غیر این صورت، ممکن است نتوانید رمز مرتبط سازی را از اعلان وارد کنید.</string>
     <string name="adb_pairing_tutorial_content_left_is_clickable">لطفاً توجه داشته باشید، قسمت سمت راست گزینه \"اشکال زدایی بی‌سیم\" قابل لمس است، با ضربه زدن روی آن صفحه جدیدی باز می شود. فقط روشن کردن دکمه سمت چپ کافی نیست.</string>
-    <string name="adb_pairing_tutorial_content_finish">به Shizuku برگردید و Shizuku را راه‌اندازی کنید.</string>
-    <string name="adb_pairing_tutorial_content_network">برنامه Shizuku نیاز به دسترسی به شبکه محلی دارد. زیرا توسط مجوز شبکه مدیریت می شود.</string>
-    <string name="adb_pairing_tutorial_content_network_limation_not_foreground">برخی از دستگاه ها (مانند MIUI) به برنامه‌ها اجازه دسترسی به شبکه را زمانی که قابل مشاهده نیستند، نمی‌دهند، حتی اگر برنامه از خدمات پیش‌زمینه به‌عنوان استاندارد استفاده کند. لطفاً ویژگی‌های بهینه‌سازی باتری را برای Shizuku در چنین دستگاه‌هایی غیرفعال کنید.</string>
+    <string name="adb_pairing_tutorial_content_finish">به Shizuku™ برگردید و Shizuku™ را راه‌اندازی کنید.</string>
+    <string name="adb_pairing_tutorial_content_network">برنامه Shizuku™ نیاز به دسترسی به شبکه محلی دارد. زیرا توسط مجوز شبکه مدیریت می شود.</string>
+    <string name="adb_pairing_tutorial_content_network_limation_not_foreground">برخی از دستگاه ها (مانند MIUI) به برنامه‌ها اجازه دسترسی به شبکه را زمانی که قابل مشاهده نیستند، نمی‌دهند، حتی اگر برنامه از خدمات پیش‌زمینه به‌عنوان استاندارد استفاده کند. لطفاً ویژگی‌های بهینه‌سازی باتری را برای Shizuku™ در چنین دستگاه‌هایی غیرفعال کنید.</string>
     <!-- Home - Root -->
     <string name="home_root_title"><![CDATA[راه‌اندازی (برای دستگاه‌هایی با دسترسی ریشه)]]></string>
-    <string name="home_root_description"><![CDATA[علاوه بر این، Shizuku می تواند به طور خودکار هنگام راه‌اندازی دستگاه راه اندازی شود. اگر نه، لطفاً بررسی کنید که آیا سیستم شما یا ابزارهای شخص ثالث Shizuku را محدود کرده است.<br>می توانید به %s مراجعه کنید.]]></string>
-    <string name="home_root_description_sui"><![CDATA[اگر از Magisk استفاده می‌کنید، می‌توانید %1$s را امتحان کنید. برای کاربران دارای امتیازات ریشه، در نهایت جایگزین Shizuku خواهد شد. توجه داشته باشید، برنامه‌های موجود برای استفاده از %2$s باید کمی تغییر کنند.]]></string>
+    <string name="home_root_description"><![CDATA[علاوه بر این، Shizuku™ می تواند به طور خودکار هنگام راه‌اندازی دستگاه راه اندازی شود. اگر نه، لطفاً بررسی کنید که آیا سیستم شما یا ابزارهای شخص ثالث Shizuku™ را محدود کرده است.<br>می توانید به %s مراجعه کنید.]]></string>
+    <string name="home_root_description_sui"><![CDATA[اگر از Magisk استفاده می‌کنید، می‌توانید %1$s را امتحان کنید. برای کاربران دارای امتیازات ریشه، در نهایت جایگزین Shizuku™ خواهد شد. توجه داشته باشید، برنامه‌های موجود برای استفاده از %2$s باید کمی تغییر کنند.]]></string>
     <string name="home_root_button_start">راه‌اندازی</string>
     <string name="home_root_button_restart">راه‌اندازی مجدد</string>
     <!-- Home - Application management -->
@@ -65,29 +65,29 @@
         <item quantity="other"><![CDATA[%d برنامه مجاز]]></item>
     </plurals>
     <string name="home_app_management_view_authorized_apps"><![CDATA[برای مدیریت برنامه های مجاز ضربه بزنید]]></string>
-    <string name="home_app_management_empty">برنامه‌هایی که Shizuku را درخواست کرده یا اعلام کرده‌اند در اینجا نشان داده می‌شوند.</string>
+    <string name="home_app_management_empty">برنامه‌هایی که Shizuku™ را درخواست کرده یا اعلام کرده‌اند در اینجا نشان داده می‌شوند.</string>
     <!-- Home - Learn more -->
-    <string name="home_learn_more_title">یادگیری Shizuku</string>
-    <string name="home_learn_more_description">یاد بگیرید که چگونه با Shizuku توسعه دهید</string>
+    <string name="home_learn_more_title">یادگیری Shizuku™</string>
+    <string name="home_learn_more_description">یاد بگیرید که چگونه با Shizuku™ توسعه دهید</string>
     <!-- Home - Adb permissions limited -->
     <string name="home_adb_is_limited_title">شما باید یک قدم اضافی بردارید</string>
-    <string name="home_adb_is_limited_description">سازنده دستگاه شما مجوزهای adb را محدود کرده است و برنامه هایی که از Shizuku استفاده می کنند به درستی کار نمی کنند.\n\nمعمولاً با تنظیم برخی از گزینه‌ها در \"گزینه‌های توسعه دهنده\" می‌توان این محدودیت را برطرف کرد. لطفاً راهنما را برای جزئیات نحوه انجام این کار بخوانید.\n\nشاید لازم باشد Shizuku را مجدداً راه اندازی کنید تا عملیات اجرایی شود.</string>
+    <string name="home_adb_is_limited_description">سازنده دستگاه شما مجوزهای adb را محدود کرده است و برنامه هایی که از Shizuku™ استفاده می کنند به درستی کار نمی کنند.\n\nمعمولاً با تنظیم برخی از گزینه‌ها در \"گزینه‌های توسعه دهنده\" می‌توان این محدودیت را برطرف کرد. لطفاً راهنما را برای جزئیات نحوه انجام این کار بخوانید.\n\nشاید لازم باشد Shizuku™ را مجدداً راه اندازی کنید تا عملیات اجرایی شود.</string>
     <!-- Application management -->
     <string name="app_management_dialog_adb_is_limited_title">مجوز adb محدود است</string>
     <string name="app_management_dialog_adb_is_limited_message"><![CDATA[این احتمال وجود دارد که سازنده دستگاه شما مجوز adb را محدود کند.<p>ممکن است راه حلی برای دستگاه شما در <b><a href=\"%1$s\">این سند</a></b> وجود داشته باشد.]]></string>
-    <string name="app_management_item_summary_requires_root">* نیاز دارد که Shizuku با امتیازات ریشه اجرا شود</string>
+    <string name="app_management_item_summary_requires_root">* نیاز دارد که Shizuku™ با امتیازات ریشه اجرا شود</string>
     <!-- Terminal -->
-    <string name="home_terminal_title">از Shizuku در برنامه های پایانه استفاده کنید</string>
-    <string name="home_terminal_description">دستورات را از طریق Shizuku در برنامه های پایانه که دوست دارید اجرا کنید</string>
+    <string name="home_terminal_title">از Shizuku™ در برنامه های پایانه استفاده کنید</string>
+    <string name="home_terminal_description">دستورات را از طریق Shizuku™ در برنامه های پایانه که دوست دارید اجرا کنید</string>
     <string name="terminal_tutorial_1">ابتدا پرونده ها را به هر جایی که می خواهید صادر کنید. دو پرونده %1$s و %2$s پیدا خواهید کرد.</string>
     <string name="terminal_tutorial_1_description">اگر پرونده هایی با همین نام در پوشه انتخاب شده وجود داشته باشد، حذف خواهند شد.\n\nتابع صادرات از SAF (چارچوب دسترسی ذخیره سازی) استفاده می کند. گزارش شده است که MIUI عملکردهای SAF را خراب می کند. اگر از MIUI استفاده می کنید، ممکن است مجبور شوید پرونده را از apk شیزوکو استخراج کنید یا از GitHub بارگیری کنید.</string>
     <string name="terminal_export_files">صادرات پرونده ها</string>
     <string name="terminal_tutorial_2">سپس، از هر ویرایشگر متنی برای باز کردن و ویرایش %1$s استفاده کنید.</string>
-    <string name="terminal_tutorial_2_description">برای مثال، اگر می‌خواهید از Shizuku در %1$s استفاده کنید، باید %2$s را با %3$s جایگزین کنید (%4$s نام بسته %1$s است).</string>
-    <string name="terminal_tutorial_3">در نهایت، پرونده ها را به جایی منتقل کنید که برنامه پایانه شما می تواند به آن دسترسی داشته باشد، می توانید از %1$s برای اجرای دستورات از طریق Shizuku استفاده کنید.</string>
+    <string name="terminal_tutorial_2_description">برای مثال، اگر می‌خواهید از Shizuku™ در %1$s استفاده کنید، باید %2$s را با %3$s جایگزین کنید (%4$s نام بسته %1$s است).</string>
+    <string name="terminal_tutorial_3">در نهایت، پرونده ها را به جایی منتقل کنید که برنامه پایانه شما می تواند به آن دسترسی داشته باشد، می توانید از %1$s برای اجرای دستورات از طریق Shizuku™ استفاده کنید.</string>
     <string name="terminal_tutorial_3_description">چند نکته: به %1$s اجازه اجرا بدهید و آن را به %2$s اضافه کنید، می‌توانید مستقیماً از %1$s استفاده کنید.</string>
     <string name="rish_description"><![CDATA[
-با %1$s، در هر برنامه پایانه‌ای، می‌توانید به پوسته‌ای که Shizuku اجرا می‌کند متصل شوید و با آن تعامل داشته باشید.
+با %1$s، در هر برنامه پایانه‌ای، می‌توانید به پوسته‌ای که Shizuku™ اجرا می‌کند متصل شوید و با آن تعامل داشته باشید.
 <p>درباره استفاده دقیق %1$s، برای مشاهده سند ضربه بزنید.
     ]]></string>
     <!-- Settings -->
@@ -101,18 +101,18 @@
     <string name="settings_translation">در ترجمه شرکت کنید</string>
     <string name="settings_translation_summary">با ما همکاری کنید تا %s را به زبان شما ترجمه کنیم</string>
     <string name="settings_start_on_boot">شروع هنگام راه‌اندازی دستگاه (ریشه)</string>
-    <string name="settings_start_on_boot_summary">برای دستگاه های ریشه شده، Shizuku می تواند به طور خودکار در هنگام راه‌اندازی دستگاه شروع شود</string>
+    <string name="settings_start_on_boot_summary">برای دستگاه های ریشه شده، Shizuku™ می تواند به طور خودکار در هنگام راه‌اندازی دستگاه شروع شود</string>
     <string name="settings_use_system_color">از رنگ طرح زمینه دستگاه استفاده کنید</string>
     <!-- About -->
     <string name="action_about">درباره</string>
     <string name="about_view_source_code"><![CDATA[کد منبع را در %s مشاهده کنید]]></string>
     <!-- Stop -->
-    <string name="action_stop">توقف Shizuku</string>
-    <string name="dialog_stop_message">خدمات Shizuku متوقف خواهد شد.</string>
+    <string name="action_stop">توقف Shizuku™</string>
+    <string name="dialog_stop_message">خدمات Shizuku™ متوقف خواهد شد.</string>
     <!-- Notification -->
     <string name="notification_channel_service_status">وضعیت شروع خدمات</string>
-    <string name="notification_service_starting">خدمات Shizuku شروع می شود…</string>
-    <string name="notification_service_start_failed">راه‌اندازی خدمات Shizuku ناموفق بود.</string>
+    <string name="notification_service_starting">خدمات Shizuku™ شروع می شود…</string>
+    <string name="notification_service_start_failed">راه‌اندازی خدمات Shizuku™ ناموفق بود.</string>
     <string name="notification_service_start_no_root">درخواست مجوز ریشه انجام نشد.</string>
     <string name="notification_working">در حال کار کردن…</string>
     <string name="notification_channel_adb_pairing">مرتبط سازی اشکال‌زدایی بی‌سیم</string>
@@ -122,14 +122,14 @@
     <string name="notification_adb_pairing_stop_searching">توقف جستجو</string>
     <string name="notification_adb_pairing_working_title">مرتبط سازی در حال انجام است</string>
     <string name="notification_adb_pairing_succeed_title">مرتبط سازی با موفقیت انجام شد</string>
-    <string name="notification_adb_pairing_succeed_text">اکنون می توانید خدمات Shizuku را راه اندازی کنید.</string>
+    <string name="notification_adb_pairing_succeed_text">اکنون می توانید خدمات Shizuku™ را راه اندازی کنید.</string>
     <string name="notification_adb_pairing_failed_title">مرتبط سازی انجام نشد</string>
     <string name="notification_adb_pairing_retry">سعی مجدد</string>
     <!-- Permission related, appears in system permission UI -->
-    <string name="permission_group_label" translatable="false">Shizuku</string>
+    <string name="permission_group_label" translatable="false">Shizuku™</string>
     <string name="permission_group_description" translatable="false">@string/permission_label</string>
-    <string name="permission_label">دسترسی Shizuku</string>
-    <string name="permission_description">به برنامه اجازه دهید از Shizuku استفاده کند.</string>
+    <string name="permission_label">دسترسی Shizuku™</string>
+    <string name="permission_description">به برنامه اجازه دهید از Shizuku™ استفاده کند.</string>
     <string name="permission_warning_template"><![CDATA[اجازه <b>%1$s</b> برای %2$s؟]]></string>
     <string name="grant_dialog_button_allow_always">همیشه اجازه داده شود</string>
     <string name="grant_dialog_button_deny">"رد"</string>
@@ -143,8 +143,8 @@
     <string name="toast_copied_to_clipboard_with_text"><![CDATA[<b>%s</b> در بریده‌دان رونوشت شده است.]]></string>
     <!-- Messages for legacy -->
     <string name="dialog_legacy_not_support_title">%1$s از شیزوکوی جدید پشتیبانی نمی کند</string>
-    <string name="dialog_legacy_not_support_message"><![CDATA[شیزوکوی قدیمی از مارس ۲۰۱۹ منسوخ شده است. همچنین، Shizuku قدیمی در دستگاه‌های اندروید جدید کار نمی‌کند.<p>لطفاً از توسعه‌دهنده <b>%1$s</b> بخواهید که به‌روزرسانی کند.]]></string>
-    <string name="dialog_requesting_legacy_title">%1$s در حال درخواست Shizuku قدیمی است</string>
-    <string name="dialog_requesting_legacy_message"><![CDATA[<b>%1$s</b> پشتیبانی نسخه جدید شیزوکو دارد، اما شیزوکو قدیمی را درخواست می‌کند. این ممکن است به این دلیل باشد که Shizuku در حال اجرا نیست، لطفاً در برنامه Shizuku بررسی کنید.<p>Shizuku قدیمی از مارس ۲۰۱۹ منسوخ شده است.]]></string>
-    <string name="dialog_requesting_legacy_button_open_shizuku">باز کردن Shizuku</string>
+    <string name="dialog_legacy_not_support_message"><![CDATA[شیزوکوی قدیمی از مارس ۲۰۱۹ منسوخ شده است. همچنین، Shizuku™ قدیمی در دستگاه‌های اندروید جدید کار نمی‌کند.<p>لطفاً از توسعه‌دهنده <b>%1$s</b> بخواهید که به‌روزرسانی کند.]]></string>
+    <string name="dialog_requesting_legacy_title">%1$s در حال درخواست Shizuku™ قدیمی است</string>
+    <string name="dialog_requesting_legacy_message"><![CDATA[<b>%1$s</b> پشتیبانی نسخه جدید شیزوکو دارد، اما شیزوکو قدیمی را درخواست می‌کند. این ممکن است به این دلیل باشد که Shizuku™ در حال اجرا نیست، لطفاً در برنامه Shizuku™ بررسی کنید.<p>Shizuku™ قدیمی از مارس ۲۰۱۹ منسوخ شده است.]]></string>
+    <string name="dialog_requesting_legacy_button_open_shizuku">باز کردن Shizuku™</string>
 </resources>

--- a/manager/src/main/res/values-fil/strings.xml
+++ b/manager/src/main/res/values-fil/strings.xml
@@ -1,28 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="terminal_tutorial_3_description">Tip: bigyan ng pahintulot na ma-execute ang %1$s at idagdag ito sa %2$s, pwede mong direktang magamit ang %1$s.</string>
-    <string name="terminal_tutorial_3">At, ilipat ang mga file sa kung saan ito pwedeng ma-access ng terminal app mo, magagamit mo ang %1$s para magpaandar ng mga utos papuntang Shizuku.</string>
-    <string name="terminal_tutorial_2_description">Halimbawa, kung gusto mong gamitin ang Shizuku sa %1$s, dapat palitan mo ang %2$s ng %3$s (ang package name ng %1$s ay %4$s).</string>
+    <string name="terminal_tutorial_3">At, ilipat ang mga file sa kung saan ito pwedeng ma-access ng terminal app mo, magagamit mo ang %1$s para magpaandar ng mga utos papuntang Shizuku™.</string>
+    <string name="terminal_tutorial_2_description">Halimbawa, kung gusto mong gamitin ang Shizuku™ sa %1$s, dapat palitan mo ang %2$s ng %3$s (ang package name ng %1$s ay %4$s).</string>
     <string name="terminal_tutorial_2">Tapos, guamit ng anumang editor ng teksto para buksan at baguhin ang %1$s.</string>
     <string name="terminal_export_files">I-export ang mga file</string>
     <string name="terminal_tutorial_1_description">Mabubura ang mga file na may parehong pangalan sa folder na pipiliin mo.
 \n
-\nGinagamit ang SAF (Storage Access Framework) para ma-export ang file. Naiulat na hindi gumagana nang maayos ang SAF sa MIUI. Kung nasa MIUI ka, baka kailangan mong i-extract ang file mula sa apk ng Shizuku o i-download ito mula sa GitHub.</string>
+\nGinagamit ang SAF (Storage Access Framework) para ma-export ang file. Naiulat na hindi gumagana nang maayos ang SAF sa MIUI. Kung nasa MIUI ka, baka kailangan mong i-extract ang file mula sa apk ng Shizuku™ o i-download ito mula sa GitHub.</string>
     <string name="terminal_tutorial_1">Una, i-export ang mga file saan mo man gusto. May dalawa kang file na makikita, %1$s at %2$s.</string>
-    <string name="home_terminal_description">Magpatakbo ng mga utos papuntang Shizuku gamit ang terminal app mo</string>
-    <string name="home_terminal_title">Gamitin ang Shizuku sa mga terminal app</string>
-    <string name="app_management_item_summary_requires_root">* kailangang patakbuhin ang Shizuku gamit ang root</string>
+    <string name="home_terminal_description">Magpatakbo ng mga utos papuntang Shizuku™ gamit ang terminal app mo</string>
+    <string name="home_terminal_title">Gamitin ang Shizuku™ sa mga terminal app</string>
+    <string name="app_management_item_summary_requires_root">* kailangang patakbuhin ang Shizuku™ gamit ang root</string>
     <string name="app_management_dialog_adb_is_limited_message">Posibleng nilimitahan ng gumawa ng device mo ang kakayahan ng adb.&lt;p&gt;Maaaring may solusyon para sa sistema mo sa &lt;b&gt;&lt;a href=\"%1$s\"&gt;dokumentong ito&lt;/a&gt;&lt;/b&gt;.</string>
     <string name="app_management_dialog_adb_is_limited_title">Limitado ang pahintulot ng adb</string>
-    <string name="home_adb_is_limited_description">Pinaghigpitan ng gumawa ng device mo ang kakayahan ng adb, kaya hindi gagana nang maayos ang mga app na gumagamit ng Shizuku.
+    <string name="home_adb_is_limited_description">Pinaghigpitan ng gumawa ng device mo ang kakayahan ng adb, kaya hindi gagana nang maayos ang mga app na gumagamit ng Shizuku™.
 \n
 \nKadalasan, pwedeng matanggal ang mga paghihigpit na ito sa pamamagitan ng ilang mga pagbabago sa \"Mga opsyon ng developer\". Mangyaring sumangguni sa gabay para sa higit pang detalye kung paano ito gagawin.
 \n
-\nMaaaring kailanganin mong isara at buksan ulit ang Shizuku para umepekto ang opersayon.</string>
+\nMaaaring kailanganin mong isara at buksan ulit ang Shizuku™ para umepekto ang opersayon.</string>
     <string name="home_adb_is_limited_title">May mga karagdagang hakbang kang dapat gawin</string>
-    <string name="home_learn_more_description">Matuto kung paano mag-develop gamit ang Shizuku</string>
-    <string name="home_learn_more_title">Matuto Pa Tungkol sa Shizuku</string>
-    <string name="home_app_management_empty">Lalabas dito ang mga app na hiniling o idineklara ang Shizuku.</string>
+    <string name="home_learn_more_description">Matuto kung paano mag-develop gamit ang Shizuku™</string>
+    <string name="home_learn_more_title">Matuto Pa Tungkol sa Shizuku™</string>
+    <string name="home_app_management_empty">Lalabas dito ang mga app na hiniling o idineklara ang Shizuku™.</string>
     <string name="home_app_management_view_authorized_apps">Pindutin para pamahalaan ang mga awtorisadong app</string>
     <plurals name="home_app_management_authorized_apps_count">
         <item quantity="one">%d aplikasyon ang awtorisado</item>
@@ -31,20 +31,20 @@
     <string name="home_app_management_title">Pamamahala sa aplikasyon</string>
     <string name="home_root_button_restart">Simulan muli</string>
     <string name="home_root_button_start">Simulan</string>
-    <string name="home_root_description_sui">Kung gumagamit ka ng Magisk, subukan mo ang %1$s. Para sa mga may root, dahan-dahan nitong papalitan ang Shizuku. Tandaan, may kaunting pagbabagong kakailanganin ang mga kasalukuyang app para gamitin ang %2$s.</string>
-    <string name="home_root_description">Pwede ring awtomatikong masimulan ang Shizuku pagka-boot. Kung hindi, maaaring nilimitahan ng iyong sistema o ng third-party na kagamitan ang Shizuku.&lt;br&gt;Sumangguni sa %s.</string>
+    <string name="home_root_description_sui">Kung gumagamit ka ng Magisk, subukan mo ang %1$s. Para sa mga may root, dahan-dahan nitong papalitan ang Shizuku™. Tandaan, may kaunting pagbabagong kakailanganin ang mga kasalukuyang app para gamitin ang %2$s.</string>
+    <string name="home_root_description">Pwede ring awtomatikong masimulan ang Shizuku™ pagka-boot. Kung hindi, maaaring nilimitahan ng iyong sistema o ng third-party na kagamitan ang Shizuku™.&lt;br&gt;Sumangguni sa %s.</string>
     <string name="home_root_title">Simulan (para sa mga device na may root)</string>
-    <string name="adb_pairing_tutorial_content_network_limation_not_foreground">Sa ilang sistema (tulad ng MIUI), hindi maa-access ng mga app ang network kapag hindi sila nakikita, kahit gumagamit ang app ng pangkaraniwang foreground na serbisyo. Patayin ang pag-optimize ng baterya para sa Shizuku sa mga sistemang iyon.</string>
-    <string name="adb_pairing_tutorial_content_network">Kailangang ma-access ng Shizuku ang lokal na network. Kinokontrol ito ng pahintulot sa network.</string>
-    <string name="adb_pairing_tutorial_content_finish">Bumalik sa Shizuku at simulan ang Shizuku.</string>
+    <string name="adb_pairing_tutorial_content_network_limation_not_foreground">Sa ilang sistema (tulad ng MIUI), hindi maa-access ng mga app ang network kapag hindi sila nakikita, kahit gumagamit ang app ng pangkaraniwang foreground na serbisyo. Patayin ang pag-optimize ng baterya para sa Shizuku™ sa mga sistemang iyon.</string>
+    <string name="adb_pairing_tutorial_content_network">Kailangang ma-access ng Shizuku™ ang lokal na network. Kinokontrol ito ng pahintulot sa network.</string>
+    <string name="adb_pairing_tutorial_content_finish">Bumalik sa Shizuku™ at simulan ang Shizuku™.</string>
     <string name="adb_pairing_tutorial_content_left_is_clickable">Tandaan, ang kaliwang bahagi ng \"Wireless na pag-debug\" ay napipindot, nagbubukas ito ng bagong pahina. Mali kung pipindutin mo lang ang switch sa kanan.</string>
     <string name="adb_pairing_tutorial_content_miui_2">Kung hindi mo ito gagawin, maaaring hindi mo mailalagay ang code ng pagpapares sa notipikasyon.</string>
     <string name="adb_pairing_tutorial_content_miui">Maaaring kailangan ng mga gumagamit ng MIUI na gawing \"Android\" ang estilo ng notipikasyon sa \"Notification\" - \"Notification shade\" sa system settings.</string>
-    <string name="adb_pairing_tutorial_content_notification_blocked">Kailangan mong makisalamuha sa isang notipikasyon mula sa Shizuku para makumpleto ang proseso sa pagpapares. Mangyaring payagan ang Shizuku na magpadala ng mga notipikasyon.</string>
+    <string name="adb_pairing_tutorial_content_notification_blocked">Kailangan mong makisalamuha sa isang notipikasyon mula sa Shizuku™ para makumpleto ang proseso sa pagpapares. Mangyaring payagan ang Shizuku™ na magpadala ng mga notipikasyon.</string>
     <string name="adb_pairing_tutorial_content_enter_pairing_code">Ilagay ang code sa notipikasyon para makumpleto ang pagpapares.</string>
     <string name="adb_pairing_tutorial_content_steps">Pumunta sa \"Mga opsyon ng developer\" - \"Wireless na pag-debug\". Pindutin ang \"Pinapares ang device gamit ang code ng pagpapares\", may anim-na-numerong code kang makikita.</string>
-    <string name="adb_pairing_tutorial_content_notification">Tutulungan ka ng isang notipikasyon mula sa Shizuku na tapusin ang pagpapares.</string>
-    <string name="adb_pairing_tutorial_title">Ipares ang Shizuku sa device mo</string>
+    <string name="adb_pairing_tutorial_content_notification">Tutulungan ka ng isang notipikasyon mula sa Shizuku™ na tapusin ang pagpapares.</string>
+    <string name="adb_pairing_tutorial_title">Ipares ang Shizuku™ sa device mo</string>
     <string name="notification_settings">Mga opsyon sa notipikasyon</string>
     <string name="development_settings">Mga opsyon ng developer</string>
     <string name="adb_pair_required">Sundin muna ang mga hakbang sa pagpapares.</string>
@@ -68,18 +68,18 @@
     <string name="dialog_adb_discovery_message_toggle_wireless_debugging">Mangyaring patayin at buksan ulit ang \"Wireless na pag-debug\" kung sige lang ito sa paghahanap.</string>
     <string name="dialog_adb_discovery_message">Buksan ang \"Wireless na pag-debug\" sa \"Mga opsyon ng developer\". Awtomatikong namamatay ang \"Wireless na pag-debug\" kapag may nagbago sa network.
 \n
-\nTandaan, huwag patayin ang \"Mga opsyon ng developer\" o \"Pag-debug ng USB\", mahihinto ang Shizuku.</string>
+\nTandaan, huwag patayin ang \"Mga opsyon ng developer\" o \"Pag-debug ng USB\", mahihinto ang Shizuku™.</string>
     <string name="dialog_adb_discovery">Hinahanap ang serbisyo ng wireless na pag-debug</string>
     <string name="home_wireless_adb_view_guide_button">Hakbang-hakbang na gabay</string>
     <string name="home_wireless_adb_description_pre_11">Kailangang kumonekta sa kompyuter para mabuksan ang Wireless na pag-debug sa Android 10 pababa.</string>
-    <string name="home_wireless_adb_description">Pwede mong buksan ang Wireless na pag-debug at simulan ang Shizuku direkta sa iyong device nang hindi kumokonekta sa kompyuter sa Android 11 pataas.&lt;p&gt;Mangyaring sumangguni muna sa gabay.</string>
+    <string name="home_wireless_adb_description">Pwede mong buksan ang Wireless na pag-debug at simulan ang Shizuku™ direkta sa iyong device nang hindi kumokonekta sa kompyuter sa Android 11 pataas.&lt;p&gt;Mangyaring sumangguni muna sa gabay.</string>
     <string name="home_wireless_adb_title">Simulan gamit ang Wireless na pag-debug</string>
     <string name="home_adb_dialog_view_command_button_send">Ipadala</string>
     <string name="home_adb_dialog_view_command_copy_button">Kopyahin</string>
     <string name="home_adb_dialog_view_command_message">&lt;font face=monospace&gt;%1$s&lt;/font&gt;&lt;br&gt;&lt;br&gt;* May iba pang mga dapat ikonsidera, siguraduhin munang nabasa mo na ang gabay.</string>
     <string name="home_adb_button_view_command">Tingnan ang command</string>
     <string name="home_adb_button_view_help">Sumangguni sa gabay</string>
-    <string name="home_adb_description">Kailangan mong gumamit ng adb para masimulan ang Shizuku kung walang root ang device mo (kailangang kumonekta sa kompyuter). Dapat ulitin ito tuwing nare-restart ang device mo. Mangyaring <b><a href="%1$s">sumangguni sa gabay</a></b>.</string>
+    <string name="home_adb_description">Kailangan mong gumamit ng adb para masimulan ang Shizuku™ kung walang root ang device mo (kailangang kumonekta sa kompyuter). Dapat ulitin ito tuwing nare-restart ang device mo. Mangyaring <b><a href="%1$s">sumangguni sa gabay</a></b>.</string>
     <string name="home_adb_title">Magsimula sa pamamagitan ng pagkonekta sa kompyuter</string>
     <string name="home_status_service_version_update">Bersyon %2$s, %1$s&lt;br&gt;Simulan ulit para maka-update patungong bersyon %3$s</string>
     <string name="home_status_service_version">Bersyon %2$s, %1$s</string>
@@ -87,7 +87,7 @@
     <string name="home_status_service_is_running">Tumatakbo ang %1$s</string>
     <string name="translation_contributors">\@Cyndaquissshhh (Hosted Weblate)</string>
     <string name="notification_adb_pairing_failed_title">Nagkaproblema sa pagpapares</string>
-    <string name="notification_adb_pairing_succeed_text">Masisimulan mo na ngayon ang serbisyo ng Shizuku.</string>
+    <string name="notification_adb_pairing_succeed_text">Masisimulan mo na ngayon ang serbisyo ng Shizuku™.</string>
     <string name="notification_adb_pairing_succeed_title">Matagumpay na nakapagpares</string>
     <string name="notification_adb_pairing_working_title">Kasalukuyang nagpapares</string>
     <string name="notification_adb_pairing_stop_searching">Ihinto ang paghahanap</string>
@@ -97,15 +97,15 @@
     <string name="notification_adb_pairing_input_paring_code">Ilagay ang code ng pagpapares</string>
     <string name="notification_channel_adb_pairing">Pagpapares ng wireless na pag-debug</string>
     <string name="notification_working">Inaasikaso…</string>
-    <string name="notification_service_start_failed">Nagkaproblema sa pagsisimula ng serbisyo ng Shizuku.</string>
-    <string name="notification_service_starting">Nagsisimula ang serbisyo ng Shizuku…</string>
+    <string name="notification_service_start_failed">Nagkaproblema sa pagsisimula ng serbisyo ng Shizuku™.</string>
+    <string name="notification_service_starting">Nagsisimula ang serbisyo ng Shizuku™…</string>
     <string name="notification_channel_service_status">Estado sa pagbubukas ng serbisyo</string>
-    <string name="dialog_stop_message">Ihihinto ang serbisyo ng Shizuku.</string>
-    <string name="action_stop">Ihinto ang Shizuku</string>
+    <string name="dialog_stop_message">Ihihinto ang serbisyo ng Shizuku™.</string>
+    <string name="action_stop">Ihinto ang Shizuku™</string>
     <string name="about_view_source_code">Tingnan ang source code sa %s</string>
     <string name="action_about">Tungkol</string>
     <string name="settings_use_system_color">Gamitin ang kulay ng tema ng sistema</string>
-    <string name="settings_start_on_boot_summary">Pwede itakdang tumakbo agad pagka-boot ang Shizuku sa mga naka-root na device</string>
+    <string name="settings_start_on_boot_summary">Pwede itakdang tumakbo agad pagka-boot ang Shizuku™ sa mga naka-root na device</string>
     <string name="settings_start_on_boot">Buksan pagka-boot (root)</string>
     <string name="settings_translation_summary">Tulungan kaming isalin ang %s sa iyong wika</string>
     <string name="settings_translation">Sumali sa pagsasalin</string>
@@ -116,12 +116,12 @@
     <string name="settings_user_interface">Hitsura</string>
     <string name="settings_language">Wika</string>
     <string name="settings_title">Mga Setting</string>
-    <string name="rish_description">Gamit ang %1$s, makakakonekta ka sa shell ng Shizuku gamit ang anumang terminal app. &lt;p&gt;Pindutin para makita ang detalyadong impormasyon tungkol sa %1$s.</string>
+    <string name="rish_description">Gamit ang %1$s, makakakonekta ka sa shell ng Shizuku™ gamit ang anumang terminal app. &lt;p&gt;Pindutin para makita ang detalyadong impormasyon tungkol sa %1$s.</string>
     <string name="grant_dialog_button_deny">Tanggihan</string>
     <string name="grant_dialog_button_allow_always">Laging payagan</string>
     <string name="permission_warning_template">Payagan ang <b>%1$s</b> na %2$s\?</string>
-    <string name="permission_description">Payagan ang app na gamitin ang Shizuku.</string>
-    <string name="permission_label">ma-access ang Shizuku</string>
+    <string name="permission_description">Payagan ang app na gamitin ang Shizuku™.</string>
+    <string name="permission_label">ma-access ang Shizuku™</string>
     <string name="notification_adb_pairing_retry">Subukan ulit</string>
     <string name="starter">Panimula</string>
     <string name="start_with_root_failed">Hindi masimulan ang serbisyo sapagkat walang pahintulot sa root o hindi na-root ang device na ito.</string>
@@ -129,9 +129,9 @@
     <string name="toast_copied_to_clipboard">Nakopya sa clipboard ang
 \n%s</string>
     <string name="toast_copied_to_clipboard_with_text">Nakopya ang <b>%s</b> sa clipboard.</string>
-    <string name="dialog_legacy_not_support_title">Hindi sinusuportahan ng %1$s ang makabagong Shizuku (API v11+)</string>
-    <string name="dialog_legacy_not_support_message">Inihinto na ang suporta sa makalumang Shizuku (API v10-). Hindi na rin gagana ang makalumang Shizuku sa mga mas bagong bersyon ng Android.&lt;p&gt;Mangyaring ipaalam sa may-akda ng &lt;b&gt;%1$s&lt;/b&gt; na kailangan na nitong mag-update.</string>
-    <string name="dialog_requesting_legacy_title">Humihiling ng makalumang Shizuku ang %1$s</string>
-    <string name="dialog_requesting_legacy_button_open_shizuku">Buksan ang Shizuku</string>
-    <string name="dialog_requesting_legacy_message">Suportado ng &lt;b&gt;%1$s&lt;/b&gt; ang makabagong Shizuku, pero humihiling ito nang makalumang Shizuku. Pakitingnan sa Shizuku app kung tumatakbo ba nang maayos ang Shizuku dahil baka ito ay dahil nagkakaproblema ang Shizuku.&lt;p&gt;Hindi na suportado ang makalumang Shizuku simula Marso 2019.</string>
+    <string name="dialog_legacy_not_support_title">Hindi sinusuportahan ng %1$s ang makabagong Shizuku™ (API v11+)</string>
+    <string name="dialog_legacy_not_support_message">Inihinto na ang suporta sa makalumang Shizuku™ (API v10-). Hindi na rin gagana ang makalumang Shizuku™ sa mga mas bagong bersyon ng Android.&lt;p&gt;Mangyaring ipaalam sa may-akda ng &lt;b&gt;%1$s&lt;/b&gt; na kailangan na nitong mag-update.</string>
+    <string name="dialog_requesting_legacy_title">Humihiling ng makalumang Shizuku™ ang %1$s</string>
+    <string name="dialog_requesting_legacy_button_open_shizuku">Buksan ang Shizuku™</string>
+    <string name="dialog_requesting_legacy_message">Suportado ng &lt;b&gt;%1$s&lt;/b&gt; ang makabagong Shizuku™, pero humihiling ito nang makalumang Shizuku™. Pakitingnan sa Shizuku™ app kung tumatakbo ba nang maayos ang Shizuku™ dahil baka ito ay dahil nagkakaproblema ang Shizuku™.&lt;p&gt;Hindi na suportado ang makalumang Shizuku™ simula Marso 2019.</string>
 </resources>

--- a/manager/src/main/res/values-fr/strings.xml
+++ b/manager/src/main/res/values-fr/strings.xml
@@ -5,12 +5,12 @@
     <string name="dialog_adb_pairing_discovery">Recherche du service d\'association</string>
     <string name="dialog_adb_pairing_title">Associer avec l\'appareil</string>
     <string name="adb_pairing">Association</string>
-    <string name="home_adb_description">Pour les appareils sans root, vous avez besoin d\'utiliser adb pour démarrer Shizuku (requiert la connexion à un ordinateur). Ce processus doit être répété à chaque fois que l\'appareil est redémarré. Merci de <b><a href="%1$s">lire l\'aide</a></b>.</string>
-    <string name="dialog_requesting_legacy_button_open_shizuku">Ouvrir Shizuku</string>
-    <string name="dialog_requesting_legacy_message">&lt;b&gt;%1$s&lt;/b&gt; supporte les versions récentes de Shizuku, mais demande l\'accès à l\'ancien Shizuku. C\'est peut être parce que Shizuku n\'est pas en cours de fonctionnement, merci de vérifier dans l\'appli Shizuku.&lt;p&gt;L\'ancien Shizuku est obsolète depuis mars 2019.</string>
-    <string name="dialog_requesting_legacy_title">%1$s requiert l\'ancien Shizuku</string>
-    <string name="dialog_legacy_not_support_message">Les anciennes versions de Shizuku sont obsolètes depuis mars 2019. Aussi, elles ne fonctionnent pas sur les versions plus récentes d\'Android.&lt;p&gt;Merci de demander au développeur de &lt;b&gt;%1$s&lt;/b&gt; de mettre à jour.</string>
-    <string name="dialog_legacy_not_support_title">%1$s ne supporte pas les versions plus récentes de Shizuku</string>
+    <string name="home_adb_description">Pour les appareils sans root, vous avez besoin d\'utiliser adb pour démarrer Shizuku™ (requiert la connexion à un ordinateur). Ce processus doit être répété à chaque fois que l\'appareil est redémarré. Merci de <b><a href="%1$s">lire l\'aide</a></b>.</string>
+    <string name="dialog_requesting_legacy_button_open_shizuku">Ouvrir Shizuku™</string>
+    <string name="dialog_requesting_legacy_message">&lt;b&gt;%1$s&lt;/b&gt; supporte les versions récentes de Shizuku™, mais demande l\'accès à l\'ancien Shizuku™. C\'est peut être parce que Shizuku™ n\'est pas en cours de fonctionnement, merci de vérifier dans l\'appli Shizuku™.&lt;p&gt;L\'ancien Shizuku™ est obsolète depuis mars 2019.</string>
+    <string name="dialog_requesting_legacy_title">%1$s requiert l\'ancien Shizuku™</string>
+    <string name="dialog_legacy_not_support_message">Les anciennes versions de Shizuku™ sont obsolètes depuis mars 2019. Aussi, elles ne fonctionnent pas sur les versions plus récentes d\'Android.&lt;p&gt;Merci de demander au développeur de &lt;b&gt;%1$s&lt;/b&gt; de mettre à jour.</string>
+    <string name="dialog_legacy_not_support_title">%1$s ne supporte pas les versions plus récentes de Shizuku™</string>
     <string name="toast_copied_to_clipboard_with_text"><b>%s</b> a bien été copié dans le presse papier.</string>
     <string name="toast_copied_to_clipboard">%s
 \na bien été copié dans le presse papier.</string>
@@ -20,11 +20,11 @@
     <string name="grant_dialog_button_deny">Refuser</string>
     <string name="grant_dialog_button_allow_always">Autoriser tout le temps</string>
     <string name="permission_warning_template">Autoriser <b>%1$s</b> à %2$s \?</string>
-    <string name="permission_description">Autorise l\'appli à utiliser Shizuku.</string>
-    <string name="permission_label">accéder à Shizuku</string>
+    <string name="permission_description">Autorise l\'appli à utiliser Shizuku™.</string>
+    <string name="permission_label">accéder à Shizuku™</string>
     <string name="notification_adb_pairing_retry">Réessayer</string>
     <string name="notification_adb_pairing_failed_title">L\'association a échoué</string>
-    <string name="notification_adb_pairing_succeed_text">Vous pouvez démarrer le service de Shizuku maintenant.</string>
+    <string name="notification_adb_pairing_succeed_text">Vous pouvez démarrer le service de Shizuku™ maintenant.</string>
     <string name="notification_adb_pairing_succeed_title">Association terminée</string>
     <string name="notification_adb_pairing_working_title">Association en cours</string>
     <string name="notification_adb_pairing_stop_searching">Arrêter de chercher</string>
@@ -34,14 +34,14 @@
     <string name="notification_channel_adb_pairing">Association du débogage sans fil</string>
     <string name="notification_working">Chargement…</string>
     <string name="notification_service_start_no_root">Impossible de demander la permission root.</string>
-    <string name="notification_service_start_failed">Le démarrage du service de Shizuku a échoué.</string>
-    <string name="notification_service_starting">Le service Shizuku démarre…</string>
+    <string name="notification_service_start_failed">Le démarrage du service de Shizuku™ a échoué.</string>
+    <string name="notification_service_starting">Le service Shizuku™ démarre…</string>
     <string name="notification_channel_service_status">Statut du démarrage du service</string>
-    <string name="dialog_stop_message">Le service Shizuku sera arrêté.</string>
-    <string name="action_stop">Arrêter Shizuku</string>
+    <string name="dialog_stop_message">Le service Shizuku™ sera arrêté.</string>
+    <string name="action_stop">Arrêter Shizuku™</string>
     <string name="about_view_source_code">Voir le code source sur %s</string>
     <string name="action_about">À propos</string>
-    <string name="settings_start_on_boot_summary">Pour les appareils rootés, Shizuku peut se lancer automatiquement au démarrage</string>
+    <string name="settings_start_on_boot_summary">Pour les appareils rootés, Shizuku™ peut se lancer automatiquement au démarrage</string>
     <string name="settings_start_on_boot">Lancer au démarrage de l\'appareil (root)</string>
     <string name="settings_translation_summary">Aidez-nous à traduire %s dans votre langue</string>
     <string name="settings_translation">Participer à la traduction</string>
@@ -52,23 +52,23 @@
     <string name="settings_user_interface">Apparence</string>
     <string name="settings_language">Langue</string>
     <string name="settings_title">Paramètres</string>
-    <string name="rish_description">Avec %1$s, dans n\'importe quelle appli de terminal, vous pouvez vous connecter et interagir avec le shell lancé par Shizuku. &lt;p&gt;À propos de l\'usage détaillé de %1$s, appuyez pour voir le document.</string>
+    <string name="rish_description">Avec %1$s, dans n\'importe quelle appli de terminal, vous pouvez vous connecter et interagir avec le shell lancé par Shizuku™. &lt;p&gt;À propos de l\'usage détaillé de %1$s, appuyez pour voir le document.</string>
     <string name="terminal_tutorial_3_description">Quelques astuces : accordez la permission d\'exécution à %1$s et ajoutez le au %2$s, vous pourrez utiliser %1$s directement.</string>
-    <string name="terminal_tutorial_3">Enfin, déplacez les fichiers quelque part où votre appli de terminal a accès, vous pourrez utiliser %1$s pour exécuter des commandes à travers Shizuku.</string>
-    <string name="terminal_tutorial_2_description">Par exemple, si vous voulez utiliser Shizuku dans %1$s, vous devriez remplacer %2$s par %3$s (%4$s est le nom de package de %1$s).</string>
+    <string name="terminal_tutorial_3">Enfin, déplacez les fichiers quelque part où votre appli de terminal a accès, vous pourrez utiliser %1$s pour exécuter des commandes à travers Shizuku™.</string>
+    <string name="terminal_tutorial_2_description">Par exemple, si vous voulez utiliser Shizuku™ dans %1$s, vous devriez remplacer %2$s par %3$s (%4$s est le nom de package de %1$s).</string>
     <string name="terminal_tutorial_2">Ensuite, utilisez un éditeur de texte pour ouvrir et éditer %1$s.</string>
     <string name="terminal_export_files">Exporter les fichiers</string>
     <string name="terminal_tutorial_1_description">Si il y a des fichiers avec le même nom dans le dossier sélectionné, ils seront supprimés.
 \n
-\nLa fonction exporter utilise le SAF (Framework d\'Accès au Stockage). Nous savons que MIUI casse les fonctions du SAF. Si vous utilisez MIUI, vous pourriez devoir extraire les fichiers depuis l\'apk de Shizuku ou les télécharger depuis GitHub.</string>
+\nLa fonction exporter utilise le SAF (Framework d\'Accès au Stockage). Nous savons que MIUI casse les fonctions du SAF. Si vous utilisez MIUI, vous pourriez devoir extraire les fichiers depuis l\'apk de Shizuku™ ou les télécharger depuis GitHub.</string>
     <string name="terminal_tutorial_1">D\'abord, exportez les fichiers oú vous voulez. Vous trouverez deux fichiers, %1$s et %2$s.</string>
-    <string name="home_terminal_description">Exécuter des commandes à travers Shizuku dans les applis de terminal que vous aimez</string>
-    <string name="home_terminal_title">Utiliser Shizuku dans les applis de terminal</string>
-    <string name="app_management_item_summary_requires_root">* nécessite que Shizuku fonctionne avec le root</string>
+    <string name="home_terminal_description">Exécuter des commandes à travers Shizuku™ dans les applis de terminal que vous aimez</string>
+    <string name="home_terminal_title">Utiliser Shizuku™ dans les applis de terminal</string>
+    <string name="app_management_item_summary_requires_root">* nécessite que Shizuku™ fonctionne avec le root</string>
     <string name="app_management_dialog_adb_is_limited_message">Il est fortement possible que le fabricant de votre appareil limite la permission de adb.&lt;p&gt;Il pourrait avoir une solution pour votre système dans &lt;b&gt;&lt;a href=\"%1$s\"&gt;ce document&lt;/a&gt;&lt;/b&gt;.</string>
     <string name="app_management_dialog_adb_is_limited_title">La permission de adb est limitée</string>
-    <string name="home_learn_more_description">Apprenez comment développer avec Shizuku</string>
-    <string name="home_learn_more_title">Apprendre Shizuku</string>
+    <string name="home_learn_more_description">Apprenez comment développer avec Shizuku™</string>
+    <string name="home_learn_more_title">Apprendre Shizuku™</string>
     <string name="home_app_management_view_authorized_apps">Appuyez pour gérer les applis autorisées</string>
     <plurals name="home_app_management_authorized_apps_count">
         <item quantity="one">%d application autorisée</item>
@@ -77,16 +77,16 @@
     <string name="home_app_management_title">Gestion d\'application</string>
     <string name="home_root_button_restart">Redémarrer</string>
     <string name="home_root_button_start">Démarrer</string>
-    <string name="home_root_description_sui">Si vous utilisez Magisk, vous pouvez essayer %1$s. Pour les utilisateurs root, il pourrait éventuellement remplacer Shizuku. Note, les applications existantes nécessiteraient de changer un petit peu pour utiliser %2$s.</string>
-    <string name="home_root_description">De plus, Shizuku peut être démarré automatiquement au démarrage. Si non, merci de vérifier si votre système ou un outil tiers a restreint Shizuku. &lt;br&gt;Vous pouvez vous référer à %s.</string>
+    <string name="home_root_description_sui">Si vous utilisez Magisk, vous pouvez essayer %1$s. Pour les utilisateurs root, il pourrait éventuellement remplacer Shizuku™. Note, les applications existantes nécessiteraient de changer un petit peu pour utiliser %2$s.</string>
+    <string name="home_root_description">De plus, Shizuku™ peut être démarré automatiquement au démarrage. Si non, merci de vérifier si votre système ou un outil tiers a restreint Shizuku™. &lt;br&gt;Vous pouvez vous référer à %s.</string>
     <string name="home_root_title">Démarrer (pour les appareils rootés)</string>
-    <string name="adb_pairing_tutorial_content_finish">Retournez dans Shizuku et lancez le.</string>
+    <string name="adb_pairing_tutorial_content_finish">Retournez dans Shizuku™ et lancez le.</string>
     <string name="adb_pairing_tutorial_content_miui">Les utilisateurs de MIUI pourraient devoir changer le style de notifications vers \"Android\" dans \"Notifications\" - \"Style de notification\" dans les paramètres système.</string>
-    <string name="adb_pairing_tutorial_content_notification_blocked">Le processus d\'association requiert que vous interagissez avec une notification de Shizuku. Merci d\'autoriser Shizuku à envoyer les notifications.</string>
+    <string name="adb_pairing_tutorial_content_notification_blocked">Le processus d\'association requiert que vous interagissez avec une notification de Shizuku™. Merci d\'autoriser Shizuku™ à envoyer les notifications.</string>
     <string name="adb_pairing_tutorial_content_enter_pairing_code">Entrez le code dans la notification pour compléter l\'association.</string>
     <string name="adb_pairing_tutorial_content_steps">Allez dans les \"Options pour les développeurs\" - \"Débogage sans fil\". Appuyez sur \"Associer l\'appareil avec un code d\'association\", vous verrez un code à six chiffres.</string>
-    <string name="adb_pairing_tutorial_content_notification">Une notification de Shizuku vous aidera à compléter l\'association.</string>
-    <string name="adb_pairing_tutorial_title">Associer Shizuku avec votre appareil</string>
+    <string name="adb_pairing_tutorial_content_notification">Une notification de Shizuku™ vous aidera à compléter l\'association.</string>
+    <string name="adb_pairing_tutorial_title">Associer Shizuku™ avec votre appareil</string>
     <string name="notification_settings">Options des notifications</string>
     <string name="development_settings">Options pour les développeurs</string>
     <string name="adb_pair_required">Merci d\'aller à l\'étape d\'association d\'abord.</string>
@@ -99,11 +99,11 @@
     <string name="dialog_adb_pairing_paring_code">Code d\'association</string>
     <string name="dialog_adb_invalid_port">Le port est un entier compris entre 1 et 65535.</string>
     <string name="dialog_adb_port">Port</string>
-    <string name="dialog_adb_discovery_message">Merci d\'activer \"Débogage sans fil\" dans les \"Options pour les développeurs\". Le paramètre \"Débogage sans fil\" est automatiquement désactivé quand la connexion réseau change.\n\nNote, ne pas désactiver les \"Options pour les développeurs\" ou le \"Débogage USB\", ou Shizuku sera arrêté.</string>
+    <string name="dialog_adb_discovery_message">Merci d\'activer \"Débogage sans fil\" dans les \"Options pour les développeurs\". Le paramètre \"Débogage sans fil\" est automatiquement désactivé quand la connexion réseau change.\n\nNote, ne pas désactiver les \"Options pour les développeurs\" ou le \"Débogage USB\", ou Shizuku™ sera arrêté.</string>
     <string name="dialog_adb_discovery">Recherche du service de débogage sans fil</string>
     <string name="home_wireless_adb_view_guide_button">Guide étape par étape</string>
     <string name="home_wireless_adb_description_pre_11">Avant Android 11, la connection à un ordinateur est requise pour activer le débogage sans fil.</string>
-    <string name="home_wireless_adb_description">Sur Android 11 ou supérieur, vous pouvez activer le débogage sans fil et démarrer Shizuku directement depuis votre appareil, sans le connecter à un ordinateur.&lt;p&gt;Merci de lire le guide étape par étape d\'abord.</string>
+    <string name="home_wireless_adb_description">Sur Android 11 ou supérieur, vous pouvez activer le débogage sans fil et démarrer Shizuku™ directement depuis votre appareil, sans le connecter à un ordinateur.&lt;p&gt;Merci de lire le guide étape par étape d\'abord.</string>
     <string name="home_wireless_adb_title">Démarrer par débogage sans fil</string>
     <string name="home_adb_dialog_view_command_button_send">Envoyer</string>
     <string name="home_adb_dialog_view_command_copy_button">Copier</string>
@@ -116,16 +116,16 @@
     <string name="home_status_service_version_update">Version %2$s, %1$s&lt;br&gt;Relancez pour mettre à jour vers la version %3$s</string>
     <string name="home_adb_title">Démarrer par connection à un ordinateur</string>
     <string name="adb_pairing_tutorial_content_miui_2">Sinon, vous ne pourrez peut-être pas saisir le code d\'association depuis la notification.</string>
-    <string name="adb_pairing_tutorial_content_network">Shizuku requiert l\'accès au réseau local. C\'est contrôlé par l\'autorisation réseau.</string>
-    <string name="adb_pairing_tutorial_content_network_limation_not_foreground">Certains systèmes (tels que MIUI) interdisent aux applis d\'accéder au réseau quand elles ne sont pas visibles, même si l\'appli utilise un service de premier plan comme standard. Merci de désactiver l\'optimisation de la batterie pour Shizuku sur de tels systèmes.</string>
+    <string name="adb_pairing_tutorial_content_network">Shizuku™ requiert l\'accès au réseau local. C\'est contrôlé par l\'autorisation réseau.</string>
+    <string name="adb_pairing_tutorial_content_network_limation_not_foreground">Certains systèmes (tels que MIUI) interdisent aux applis d\'accéder au réseau quand elles ne sont pas visibles, même si l\'appli utilise un service de premier plan comme standard. Merci de désactiver l\'optimisation de la batterie pour Shizuku™ sur de tels systèmes.</string>
     <string name="settings_use_system_color">Utiliser la couleur du thème système</string>
     <string name="adb_pairing_tutorial_content_left_is_clickable">Veuillez noter que la partie gauche de l\'option \"Débogage sans fil\" est clickable, la tapper va ouvrir une nouvelle page. Seulement activer le commutateur à droite est incorrect.</string>
-    <string name="home_adb_is_limited_description">Le fabricant de votre appareil a restreint les permissions adb et les applis utilisant Shizuku ne fonctionneront pas bien.
+    <string name="home_adb_is_limited_description">Le fabricant de votre appareil a restreint les permissions adb et les applis utilisant Shizuku™ ne fonctionneront pas bien.
 \n
 \nGénéralement, cette limitation peut être levée en ajustant certaines options dans les \"Options développeur\". Merci de lire l\'aide pour des détails sur la façon de procéder.
 \n
-\nVous devrez sûrement redémarrer Shizuku pour que l\'opération prenne effet.</string>
+\nVous devrez sûrement redémarrer Shizuku™ pour que l\'opération prenne effet.</string>
     <string name="home_adb_is_limited_title">Une étape supplémentaire est nécessaire</string>
-    <string name="home_app_management_empty">Les applications qui ont demandé ou déclaré l\'accès à Shizuku apparaîtront ici.</string>
+    <string name="home_app_management_empty">Les applications qui ont demandé ou déclaré l\'accès à Shizuku™ apparaîtront ici.</string>
     <string name="dialog_adb_discovery_message_toggle_wireless_debugging">Merci d\'essayer de désactiver et de réactiver le \"Débogage sans-fil\" si ça continue à chercher.</string>
 </resources>

--- a/manager/src/main/res/values-he/strings.xml
+++ b/manager/src/main/res/values-he/strings.xml
@@ -2,7 +2,7 @@
 <resources>
     <string name="home_adb_button_view_command">הצג פקודה</string>
     <string name="home_adb_button_view_help">קראו את דפי העזרה</string>
-    <string name="home_adb_description">עבור מכשירים ללא גישת שורש, עליך להשתמש ב-adb כדי להתחיל את Shizuku (נדרש חיבור למחשב). \u0020עליך לחזור על תהליך זה בכל פעם שמכשירך יופעל מחדש. בבקשה <b> <a href="%1$s">קראו את דפי העזרה</a></b>.</string>
+    <string name="home_adb_description">עבור מכשירים ללא גישת שורש, עליך להשתמש ב-adb כדי להתחיל את Shizuku™ (נדרש חיבור למחשב). \u0020עליך לחזור על תהליך זה בכל פעם שמכשירך יופעל מחדש. בבקשה <b> <a href="%1$s">קראו את דפי העזרה</a></b>.</string>
     <string name="home_adb_title">התחל באמצעות חיבור למחשב</string>
     <string name="home_status_service_version_update">גירסה %2$s, %1$s&lt;br&gt;התחל מחדש כדי לעדכן לגירסה %3$s</string>
     <string name="home_status_service_version">גירסה %2$s, %1$s</string>
@@ -11,6 +11,6 @@
     <string name="home_adb_dialog_view_command_message">&lt;font face=monospace&gt;%1$s&lt;/font&gt;&lt;br&gt;&lt;br&gt;* יש עדין שיקולים אחרים, בבקשה תאשר שקראת את העזרה לפני.</string>
     <string name="home_adb_dialog_view_command_button_send">שלח</string>
     <string name="home_adb_dialog_view_command_copy_button">העתק</string>
-    <string name="home_wireless_adb_description">באנדרואיד 11 ומעלה, אתם יכולים להפעיל ניפוי באגים אלחוטי ולהתחיל את Shizuku ישירות מהמכשיר שלכם, ללא חיבור למחשב. קודם כל, הביטו בבקשה במדריך.</string>
+    <string name="home_wireless_adb_description">באנדרואיד 11 ומעלה, אתם יכולים להפעיל ניפוי באגים אלחוטי ולהתחיל את Shizuku™ ישירות מהמכשיר שלכם, ללא חיבור למחשב. קודם כל, הביטו בבקשה במדריך.</string>
     <string name="home_wireless_adb_title">התחל עם ניפוי באגים אלחוטי</string>
 </resources>

--- a/manager/src/main/res/values-hu/strings.xml
+++ b/manager/src/main/res/values-hu/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name" translatable="false">Shizuku HU</string>
+    <string name="app_name" translatable="false">Shizuku™ HU</string>
     <!-- To translators: you can leave your here -->
     <string name="translation_contributors">gidano - sympda.blog.hu</string>
     <!-- Home - Status -->
@@ -10,7 +10,7 @@
     <string name="home_status_service_version_update"><![CDATA[Verzió %2$s, %1$s<br>Kezdje újra a %3$s verzióra való frissítéshez]]></string>
     <!-- Home - Adb -->
     <string name="home_adb_title"><![CDATA[Kezdje a számítógéphez való csatlakozással]]></string>
-    <string name="home_adb_description"><![CDATA[Root nélküli eszközök esetén az adb-t kell használnia a Shizuku elindításához (számítógépes kapcsolat szükséges). Ezt a folyamatot minden alkalommal meg kell ismételni az eszköz újraindításakor. Kérem <b><a href=\"%1$s\">olvassa el a súgót</a></b>.]]></string>
+    <string name="home_adb_description"><![CDATA[Root nélküli eszközök esetén az adb-t kell használnia a Shizuku™ elindításához (számítógépes kapcsolat szükséges). Ezt a folyamatot minden alkalommal meg kell ismételni az eszköz újraindításakor. Kérem <b><a href=\"%1$s\">olvassa el a súgót</a></b>.]]></string>
     <string name="home_adb_button_view_help">Olvassa el a súgót</string>
     <string name="home_adb_button_view_command">Parancs megtekintés</string>
     <string name="home_adb_dialog_view_command_message">&lt;font face=monospace&gt;%1$s&lt;/font&gt;&lt;br&gt;&lt;br&gt;* Vannak más szempontok is, kérjük erősítse meg, hogy először elolvasta a súgót.</string>
@@ -18,12 +18,12 @@
     <string name="home_adb_dialog_view_command_button_send">Küldés</string>
     <!-- Home - Wireless Adb -->
     <string name="home_wireless_adb_title"><![CDATA[Kezdje a vezeték nélküli hibakereséssel]]></string>
-    <string name="home_wireless_adb_description"><![CDATA[Android 11 vagy újabb rendszeren engedélyezheti a vezeték nélküli hibakeresést, és közvetlenül az eszközéről indíthatja el a Shizukut, anélkül, hogy számítógéphez csatlakozna..<p>Először tekintse meg a lépésről lépésre szóló útmutatót.]]></string>
+    <string name="home_wireless_adb_description"><![CDATA[Android 11 vagy újabb rendszeren engedélyezheti a vezeték nélküli hibakeresést, és közvetlenül az eszközéről indíthatja el a Shizuku™t, anélkül, hogy számítógéphez csatlakozna..<p>Először tekintse meg a lépésről lépésre szóló útmutatót.]]></string>
     <string name="home_wireless_adb_description_pre_11"><![CDATA[Az Android 11 előtt a vezeték nélküli hibakeresés engedélyezéséhez csatlakozni kell egy számítógéphez.]]></string>
     <string name="home_wireless_adb_view_guide_button">Lépésről-lépésre útmutató</string>
     <!-- Adb -->
     <string name="dialog_adb_discovery">Vezeték nélküli hibakereső szolgáltatás keresése</string>
-    <string name="dialog_adb_discovery_message">Engedélyezze a \"Vezeték nélküli hibakeresés\"t a \"Fejlesztői lehetőségek\"nél. A \"Vezeték nélküli hibakeresés\" hálózatváltáskor auto. le van tiltva.\n\nMegj.: ne tiltsa le a \"Fejlesztői lehetőségek\"et vagy az \"USB hibakeresés\"t, ekkor a Shizuku le fog állni.</string>
+    <string name="dialog_adb_discovery_message">Engedélyezze a \"Vezeték nélküli hibakeresés\"t a \"Fejlesztői lehetőségek\"nél. A \"Vezeték nélküli hibakeresés\" hálózatváltáskor auto. le van tiltva.\n\nMegj.: ne tiltsa le a \"Fejlesztői lehetőségek\"et vagy az \"USB hibakeresés\"t, ekkor a Shizuku™ le fog állni.</string>
     <string name="dialog_adb_port">Port</string>
     <string name="dialog_adb_invalid_port">A port egy 1 és 65535 közötti egész szám.</string>
     <string name="adb_pairing">Párosítás</string>
@@ -40,21 +40,21 @@
     <string name="adb_pair_required">Kérjük először végezze el a párosítási lépést.</string>
     <string name="development_settings">Fejlesztői lehetőségek</string>
     <string name="notification_settings">Értesítési lehetőségek</string>
-    <string name="adb_pairing_tutorial_title">Párosítsa a Shizukut készülékével</string>
-    <string name="adb_pairing_tutorial_content_notification">A Shizuku értesítése segít a párosítás befejezésében.</string>
+    <string name="adb_pairing_tutorial_title">Párosítsa a Shizuku™t készülékével</string>
+    <string name="adb_pairing_tutorial_content_notification">A Shizuku™ értesítése segít a párosítás befejezésében.</string>
     <string name="adb_pairing_tutorial_content_steps">Lépjen a \"Fejlesztői lehetőségek\" - \"Vezeték nélküli hibakeresés\" menüpontra. Koppintson az \"Eszköz párosítása párosítási kóddal\" lehetőségre, és megjelenik egy hatjegyű kód.</string>
     <string name="adb_pairing_tutorial_content_enter_pairing_code">A párosítás befejezéséhez írja be az értesítésben lévő kódot.</string>
-    <string name="adb_pairing_tutorial_content_notification_blocked">A párosítási folyamat során kapcsolatba kell lépni Shizuku értesítésével. Kérjük, engedélyezze a Shizukunak, hogy értesítéseket tegyen közzé.</string>
+    <string name="adb_pairing_tutorial_content_notification_blocked">A párosítási folyamat során kapcsolatba kell lépni Shizuku™ értesítésével. Kérjük, engedélyezze a Shizuku™nak, hogy értesítéseket tegyen közzé.</string>
     <string name="adb_pairing_tutorial_content_miui">Előfordulhat, hogy a MIUI-felhasználóknak át kell váltaniuk az értesítési stílust \"Android\"-ra a \"Értesítés\" - \"Értesítési árnyék\" lehetőségről a rendszerbeállításokban.</string>
     <string name="adb_pairing_tutorial_content_miui_2">Ellenkező esetben előfordulhat, hogy nem tudja megadni a párosítási kódot az értesítésből.</string>
     <string name="adb_pairing_tutorial_content_left_is_clickable">Felhívjuk figyelmét, hogy a \"Vezeték nélküli hibakeresés\" opció bal oldali része kattintható, rákattintva egy új oldal nyílik meg. A jobb oldali kapcsoló bekapcsolása helytelen.</string>
-    <string name="adb_pairing_tutorial_content_finish">Vissza és Shizuku elindítása.</string>
-    <string name="adb_pairing_tutorial_content_network">A Shizukunak hozzá kell férnie a helyi hálózathoz. A hálózati engedély vezérli.</string>
-    <string name="adb_pairing_tutorial_content_network_limation_not_foreground">Egyes rendszerek (például a MIUI) nem engedélyezik az alkalmazások számára, hogy hozzáférjenek a hálózathoz ha nem láthatók, még akkor sem, ha az alkalmazás alapértelmezés szerint előtérbeli szolgáltatást használ. Kapcsolja ki a Shizuku akku optimalizálási funkcióit az ilyen rendszereken.</string>
+    <string name="adb_pairing_tutorial_content_finish">Vissza és Shizuku™ elindítása.</string>
+    <string name="adb_pairing_tutorial_content_network">A Shizuku™nak hozzá kell férnie a helyi hálózathoz. A hálózati engedély vezérli.</string>
+    <string name="adb_pairing_tutorial_content_network_limation_not_foreground">Egyes rendszerek (például a MIUI) nem engedélyezik az alkalmazások számára, hogy hozzáférjenek a hálózathoz ha nem láthatók, még akkor sem, ha az alkalmazás alapértelmezés szerint előtérbeli szolgáltatást használ. Kapcsolja ki a Shizuku™ akku optimalizálási funkcióit az ilyen rendszereken.</string>
     <!-- Home - Root -->
     <string name="home_root_title">Indítás (rootolt eszközökhöz)</string>
-    <string name="home_root_description"><![CDATA[Ezenkívül a Shizuku automatikusan elindítható rendszerindításkor. Ha nem, ellenőrizze, hogy rendszere vagy harmadik féltől származó eszközei nem korlátozták-e a Shizukut.<br>A következőre hivatkozhat: %s.]]></string>
-    <string name="home_root_description_sui"><![CDATA[Ha Magisk-et használ, megpróbálhatja a %1$s-t. A root felhasználók számára végül felváltja a Shizukut. Megj.: a meglévő alkalmazásokat kissé módosítani kell a %2$s használatához.]]></string>
+    <string name="home_root_description"><![CDATA[Ezenkívül a Shizuku™ automatikusan elindítható rendszerindításkor. Ha nem, ellenőrizze, hogy rendszere vagy harmadik féltől származó eszközei nem korlátozták-e a Shizuku™t.<br>A következőre hivatkozhat: %s.]]></string>
+    <string name="home_root_description_sui"><![CDATA[Ha Magisk-et használ, megpróbálhatja a %1$s-t. A root felhasználók számára végül felváltja a Shizuku™t. Megj.: a meglévő alkalmazásokat kissé módosítani kell a %2$s használatához.]]></string>
     <string name="home_root_button_start">Indítás</string>
     <string name="home_root_button_restart">Újraindítás</string>
     <!-- Home - Application management -->
@@ -64,29 +64,29 @@
         <item quantity="other"><![CDATA[%d app engedélyezett]]></item>
     </plurals>
     <string name="home_app_management_view_authorized_apps"><![CDATA[Érintse meg az engedélyezett alkalmazások kezeléséhez]]></string>
-    <string name="home_app_management_empty">Itt jelennek meg azok az alkalmazások, amelyek Shizukut kértek vagy bejelentettek.</string>
+    <string name="home_app_management_empty">Itt jelennek meg azok az alkalmazások, amelyek Shizuku™t kértek vagy bejelentettek.</string>
     <!-- Home - Learn more -->
-    <string name="home_learn_more_title">Tanulja a Shizukut</string>
-    <string name="home_learn_more_description">Tanuljon meg fejlődni a Shizukuval</string>
+    <string name="home_learn_more_title">Tanulja a Shizuku™t</string>
+    <string name="home_learn_more_description">Tanuljon meg fejlődni a Shizuku™val</string>
     <!-- Home - Adb permissions limited -->
     <string name="home_adb_is_limited_title">Egy plusz lépést kell tennie</string>
-    <string name="home_adb_is_limited_description">Az eszköz gyártója korlátozta az adb-engedélyeket, és a Shizuku-t használó alkalmazások nem működnek megfelelően.\n\nÁltalában ez a korlátozás bizonyos beállítások módosításával feloldható a \"Fejlesztői lehetőségek\"-nél. Kérjük, olvassa el a súgót ennek részleteiért.\n\nLehet, hogy újra kell indítania a Shizukut, hogy a művelet érvénybe lépjen.</string>
+    <string name="home_adb_is_limited_description">Az eszköz gyártója korlátozta az adb-engedélyeket, és a Shizuku™-t használó alkalmazások nem működnek megfelelően.\n\nÁltalában ez a korlátozás bizonyos beállítások módosításával feloldható a \"Fejlesztői lehetőségek\"-nél. Kérjük, olvassa el a súgót ennek részleteiért.\n\nLehet, hogy újra kell indítania a Shizuku™t, hogy a művelet érvénybe lépjen.</string>
     <!-- Application management -->
     <string name="app_management_dialog_adb_is_limited_title">Az adb engedélye korlátozott</string>
     <string name="app_management_dialog_adb_is_limited_message"><![CDATA[Nagyon valószínű, hogy az eszköz gyártója korlátozza az adb engedélyét.<p>Lehet, hogy van megoldás a rendszeréhez ebben a <b><a href=\"%1$s\">dokumentumban</a></b>.]]></string>
-    <string name="app_management_item_summary_requires_root">* szükséges, hogy a Shizuku root-on fusson</string>
+    <string name="app_management_item_summary_requires_root">* szükséges, hogy a Shizuku™ root-on fusson</string>
     <!-- Terminal -->
-    <string name="home_terminal_title">Használja a Shizukut a terminál appokban</string>
-    <string name="home_terminal_description">Futtasson parancsokat a Shizuku-n keresztül a kívánt terminálalkalmazásokban</string>
+    <string name="home_terminal_title">Használja a Shizuku™t a terminál appokban</string>
+    <string name="home_terminal_description">Futtasson parancsokat a Shizuku™-n keresztül a kívánt terminálalkalmazásokban</string>
     <string name="terminal_tutorial_1">Először is exportálja a fájlokat a kívánt helyre. Két fájlt fog találni, %1$s és %2$s.</string>
-    <string name="terminal_tutorial_1_description">Ha a kiválasztott mappában vannak azonos nevű fájlok, akkor azok törlődnek.\n\nAz export funkció SAF-et használ (Storage Access Framework). A jelentések szerint a MIUI megszakítja a SAF funkcióit. Ha MIUI-t használ, előfordulhat, hogy ki kell csomagolnia a fájlt a Shizuku apk-jából, vagy le kell töltenie a GitHubról.</string>
+    <string name="terminal_tutorial_1_description">Ha a kiválasztott mappában vannak azonos nevű fájlok, akkor azok törlődnek.\n\nAz export funkció SAF-et használ (Storage Access Framework). A jelentések szerint a MIUI megszakítja a SAF funkcióit. Ha MIUI-t használ, előfordulhat, hogy ki kell csomagolnia a fájlt a Shizuku™ apk-jából, vagy le kell töltenie a GitHubról.</string>
     <string name="terminal_export_files">Fájlok exportálása</string>
     <string name="terminal_tutorial_2">Ezután bármelyik szövegszerkesztővel nyissa meg és szerkessze a %1$s fájlt.</string>
-    <string name="terminal_tutorial_2_description">Ha például a Shizukut szeretné használni a %1$s alkalmazásban, cserélje ki a %2$s kifejezést a következőre: %3$s (%4$s a csomag neve ennek: %1$s).</string>
-    <string name="terminal_tutorial_3">Végül helyezze át a fájlokat valahova, ahol a terminálalkalmazása hozzáférhet, így a %1$s segítségével parancsokat futtathat a Shizuku-n keresztül..</string>
+    <string name="terminal_tutorial_2_description">Ha például a Shizuku™t szeretné használni a %1$s alkalmazásban, cserélje ki a %2$s kifejezést a következőre: %3$s (%4$s a csomag neve ennek: %1$s).</string>
+    <string name="terminal_tutorial_3">Végül helyezze át a fájlokat valahova, ahol a terminálalkalmazása hozzáférhet, így a %1$s segítségével parancsokat futtathat a Shizuku™-n keresztül..</string>
     <string name="terminal_tutorial_3_description">Néhány tipp: adjon végrehajtási engedélyt a következőnek: %1$s, és adja hozzá a következőhöz: %2$s, így közvetlenül használhatja a %1$s-t.</string>
     <string name="rish_description"><![CDATA[
-A %1$s segítségével bármely terminálalkalmazásban csatlakozhat a Shizuku által futtatott shellhez, és kommunikálhat vele.
+A %1$s segítségével bármely terminálalkalmazásban csatlakozhat a Shizuku™ által futtatott shellhez, és kommunikálhat vele.
 <p>A %1$s részletes használatáról, érintse a dokumentum megtekintéséhez.
     ]]></string>
     <!-- Settings -->
@@ -100,18 +100,18 @@ A %1$s segítségével bármely terminálalkalmazásban csatlakozhat a Shizuku �
     <string name="settings_translation">Vegyen részt a fordításban</string>
     <string name="settings_translation_summary">Segítsen nekünk lefordítani a %s-t az Ön nyelvére</string>
     <string name="settings_start_on_boot">Induljon rendszerindításkor (root)</string>
-    <string name="settings_start_on_boot_summary">Rootolt eszközök esetén a Shizuku képes auto. elindulni rendszerindításkor</string>
+    <string name="settings_start_on_boot_summary">Rootolt eszközök esetén a Shizuku™ képes auto. elindulni rendszerindításkor</string>
     <string name="settings_use_system_color">Használja a rendszertéma színét</string>
     <!-- About -->
     <string name="action_about">Rólunk</string>
     <string name="about_view_source_code"><![CDATA[Forráskód megtekintése itt: %s]]></string>
     <!-- Stop -->
-    <string name="action_stop">A Shizuku leállítása</string>
-    <string name="dialog_stop_message">A Shizuku szolgáltatás leáll.</string>
+    <string name="action_stop">A Shizuku™ leállítása</string>
+    <string name="dialog_stop_message">A Shizuku™ szolgáltatás leáll.</string>
     <!-- Notification -->
     <string name="notification_channel_service_status">Szolgáltatásindítási állapot</string>
-    <string name="notification_service_starting">A Shizuku szolgáltatás indul…</string>
-    <string name="notification_service_start_failed">A Shizuku szolgáltatás indítása nem sikerült.</string>
+    <string name="notification_service_starting">A Shizuku™ szolgáltatás indul…</string>
+    <string name="notification_service_start_failed">A Shizuku™ szolgáltatás indítása nem sikerült.</string>
     <string name="notification_service_start_no_root">Nem sikerült root engedélyt kérni.</string>
     <string name="notification_working">Dolgozom…</string>
     <string name="notification_channel_adb_pairing">Vezeték nélküli hibakeresés pairing</string>
@@ -121,14 +121,14 @@ A %1$s segítségével bármely terminálalkalmazásban csatlakozhat a Shizuku �
     <string name="notification_adb_pairing_stop_searching">A keresés leállítása</string>
     <string name="notification_adb_pairing_working_title">A párosítás folyamatban</string>
     <string name="notification_adb_pairing_succeed_title">A párosítás sikeres</string>
-    <string name="notification_adb_pairing_succeed_text">Most elindíthatja a Shizuku szolgáltatást.</string>
+    <string name="notification_adb_pairing_succeed_text">Most elindíthatja a Shizuku™ szolgáltatást.</string>
     <string name="notification_adb_pairing_failed_title">A párosítás nem sikerült</string>
     <string name="notification_adb_pairing_retry">Újra</string>
     <!-- Permission related, appears in system permission UI -->
-    <string name="permission_group_label" translatable="false">Shizuku</string>
+    <string name="permission_group_label" translatable="false">Shizuku™</string>
     <string name="permission_group_description" translatable="false">@string/permission_label</string>
-    <string name="permission_label">Shizuku hozzáférés</string>
-    <string name="permission_description">Engedélyezze az app számára a Shizuku használatát.</string>
+    <string name="permission_label">Shizuku™ hozzáférés</string>
+    <string name="permission_description">Engedélyezze az app számára a Shizuku™ használatát.</string>
     <string name="permission_warning_template"><![CDATA[Engedélyezi <b>%1$s</b> ide, %2$s?]]></string>
     <string name="grant_dialog_button_allow_always">Mindig engedje meg</string>
     <string name="grant_dialog_button_deny">"Megtagad"</string>
@@ -141,10 +141,10 @@ A %1$s segítségével bármely terminálalkalmazásban csatlakozhat a Shizuku �
     <string name="toast_copied_to_clipboard">%s\n a vágólapra másolva.</string>
     <string name="toast_copied_to_clipboard_with_text"><![CDATA[<b>%s</b> a vágólapra másolva.]]></string>
     <!-- Messages for legacy -->
-    <string name="dialog_legacy_not_support_title">%1$s nem támogatja a modern Shizukut</string>
-    <string name="dialog_legacy_not_support_message"><![CDATA[Az örökölt Shizuku 2019 márciusa óta elavult. Ezenkívül a régi Shizuku nem működik újabb Android-rendszereken.<p>Kérdezze meg a fejlesztőt <b>%1$s</b> frissítéséről.]]></string>
-    <string name="dialog_requesting_legacy_title">%1$s az örökölt Shizukut kéri</string>
-    <string name="dialog_requesting_legacy_message"><![CDATA[<b>%1$s</b> modern Shizuku támogatással rendelkezik, de az örökölt Shizukut kéri. Ez azért lehet, mert a Shizuku nem fut, ellenőrizze a Shizuku alkalmazást.<p>Az örökölt Shizuku 2019 márciusa óta elavult.]]></string>
-    <string name="dialog_requesting_legacy_button_open_shizuku">Nyissa meg a Shizukut</string>
+    <string name="dialog_legacy_not_support_title">%1$s nem támogatja a modern Shizuku™t</string>
+    <string name="dialog_legacy_not_support_message"><![CDATA[Az örökölt Shizuku™ 2019 márciusa óta elavult. Ezenkívül a régi Shizuku™ nem működik újabb Android-rendszereken.<p>Kérdezze meg a fejlesztőt <b>%1$s</b> frissítéséről.]]></string>
+    <string name="dialog_requesting_legacy_title">%1$s az örökölt Shizuku™t kéri</string>
+    <string name="dialog_requesting_legacy_message"><![CDATA[<b>%1$s</b> modern Shizuku™ támogatással rendelkezik, de az örökölt Shizuku™t kéri. Ez azért lehet, mert a Shizuku™ nem fut, ellenőrizze a Shizuku™ alkalmazást.<p>Az örökölt Shizuku™ 2019 márciusa óta elavult.]]></string>
+    <string name="dialog_requesting_legacy_button_open_shizuku">Nyissa meg a Shizuku™t</string>
     <string name="dialog_adb_discovery_message_toggle_wireless_debugging">Próbálja kikapcsolni majd engedélyezni a \"Vezeték nélküli hibakeresés\" opciót, ha továbbra is keres.</string>
 </resources>

--- a/manager/src/main/res/values-hy/strings.xml
+++ b/manager/src/main/res/values-hy/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="dialog_legacy_not_support_title">%1$s-ը չի ընդունում այժմյան Shizuku-ն</string>
+    <string name="dialog_legacy_not_support_title">%1$s-ը չի ընդունում այժմյան Shizuku™-ն</string>
     <string name="toast_copied_to_clipboard_with_text">&lt;b&gt;%s&lt;/b&gt;-ն պատճենվել է կցատարում։</string>
     <string name="toast_copied_to_clipboard">%s-ն
 \nպատճենվել է կցատարում։</string>
@@ -8,18 +8,18 @@
     <string name="start_with_root_failed">Չհաջողվեց բեռնել ծառայությունը քանի որ root թույլտվությունը մերժված է կամ սարքը root չունի։</string>
     <string name="starter">Սկսնակ</string>
     <string name="permission_description">Թողնել ծրագրին օգտվել ավելի բարձր արտոնություններով համակարգային API-ներից։</string>
-    <string name="permission_label">օգտվել Shizuku-ից</string>
-    <string name="permission_group_description">օգտվել Shizuku-ից</string>
+    <string name="permission_label">օգտվել Shizuku™-ից</string>
+    <string name="permission_group_description">օգտվել Shizuku™-ից</string>
     <string name="notification_working">Աշխատում է…</string>
     <string name="notification_service_start_no_root">Չհաջողվեց ստանալ root թույլտվություն։</string>
-    <string name="notification_service_start_failed">Shizuku-ի միացումը ձախողվեց։</string>
-    <string name="notification_service_starting">Shizuku-ի ծառայությունը միանում է…</string>
+    <string name="notification_service_start_failed">Shizuku™-ի միացումը ձախողվեց։</string>
+    <string name="notification_service_starting">Shizuku™-ի ծառայությունը միանում է…</string>
     <string name="notification_channel_service_status">Ծառայության վիճակ</string>
-    <string name="action_stop">Անջատել Shizuku-ն</string>
-    <string name="dialog_stop_message">Shizuku-ի ծառայությունը կանջատվի։</string>
+    <string name="action_stop">Անջատել Shizuku™-ն</string>
+    <string name="dialog_stop_message">Shizuku™-ի ծառայությունը կանջատվի։</string>
     <string name="about_view_source_code">Տեսնել կոդի աղբյուրը %s-ում</string>
     <string name="action_about">Ծրագրի մասին</string>
-    <string name="settings_start_on_boot_summary">Root թույլտվություն ունեցող սարքերում Shizuku-ն ավտոմատացված ձևով կարող է միանալ սարքի հետ</string>
+    <string name="settings_start_on_boot_summary">Root թույլտվություն ունեցող սարքերում Shizuku™-ն ավտոմատացված ձևով կարող է միանալ սարքի հետ</string>
     <string name="settings_start_on_boot">Միանալ սարքի հետ (root-ով)</string>
     <string name="settings_translation_summary">Օգնեք մեզ թարգմանել %s-ը Ձեր լեզվով</string>
     <string name="settings_translation">Մասնակցել թարգմանության մեջ</string>
@@ -30,11 +30,11 @@
     <string name="settings_user_interface">Տեսք</string>
     <string name="settings_language">Լեզու</string>
     <string name="settings_title">Կարգավորումներ</string>
-    <string name="app_management_item_summary_requires_root">* Shizuku-ն root թույլտվություն պետք է ունենա</string>
+    <string name="app_management_item_summary_requires_root">* Shizuku™-ն root թույլտվություն պետք է ունենա</string>
     <string name="app_management_dialog_adb_is_limited_message">Շատ հնարավոր է, որ Ձեր սարքի արտադրողը սահմանափակել է adb-ի թույլտվությունները։ &lt;p&gt;Հնարավոր լուծումները գտեք &lt;b&gt;&lt;a href=\"%1$s\"&gt;այստեղ&lt;/a&gt;&lt;/b&gt;։</string>
     <string name="app_management_dialog_adb_is_limited_title">Adb-ի թույլտվությունները սահմանափակված են</string>
-    <string name="home_learn_more_description">Սովորեք ծրագրավորել Shizuku-ով կամ Shizuku-ն ուրիշ ծրագրերի հետ օգտագործել</string>
-    <string name="home_learn_more_title">Սովորել Shizuku</string>
+    <string name="home_learn_more_description">Սովորեք ծրագրավորել Shizuku™-ով կամ Shizuku™-ն ուրիշ ծրագրերի հետ օգտագործել</string>
+    <string name="home_learn_more_title">Սովորել Shizuku™</string>
     <string name="home_app_management_view_authorized_apps">Սեղմեք, որպեսզի վավերացված ծրագրերը տիրապետելու համար</string>
     <plurals name="home_app_management_authorized_apps_count">
         <item quantity="one">Վավերացված է %d ծրագիր</item>
@@ -65,7 +65,7 @@
     <string name="dialog_adb_port">Պոռտ</string>
     <string name="dialog_adb_discovery_message">Խնդրում ենք միացնել «Անլար կարգաբերում»-ը «Ծրագրավորողի կարգավորումներ»-ի մեջ։ «Անլար կարգաբերում»-ը ավտոմատացված ձևով անջատվում է ցանցի փոփոխման ժամանակ։
 \n
-\nՉանջատեք «Ծրագրավորողի կարգավորումներ»-ը կամ «USB-ով կարգաբերում»-ը, թե չէ Shizuku-ն կանջատվի։</string>
+\nՉանջատեք «Ծրագրավորողի կարգավորումներ»-ը կամ «USB-ով կարգաբերում»-ը, թե չէ Shizuku™-ն կանջատվի։</string>
     <string name="dialog_adb_discovery">Որոնվում է անլար կարգաբերման ծառայությունը</string>
     <string name="home_wireless_adb_title">Միացնել Անլար կարգաբերման օգնությամբ</string>
     <string name="home_adb_dialog_view_command_button_send">Ուղարկել</string>
@@ -73,17 +73,17 @@
     <string name="home_adb_dialog_view_command_message">&lt;font face=monospace&gt;%1$s&lt;/font&gt;&lt;br&gt;&lt;br&gt;* Գոյություն ունեն ուրիշ դիտողություններ։ Սկզբում հաստատեք, որ կարդացել եք օգնությունը։</string>
     <string name="home_adb_button_view_command">Տեսնել հրահանգը</string>
     <string name="home_adb_button_view_help">Կարդալ օգնությունը</string>
-    <string name="home_adb_description">Առանց «root» թույլտվություն ունեցող սարքերի օգտատերերը պետք է օգտագործեն adb, որպեսզի միացնեն Shizuku-ն (անհրաժեշտ է համակարգչային կապ)։ Այս գործողությունը պետք է կրկնել ամեն անգամ սարքի վերաբեռնելուց հետո։ Խնդրում ենք &lt;b&gt;&lt;a href=\"%1$s\"&gt;կարդալ օգնությունը&lt;/a&gt;&lt;/b&gt;։</string>
+    <string name="home_adb_description">Առանց «root» թույլտվություն ունեցող սարքերի օգտատերերը պետք է օգտագործեն adb, որպեսզի միացնեն Shizuku™-ն (անհրաժեշտ է համակարգչային կապ)։ Այս գործողությունը պետք է կրկնել ամեն անգամ սարքի վերաբեռնելուց հետո։ Խնդրում ենք &lt;b&gt;&lt;a href=\"%1$s\"&gt;կարդալ օգնությունը&lt;/a&gt;&lt;/b&gt;։</string>
     <string name="home_adb_title">Միացնել համակարգչի օգնությամբ</string>
     <string name="home_status_service_version_update">Փոփոխակ %2$s, %1$s&lt;br&gt;Միացրեք կրկին որպեսզի թարմացնեք դեպի %3$s փոփոխակ</string>
     <string name="home_status_service_version">Փոփոխակ %2$s, %1$s</string>
     <string name="home_status_service_not_running">%1$s-ը միացված չէ</string>
     <string name="home_status_service_is_running">%1$s-ը միացված է</string>
     <string name="translation_contributors">Tigran Khachatryan</string>
-    <string name="dialog_requesting_legacy_title">%1$s-ն առաջարկում է օգտվել հին Shizuku-ից</string>
-    <string name="dialog_legacy_not_support_message">Հին Shizuku-ն համարվում է հնացած 2019-ի մարտից։ Հին Shizuku-ն չի աշխատում նոր Android-ի փոփոխակներում։&lt;p&gt;Դիմեք &lt;b&gt;%1$s&lt;/b&gt;-ի ծրագրավորողին և ասեք, որ ծրագիրը թարմացնի։</string>
-    <string name="dialog_requesting_legacy_button_open_shizuku">Բացել Shizuku-ն</string>
-    <string name="dialog_requesting_legacy_message">&lt;b&gt;%1$s&lt;/b&gt;-ն օժտված է նոր Shizuku-ից օգտվելու հատկությունից, բայց այն փորձում է օգտվել հին Shizuku-ից։ Հնարավոր է, որ Shizuku-ն միացված չէ, ստուգեք Shizuku ծրագիրը։&lt;p&gt;Հին Shizuku-ն համարվում է հնացած 2019-ի մարտից։</string>
+    <string name="dialog_requesting_legacy_title">%1$s-ն առաջարկում է օգտվել հին Shizuku™-ից</string>
+    <string name="dialog_legacy_not_support_message">Հին Shizuku™-ն համարվում է հնացած 2019-ի մարտից։ Հին Shizuku™-ն չի աշխատում նոր Android-ի փոփոխակներում։&lt;p&gt;Դիմեք &lt;b&gt;%1$s&lt;/b&gt;-ի ծրագրավորողին և ասեք, որ ծրագիրը թարմացնի։</string>
+    <string name="dialog_requesting_legacy_button_open_shizuku">Բացել Shizuku™-ն</string>
+    <string name="dialog_requesting_legacy_message">&lt;b&gt;%1$s&lt;/b&gt;-ն օժտված է նոր Shizuku™-ից օգտվելու հատկությունից, բայց այն փորձում է օգտվել հին Shizuku™-ից։ Հնարավոր է, որ Shizuku™-ն միացված չէ, ստուգեք Shizuku™ ծրագիրը։&lt;p&gt;Հին Shizuku™-ն համարվում է հնացած 2019-ի մարտից։</string>
     <string name="grant_dialog_button_deny">Մերժել</string>
     <string name="grant_dialog_button_allow_always">Միշտ թույլատրել</string>
     <string name="permission_warning_template">Թույլատրե՞լ <b>%1$s</b> հավելվածին %2$s:</string>

--- a/manager/src/main/res/values-id/strings.xml
+++ b/manager/src/main/res/values-id/strings.xml
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="home_status_service_version_update">Versi %2$s, %1$s &lt;br&gt; Mulai ulang untuk upgrade ke versi %3$s</string>
-    <string name="home_adb_description">Untuk perangkat tanpa akses root, Anda harus menggunakan adb untuk memulai Shizuku (perlu terhubung dengan komputer). Proses ini harus diulang setiap kali perangkat di-restart. Harap <b><a href="%1$s">baca dokumentasi</a></b> untuk info lebih lanjut.</string>
+    <string name="home_adb_description">Untuk perangkat tanpa akses root, Anda harus menggunakan adb untuk memulai Shizuku™ (perlu terhubung dengan komputer). Proses ini harus diulang setiap kali perangkat di-restart. Harap <b><a href="%1$s">baca dokumentasi</a></b> untuk info lebih lanjut.</string>
     <string name="dialog_adb_discovery_message">Harap aktifkan \"Debug Nirkabel (Wireless Debugging)\" pada \"Pilihan Pengembang (Developer Option)\". Opsi \"Debug Nirkabel\" akan nonaktif otomatis saat koneksi berubah.
 \n
-\nSebagai catatan, jangan nonaktifkan \"Pilihan Pengembang\" atau \"Debug USB\", karena Shizuku akan terhenti.</string>
+\nSebagai catatan, jangan nonaktifkan \"Pilihan Pengembang\" atau \"Debug USB\", karena Shizuku™ akan terhenti.</string>
     <string name="dialog_adb_pairing_message">Harap mulai penyambungan melalui langkah berikut: \"Pilihan Pengembang\" – \"Debug Nirkabel\" – \"Sambungkan perangkat dengan kode penghubung\".
 \n
 \nSetelah penyambungan dimulai, Anda akan diminta untuk memasukkan kode penghubung.</string>
-    <string name="adb_pairing_requires_multi_window_reason">Sistem mengharuskan dialog penyambungan untuk selalu terlihat, hal ini hanya bisa diakali dengan mode layar pisah (split-screen) untuk membuat Shizuku dan dialog sistem muncul secara bersamaan.</string>
-    <string name="home_root_description">Sebagai tambahan, Shizuku bisa dimulai secara otomatis saat perangkat dimulai. Kalau hal ini tak bisa dilakukan, harap cek apakah sistem Anda atau aplikasi pihak-ketiga telah membatasi Shizuku.&lt;br&gt;Lebih lanjut, cek %s.</string>
-    <string name="home_learn_more_description">Pelajari cara mengembangkan dengan Shizuku</string>
+    <string name="adb_pairing_requires_multi_window_reason">Sistem mengharuskan dialog penyambungan untuk selalu terlihat, hal ini hanya bisa diakali dengan mode layar pisah (split-screen) untuk membuat Shizuku™ dan dialog sistem muncul secara bersamaan.</string>
+    <string name="home_root_description">Sebagai tambahan, Shizuku™ bisa dimulai secara otomatis saat perangkat dimulai. Kalau hal ini tak bisa dilakukan, harap cek apakah sistem Anda atau aplikasi pihak-ketiga telah membatasi Shizuku™.&lt;br&gt;Lebih lanjut, cek %s.</string>
+    <string name="home_learn_more_description">Pelajari cara mengembangkan dengan Shizuku™</string>
     <string name="terminal_tutorial_1">Pertama, Ekspor file ke tempat mana pun yang Anda mau. Anda akan mendapatkan dua file, yaitu %1$s dan %2$s.</string>
     <string name="terminal_tutorial_1_description">Jika ada file bernama sama pada folder tersebut, maka file tersebut akan ditimpa.
 \n
-\nFungsi ekspor ini menggunakan SAF (Storage Access Framework). Beberapa orang melaporkan bahwa MIUI mengacaukan fungsi SAF. Jadi jika Anda memakai MIUI, mungkin Anda harus mengekstrak file ini dari apk Shizuku atau mengunduhnya dari GitHub.</string>
-    <string name="terminal_tutorial_2_description">Sebagai contoh, jika Anda mau menggunakan Shizuku di %1$s, Anda harus menimpa %2$s dengan %3$s (%4$s adalah nama paket dari %1$s).</string>
+\nFungsi ekspor ini menggunakan SAF (Storage Access Framework). Beberapa orang melaporkan bahwa MIUI mengacaukan fungsi SAF. Jadi jika Anda memakai MIUI, mungkin Anda harus mengekstrak file ini dari apk Shizuku™ atau mengunduhnya dari GitHub.</string>
+    <string name="terminal_tutorial_2_description">Sebagai contoh, jika Anda mau menggunakan Shizuku™ di %1$s, Anda harus menimpa %2$s dengan %3$s (%4$s adalah nama paket dari %1$s).</string>
     <string name="terminal_tutorial_3_description">Tips tambahan: berikan izin eksekusi pada %1$s dan tambahkan pada %2$s, Anda akan bisa menggunakan %1$s secara langsung.</string>
-    <string name="action_stop">Hentikan Shizuku</string>
+    <string name="action_stop">Hentikan Shizuku™</string>
     <string name="notification_service_start_no_root">Gagal mendapat izin root.</string>
     <string name="start_with_root_failed">Layanan tidak bisa dimulai karena aplikasi tidak mendapat izin root atau perangkat tidak memiliki akses root.</string>
     <string name="translation_contributors">laymoth</string>
@@ -48,7 +48,7 @@
     <string name="adb_pair_required">Harap lakukan penyambungan terlebih dahulu.</string>
     <string name="development_settings">Pilihan pengembang</string>
     <string name="home_root_title">Mulai (untuk perangkat dengan root)</string>
-    <string name="home_root_description_sui">Jika Anda menggunakan Magisk, Anda bisa coba %1$s. Untuk pengguna root, hal ini perlahan akan menggantikan Shizuku. Sebagai catatan, aplikasi yang sudah ada harus disesuaikan sedikit untuk menggunakan %2$s.</string>
+    <string name="home_root_description_sui">Jika Anda menggunakan Magisk, Anda bisa coba %1$s. Untuk pengguna root, hal ini perlahan akan menggantikan Shizuku™. Sebagai catatan, aplikasi yang sudah ada harus disesuaikan sedikit untuk menggunakan %2$s.</string>
     <string name="home_root_button_start">Mulai</string>
     <string name="home_root_button_restart">Mulai ulang</string>
     <string name="home_app_management_title">Manajemen Aplikasi</string>
@@ -56,15 +56,15 @@
         <item quantity="other">%d aplikasi terdaftar</item>
     </plurals>
     <string name="home_app_management_view_authorized_apps">Ketuk untuk mengatur aplikasi terdaftar</string>
-    <string name="home_learn_more_title">Pelajari Shizuku</string>
+    <string name="home_learn_more_title">Pelajari Shizuku™</string>
     <string name="app_management_dialog_adb_is_limited_title">Izin adb terbatas</string>
     <string name="app_management_dialog_adb_is_limited_message">Kemungkinan besar merk perangkat Anda membatasi perizinan adb.&lt;p&gt;Solusi untuk perangkat Anda mungkin ada pada &lt;b&gt;&lt;a href=\"%1$s\"&gt;dokumentasi ini&lt;/a&gt;&lt;/b&gt;.</string>
-    <string name="app_management_item_summary_requires_root">* Shizuku harus dijalankan dengan root</string>
-    <string name="home_terminal_title">Gunakan Shizuku pada aplikasi terminal</string>
-    <string name="home_terminal_description">Jalankan perintah melalui Shizuku pada aplikasi terminal yang Anda gunakan</string>
+    <string name="app_management_item_summary_requires_root">* Shizuku™ harus dijalankan dengan root</string>
+    <string name="home_terminal_title">Gunakan Shizuku™ pada aplikasi terminal</string>
+    <string name="home_terminal_description">Jalankan perintah melalui Shizuku™ pada aplikasi terminal yang Anda gunakan</string>
     <string name="terminal_export_files">Ekspor file</string>
     <string name="terminal_tutorial_2">Lalu, gunakan penyunting teks apa pun untuk membuka dan mengubah %1$s.</string>
-    <string name="terminal_tutorial_3">Terakhir, pindahkan file ke tempat yang bisa diakses oleh aplikasi terminal yang Anda gunakan, Anda akan bisa menggunakan %1$s untuk menjalan perintah melalui Shizuku.</string>
+    <string name="terminal_tutorial_3">Terakhir, pindahkan file ke tempat yang bisa diakses oleh aplikasi terminal yang Anda gunakan, Anda akan bisa menggunakan %1$s untuk menjalan perintah melalui Shizuku™.</string>
     <string name="settings_title">Pengaturan</string>
     <string name="settings_language">Bahasa</string>
     <string name="settings_user_interface">Penampilan</string>
@@ -75,16 +75,16 @@
     <string name="settings_translation">Ikut menerjemahkan</string>
     <string name="settings_translation_summary">Bantu kami menerjemahkan %s dengan bahasa Anda</string>
     <string name="settings_start_on_boot">Mulai saat boot (root)</string>
-    <string name="settings_start_on_boot_summary">Untuk perangkat root, Shizuku bisa mulai otomatis saat boot</string>
+    <string name="settings_start_on_boot_summary">Untuk perangkat root, Shizuku™ bisa mulai otomatis saat boot</string>
     <string name="action_about">Tentang</string>
     <string name="about_view_source_code">Lihat kode sumbernya di %s</string>
-    <string name="dialog_stop_message">Layanan Shizuku akan berhenti.</string>
+    <string name="dialog_stop_message">Layanan Shizuku™ akan berhenti.</string>
     <string name="notification_channel_service_status">Status layanan</string>
-    <string name="notification_service_starting">Memulai layanan Shizuku…</string>
-    <string name="notification_service_start_failed">Layanan Shizuku gagal dimulai.</string>
+    <string name="notification_service_starting">Memulai layanan Shizuku™…</string>
+    <string name="notification_service_start_failed">Layanan Shizuku™ gagal dimulai.</string>
     <string name="notification_working">Sedang bekerja…</string>
-    <string name="permission_description">Izinkan aplikasi menggunakan Shizuku.</string>
-    <string name="permission_label">mengakses Shizuku</string>
+    <string name="permission_description">Izinkan aplikasi menggunakan Shizuku™.</string>
+    <string name="permission_label">mengakses Shizuku™</string>
     <string name="permission_warning_template">Izinkan <b>%1$s</b> untuk %2$s\?</string>
     <string name="grant_dialog_button_allow_always">Selalu izinkan</string>
     <string name="grant_dialog_button_deny">Tolak</string>
@@ -93,16 +93,16 @@
     <string name="toast_copied_to_clipboard">%s
 \ntelah disalin ke papan klip.</string>
     <string name="toast_copied_to_clipboard_with_text"><b>%s</b> telah disalin ke papan klip.</string>
-    <string name="dialog_legacy_not_support_title">%1$s tidak mendukung Shizuku modern</string>
-    <string name="dialog_legacy_not_support_message">Shizuku Kuno sudah dihentikan sejak Maret 2019. Selain itu, Shizuku kuno tidak bisa bekerja pada sistem Android yang lebih baru.&lt;p&gt;Coba minta kepada pengembang dari &lt;b&gt;%1$s&lt;/b&gt; untuk memperbarui aplikasinya.</string>
-    <string name="dialog_requesting_legacy_title">%1$s meminta akses Shizuku kuno</string>
-    <string name="dialog_requesting_legacy_message">&lt;b&gt;%1$s&lt;/b&gt; memiliki dukungan Shizuku modern, namun meminta akses Shizuku kuno. Hal ini bisa terjadi karena Shizuku tidak aktif, harap periksa di aplikasi Shizuku. &lt;p&gt;Shizuku Kuno sudah dihentikan sejak Maret 2019.</string>
-    <string name="dialog_requesting_legacy_button_open_shizuku">Buka Shizuku</string>
-    <string name="rish_description">Dengan %1$s, di aplikasi terminal mana pun, Anda dapat terhubung dan berinteraksi dengan shell yang dijalankan oleh Shizuku. &lt;p&gt;Tentang detail penggunaan %1$s, ketuk untuk melihat dokumen.</string>
+    <string name="dialog_legacy_not_support_title">%1$s tidak mendukung Shizuku™ modern</string>
+    <string name="dialog_legacy_not_support_message">Shizuku™ Kuno sudah dihentikan sejak Maret 2019. Selain itu, Shizuku™ kuno tidak bisa bekerja pada sistem Android yang lebih baru.&lt;p&gt;Coba minta kepada pengembang dari &lt;b&gt;%1$s&lt;/b&gt; untuk memperbarui aplikasinya.</string>
+    <string name="dialog_requesting_legacy_title">%1$s meminta akses Shizuku™ kuno</string>
+    <string name="dialog_requesting_legacy_message">&lt;b&gt;%1$s&lt;/b&gt; memiliki dukungan Shizuku™ modern, namun meminta akses Shizuku™ kuno. Hal ini bisa terjadi karena Shizuku™ tidak aktif, harap periksa di aplikasi Shizuku™. &lt;p&gt;Shizuku™ Kuno sudah dihentikan sejak Maret 2019.</string>
+    <string name="dialog_requesting_legacy_button_open_shizuku">Buka Shizuku™</string>
+    <string name="rish_description">Dengan %1$s, di aplikasi terminal mana pun, Anda dapat terhubung dan berinteraksi dengan shell yang dijalankan oleh Shizuku™. &lt;p&gt;Tentang detail penggunaan %1$s, ketuk untuk melihat dokumen.</string>
     <string name="home_wireless_adb_description_pre_11">Sebelum Android 11, koneksi ke komputer diperlukan untuk mengaktifkan debug Nirkabel.</string>
     <string name="adb_pairing_tutorial_content_miui">Pengguna MIUI mungkin perlu mengubah gaya pemberitahuan ke \"Android\" dari \"Pemberitahuan\" - \"Bayangan pemberitahuan\" di pengaturan sistem.</string>
-    <string name="home_wireless_adb_description">Pada Android 11 atau yang lebih baru, Anda dapat mengaktifkan debug Nirkabel dan memulai Shizuku langsung dari perangkat Anda, tanpa menyambungkan ke komputer.&lt;p&gt;Silakan lihat panduan langkah demi langkah terlebih dahulu.</string>
-    <string name="adb_pairing_tutorial_content_notification">Notifikasi dari Shizuku akan membantu Anda untuk menyelesaikan pemasangan.</string>
+    <string name="home_wireless_adb_description">Pada Android 11 atau yang lebih baru, Anda dapat mengaktifkan debug Nirkabel dan memulai Shizuku™ langsung dari perangkat Anda, tanpa menyambungkan ke komputer.&lt;p&gt;Silakan lihat panduan langkah demi langkah terlebih dahulu.</string>
+    <string name="adb_pairing_tutorial_content_notification">Notifikasi dari Shizuku™ akan membantu Anda untuk menyelesaikan pemasangan.</string>
     <string name="adb_pairing_tutorial_content_steps">Masuk \"Opsi developer\" - \"Debug nirkabel\". Sentuh \"Sambungkan perangkat dengan kode penghubung\", Anda akan melihat enam digit kode.</string>
     <string name="adb_pairing_tutorial_content_enter_pairing_code">Masukkan kode pada notifikasi untuk menyelesaikan penyambungan.</string>
     <string name="notification_channel_adb_pairing">Pemasangan debug nirkabel</string>
@@ -110,27 +110,27 @@
     <string name="notification_adb_pairing_searching_for_service_title">Mencari layanan penyambungan</string>
     <string name="notification_adb_pairing_service_found_title">Layanan penyambungan ditemukan</string>
     <string name="notification_adb_pairing_stop_searching">Berhenti mencari</string>
-    <string name="notification_adb_pairing_succeed_text">Anda dapat memulai layanan Shizuku sekarang.</string>
+    <string name="notification_adb_pairing_succeed_text">Anda dapat memulai layanan Shizuku™ sekarang.</string>
     <string name="notification_adb_pairing_failed_title">Penyambungan gagal</string>
     <string name="notification_adb_pairing_retry">Ulangi</string>
-    <string name="adb_pairing_tutorial_title">Pasangkan Shizuku dengan perangkat Anda</string>
+    <string name="adb_pairing_tutorial_title">Pasangkan Shizuku™ dengan perangkat Anda</string>
     <string name="notification_adb_pairing_working_title">Penyambungan dalam proses</string>
     <string name="notification_adb_pairing_succeed_title">Penyambungan berhasil</string>
     <string name="notification_settings">Pengaturan notifikasi</string>
-    <string name="adb_pairing_tutorial_content_notification_blocked">Proses penyambungan membutuhkan Anda untuk berinteraksi dengan notifikasi dari Shizuku. Mohon izinkan Shizuku untuk mengirim pemberitahuan.</string>
+    <string name="adb_pairing_tutorial_content_notification_blocked">Proses penyambungan membutuhkan Anda untuk berinteraksi dengan notifikasi dari Shizuku™. Mohon izinkan Shizuku™ untuk mengirim pemberitahuan.</string>
     <string name="home_wireless_adb_view_guide_button">Panduan langkah demi langkah</string>
-    <string name="adb_pairing_tutorial_content_finish">Kembali ke Shizuku dan mulai Shizuku.</string>
+    <string name="adb_pairing_tutorial_content_finish">Kembali ke Shizuku™ dan mulai Shizuku™.</string>
     <string name="adb_pairing_tutorial_content_left_is_clickable">Harap dicatat, bagian kiri dari opsi \"Debug nirkabel \" dapat diklik, mengetuknya akan membuka halaman baru. Hanya menyalakan sakelar di sebelah kanan yang salah.</string>
     <string name="adb_pairing_tutorial_content_miui_2">Jika tidak, Anda mungkin tidak dapat memasukan kode penyandingan dari notifikasi.</string>
-    <string name="adb_pairing_tutorial_content_network">Shizuku membutuhkan akses ke jaringan lokal. Itu dikontrol oleh izin jaringan.</string>
-    <string name="adb_pairing_tutorial_content_network_limation_not_foreground">Beberapa sistem (seperti MIUI) melarang aplikasi untuk mengakses jaringan ketika tidak terlihat, bahkan jika aplikasi berjalan dilatar depan. Tolong matikan fitur optimisasi baterai untuk Shizuku pada sistem tersebut.</string>
+    <string name="adb_pairing_tutorial_content_network">Shizuku™ membutuhkan akses ke jaringan lokal. Itu dikontrol oleh izin jaringan.</string>
+    <string name="adb_pairing_tutorial_content_network_limation_not_foreground">Beberapa sistem (seperti MIUI) melarang aplikasi untuk mengakses jaringan ketika tidak terlihat, bahkan jika aplikasi berjalan dilatar depan. Tolong matikan fitur optimisasi baterai untuk Shizuku™ pada sistem tersebut.</string>
     <string name="settings_use_system_color">Gunakan tema warna sistem</string>
-    <string name="home_adb_is_limited_description">Produsen perangkat Anda telah membatasi izin adb dan aplikasi yang menggunakan Shizuku tidak akan berfungsi dengan baik.
+    <string name="home_adb_is_limited_description">Produsen perangkat Anda telah membatasi izin adb dan aplikasi yang menggunakan Shizuku™ tidak akan berfungsi dengan baik.
 \n
 \nBiasanya, batasan ini dapat dihilangkan dengan menyesuaikan beberapa opsi di \"Opsi pengembang\". Silakan baca bantuan untuk detail tentang cara melakukan ini.
 \n
-\nAnda mungkin perlu memulai ulang Shizuku agar operasi dapat diterapkan.</string>
+\nAnda mungkin perlu memulai ulang Shizuku™ agar operasi dapat diterapkan.</string>
     <string name="home_adb_is_limited_title">Anda perlu mengambil langkah ekstra</string>
-    <string name="home_app_management_empty">Aplikasi yang telah meminta atau mendeklarasikan Shizuku akan ditampilkan di sini.</string>
+    <string name="home_app_management_empty">Aplikasi yang telah meminta atau mendeklarasikan Shizuku™ akan ditampilkan di sini.</string>
     <string name="dialog_adb_discovery_message_toggle_wireless_debugging">Coba untuk matikan dan hidupkan kembali \"Debug nirkabel\" jika terus mencari.</string>
 </resources>

--- a/manager/src/main/res/values-it/strings.xml
+++ b/manager/src/main/res/values-it/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="home_adb_button_view_help">Leggi la guida</string>
-    <string name="home_adb_description">Per i dispositivi non rootati occorre usare adb per avviare Shizuku (serve una connessione ad un computer). Questo processo deve essere ripetuto ogni volta che il dispositivo viene riavviato. Per favore <b><a href="%1$s">leggi la guida</a></b>.</string>
+    <string name="home_adb_description">Per i dispositivi non rootati occorre usare adb per avviare Shizuku™ (serve una connessione ad un computer). Questo processo deve essere ripetuto ogni volta che il dispositivo viene riavviato. Per favore <b><a href="%1$s">leggi la guida</a></b>.</string>
     <string name="home_adb_title">Avvia collegandoti ad un computer</string>
     <string name="home_status_service_version_update">Versione %2$s, %1$s&lt;br&gt;Riavvia per aggiornare alla versione %3$s</string>
     <string name="home_status_service_version">Versione %2$s, %1$s</string>
@@ -11,12 +11,12 @@
     <string name="home_adb_dialog_view_command_copy_button">Copia</string>
     <string name="home_adb_dialog_view_command_button_send">Invia</string>
     <string name="home_wireless_adb_title">Avvia tramite Debug Wireless</string>
-    <string name="home_wireless_adb_description">Su Android 11 o successivi, puoi abilitare il Debug Wireless e avviare Shizuku direttamente dal tuo dispositivo, senza doverti collegare a un computer.&lt;p&gt;Consulta prima la guida passo-passo.</string>
+    <string name="home_wireless_adb_description">Su Android 11 o successivi, puoi abilitare il Debug Wireless e avviare Shizuku™ direttamente dal tuo dispositivo, senza doverti collegare a un computer.&lt;p&gt;Consulta prima la guida passo-passo.</string>
     <string name="home_wireless_adb_description_pre_11">Per le versioni precedenti ad Android 11, è necessario collegarsi ad un computer per abilitare il Debug Wireless.</string>
     <string name="home_wireless_adb_view_guide_button">Guida passo-passo</string>
     <string name="dialog_adb_discovery_message">Abilita \"Debug Wireless\" in \"Opzioni Sviluppatore\". \"Debug Wireless\" viene automaticamente disabilitato quando la rete cambia.
 \n
-\nNota, non disabilitare \"Opzioni Sviluppatore\" o \"Debug USB\", altrimenti Shizuku verrà interrotto.</string>
+\nNota, non disabilitare \"Opzioni Sviluppatore\" o \"Debug USB\", altrimenti Shizuku™ verrà interrotto.</string>
     <string name="dialog_adb_port">Porta</string>
     <string name="adb_pairing">Accoppiamento</string>
     <string name="dialog_adb_pairing_title">Accoppia con il dispositivo</string>
@@ -30,13 +30,13 @@
 \nCiò potrebbe essere dovuto ad un malfunzionamento del meccanismo di KeyStore di questo dispositivo.</string>
     <string name="adb_pair_required">Esegui prima la fase di accoppiamento.</string>
     <string name="development_settings">Modalitá sviluppatore</string>
-    <string name="adb_pairing_tutorial_title">Accoppia Shizuku col tuo dispositivo</string>
-    <string name="adb_pairing_tutorial_content_notification">Una notifica da Shizuku ti aiuterà a completare l\'accoppiamento.</string>
+    <string name="adb_pairing_tutorial_title">Accoppia Shizuku™ col tuo dispositivo</string>
+    <string name="adb_pairing_tutorial_content_notification">Una notifica da Shizuku™ ti aiuterà a completare l\'accoppiamento.</string>
     <string name="adb_pairing_tutorial_content_steps">Entra in \"Modalità sviluppatore\" - \"Debug wireless\". Seleziona \"Accoppia dispositivo con codice di associazione\", vedrai un codice a sei cifre.</string>
     <string name="adb_pairing_tutorial_content_enter_pairing_code">Inserisci il codice nella notifica per completare l\'accoppiamento.</string>
-    <string name="adb_pairing_tutorial_content_notification_blocked">Il processo di accoppiamento richiede che tu interagisca con una notifica di Shizuku. Consenti a Shizuku di mostrare notifiche.</string>
+    <string name="adb_pairing_tutorial_content_notification_blocked">Il processo di accoppiamento richiede che tu interagisca con una notifica di Shizuku™. Consenti a Shizuku™ di mostrare notifiche.</string>
     <string name="adb_pairing_tutorial_content_miui">Gli utenti MIUI potrebbero dover impostare lo stile di notifica su \"Android\" da \"Notifiche\" - \"Pannello notifiche\" nelle impostazioni di sistema.</string>
-    <string name="adb_pairing_tutorial_content_finish">Torna a Shizuku e avvia Shizuku.</string>
+    <string name="adb_pairing_tutorial_content_finish">Torna a Shizuku™ e avvia Shizuku™.</string>
     <string name="home_root_title">Avvia (per dispositivi rootati)</string>
     <string name="home_adb_button_view_command">Visualizza comando</string>
     <string name="dialog_adb_discovery">Ricerca del servizio di Debug Wireless</string>
@@ -47,21 +47,21 @@
 \n
 \nDopo l\'avvio del processo di accoppiamento, potrai inserire il codice.</string>
     <string name="notification_settings">Opzioni di notifica</string>
-    <string name="adb_pairing_tutorial_content_network_limation_not_foreground">Alcuni sistemi (come MIUI) non consentono alle app di accedere alla rete quando queste non sono visibili, anche se l\'app utilizza il servizio in primo piano come standard. Disattiva le funzioni di ottimizzazione della batteria per Shizuku su tali sistemi.</string>
+    <string name="adb_pairing_tutorial_content_network_limation_not_foreground">Alcuni sistemi (come MIUI) non consentono alle app di accedere alla rete quando queste non sono visibili, anche se l\'app utilizza il servizio in primo piano come standard. Disattiva le funzioni di ottimizzazione della batteria per Shizuku™ su tali sistemi.</string>
     <string name="adb_pairing_tutorial_content_miui_2">In caso contrario, potresti non essere in grado di inserire il codice di accoppiamento dalla notifica.</string>
-    <string name="home_root_description">Inoltre, Shizuku può essere avviato automaticamente all\'avvio. In caso contrario, controlla se il tuo sistema o l\'opzione app esterne hanno limitato Shizuku.&lt;br&gt;Puoi fare riferimento a %s.</string>
+    <string name="home_root_description">Inoltre, Shizuku™ può essere avviato automaticamente all\'avvio. In caso contrario, controlla se il tuo sistema o l\'opzione app esterne hanno limitato Shizuku™.&lt;br&gt;Puoi fare riferimento a %s.</string>
     <string name="home_root_button_start">Avvia</string>
-    <string name="home_root_description_sui">Se stai usando Magisk, puoi provare %1$s. Per gli utenti root, alla fine sostituirà Shizuku. Nota, le applicazioni esistenti devono essere leggermente modificate per poter usare %2$s.</string>
+    <string name="home_root_description_sui">Se stai usando Magisk, puoi provare %1$s. Per gli utenti root, alla fine sostituirà Shizuku™. Nota, le applicazioni esistenti devono essere leggermente modificate per poter usare %2$s.</string>
     <string name="home_root_button_restart">Riavvia</string>
     <string name="home_app_management_title">Gestione dell\'applicazione</string>
-    <string name="adb_pairing_tutorial_content_network">Shizuku ha bisogno di accedere alla rete locale. È controllato dal permesso di rete.</string>
+    <string name="adb_pairing_tutorial_content_network">Shizuku™ ha bisogno di accedere alla rete locale. È controllato dal permesso di rete.</string>
     <string name="terminal_tutorial_1">Per primo, esporta i files ovunque tu voglia, %1$s e %2$s.</string>
     <string name="terminal_export_files">Esporta files</string>
     <string name="terminal_tutorial_2">Poi usa un qualsiasi editore testi per aprire e modificare %1$s.</string>
     <string name="terminal_tutorial_1_description">Se esistono files con lo stesso nome nella cartella selezionata, saranno cancellati.
 \n
-\nLa funzione di esportazione usa SAF (Storage Access Framework). Si segnala che MIUI impedisce la funzione SAF. Se utilizzate MIUI, dovrete probabilmente estrarre il file dall\'apk Shizuku o scaricarlo da GitHub.</string>
-    <string name="home_terminal_description">Esegui comandi attraverso Shizuku nelle apps terminale che desiderate</string>
+\nLa funzione di esportazione usa SAF (Storage Access Framework). Si segnala che MIUI impedisce la funzione SAF. Se utilizzate MIUI, dovrete probabilmente estrarre il file dall\'apk Shizuku™ o scaricarlo da GitHub.</string>
+    <string name="home_terminal_description">Esegui comandi attraverso Shizuku™ nelle apps terminale che desiderate</string>
     <plurals name="home_app_management_authorized_apps_count">
         <item quantity="one">%d applicazione autorizzata</item>
         <item quantity="many">%d applicazioni autorizzate</item>
@@ -70,31 +70,31 @@
     <string name="home_app_management_view_authorized_apps">Premere per gestire le app autorizzate</string>
     <string name="app_management_dialog_adb_is_limited_title">Il permesso di adb è limitato</string>
     <string name="app_management_dialog_adb_is_limited_message">È molto probabile che il fabbricante del tuo dispositivo limiti i permessi di adb.&lt;p&gt;Ci potrebbe essere una soluzione per il vostro dispositivo in &lt;b&gt;&lt;a href=\"%1$s\"&gt;questo documento&lt;/a&gt;&lt;/b&gt;.</string>
-    <string name="app_management_item_summary_requires_root">* richiede Shizuku in modalità root</string>
-    <string name="home_learn_more_title">Impara Shizuku</string>
-    <string name="home_learn_more_description">Impara a sviluppare con Shizuku</string>
-    <string name="home_terminal_title">Utilizza Shizuku nell\'app terminale</string>
+    <string name="app_management_item_summary_requires_root">* richiede Shizuku™ in modalità root</string>
+    <string name="home_learn_more_title">Impara Shizuku™</string>
+    <string name="home_learn_more_description">Impara a sviluppare con Shizuku™</string>
+    <string name="home_terminal_title">Utilizza Shizuku™ nell\'app terminale</string>
     <string name="translation_contributors">Dany-coder778, xDonatello, cladiotto</string>
-    <string name="action_stop">Interrompi Shizuku</string>
-    <string name="dialog_requesting_legacy_message">&lt;b&gt;%1$s&lt;/b&gt; ha il supporto al Shizuku moderno, ma sta richiedendo Shizuku legacy. Questo potrebbe essere perché Shizuku non è in esecuzione, controlla nell\'app Shizuku.&lt;p&gt;Shizuku legacy è stato deprecato a marzo 2019.</string>
-    <string name="dialog_requesting_legacy_button_open_shizuku">Apri Shizuku</string>
+    <string name="action_stop">Interrompi Shizuku™</string>
+    <string name="dialog_requesting_legacy_message">&lt;b&gt;%1$s&lt;/b&gt; ha il supporto al Shizuku™ moderno, ma sta richiedendo Shizuku™ legacy. Questo potrebbe essere perché Shizuku™ non è in esecuzione, controlla nell\'app Shizuku™.&lt;p&gt;Shizuku™ legacy è stato deprecato a marzo 2019.</string>
+    <string name="dialog_requesting_legacy_button_open_shizuku">Apri Shizuku™</string>
     <string name="adb_pairing_tutorial_content_left_is_clickable">Tieni presente che la parte a sinistra dell\'opzione \"Debug wireless\" è selezionabile, toccandola si aprirà una nuova pagina. Solo la pressione dell\'interruttore a destra non è corretta.</string>
     <string name="settings_title">Impostazioni</string>
     <string name="settings_language">Lingua</string>
     <string name="settings_black_night_theme_summary">Usa il tema nero puro se la modalità notte è abilitata</string>
     <string name="settings_translation">Partecipa alla traduzione</string>
     <string name="settings_translation_summary">Aiutaci a tradurre %s nella tua lingua</string>
-    <string name="settings_start_on_boot_summary">Per i dispositivi rootati, Shizuku è in grado di avviarsi automaticamente all\'avvio</string>
+    <string name="settings_start_on_boot_summary">Per i dispositivi rootati, Shizuku™ è in grado di avviarsi automaticamente all\'avvio</string>
     <string name="notification_channel_service_status">Stato di avvio del servizio</string>
     <string name="grant_dialog_button_allow_always">Consenti sempre</string>
-    <string name="notification_service_starting">Il servizio Shizuku si sta avviando…</string>
-    <string name="dialog_requesting_legacy_title">%1$s sta richiedendo Shizuku legacy</string>
+    <string name="notification_service_starting">Il servizio Shizuku™ si sta avviando…</string>
+    <string name="dialog_requesting_legacy_title">%1$s sta richiedendo Shizuku™ legacy</string>
     <string name="permission_warning_template">Consentire a <b>%1$s</b> di %2$s\?</string>
     <string name="toast_copied_to_clipboard_with_text"><b>%s</b> è stato copiato negli appunti.</string>
-    <string name="rish_description">Con %1$s, in qualsiasi app terminale, puoi connetterti e interagire con la shell eseguita da Shizuku. &lt;p&gt;Per info sull\'utilizzo dettagliato di %1$s, tocca per visualizzare il documento.</string>
+    <string name="rish_description">Con %1$s, in qualsiasi app terminale, puoi connetterti e interagire con la shell eseguita da Shizuku™. &lt;p&gt;Per info sull\'utilizzo dettagliato di %1$s, tocca per visualizzare il documento.</string>
     <string name="notification_adb_pairing_searching_for_service_title">Ricerca del servizio di accoppiamento</string>
-    <string name="terminal_tutorial_2_description">Ad esempio, se vuoi utilizzare Shizuku in %1$s, devi sostituire %2$s con %3$s (%4$s è il nome del pacchetto di %1$s).</string>
-    <string name="terminal_tutorial_3">Infine, sposta i file in un punto in cui l\'app del terminale può accedere, così sarai in grado di utilizzare %1$s per eseguire comandi tramite Shizuku.</string>
+    <string name="terminal_tutorial_2_description">Ad esempio, se vuoi utilizzare Shizuku™ in %1$s, devi sostituire %2$s con %3$s (%4$s è il nome del pacchetto di %1$s).</string>
+    <string name="terminal_tutorial_3">Infine, sposta i file in un punto in cui l\'app del terminale può accedere, così sarai in grado di utilizzare %1$s per eseguire comandi tramite Shizuku™.</string>
     <string name="terminal_tutorial_3_description">Alcuni suggerimenti: concedi il permesso di esecuzione a %1$s e aggiungilo a %2$s, così potrai utilizzare %1$s direttamente.</string>
     <string name="settings_user_interface">Aspetto</string>
     <string name="settings_black_night_theme">Tema nero notte</string>
@@ -106,14 +106,14 @@
     <string name="settings_use_system_color">Usa il colore del tema di sistema</string>
     <string name="action_about">Info</string>
     <string name="about_view_source_code">Visualizza il codice sorgente a %s</string>
-    <string name="dialog_stop_message">Il servizio Shizuku verrà interrotto.</string>
-    <string name="notification_service_start_failed">Avvio del servizio Shizuku non riuscito.</string>
+    <string name="dialog_stop_message">Il servizio Shizuku™ verrà interrotto.</string>
+    <string name="notification_service_start_failed">Avvio del servizio Shizuku™ non riuscito.</string>
     <string name="notification_service_start_no_root">Impossibile richiedere i permessi di root.</string>
     <string name="notification_working">Esecuzione…</string>
-    <string name="notification_adb_pairing_succeed_text">Ora puoi avviare il servizio Shizuku.</string>
+    <string name="notification_adb_pairing_succeed_text">Ora puoi avviare il servizio Shizuku™.</string>
     <string name="notification_adb_pairing_retry">Riprova</string>
-    <string name="permission_label">accesso Shizuku</string>
-    <string name="permission_description">Consenti all\'app di usare Shizuku.</string>
+    <string name="permission_label">accesso Shizuku™</string>
+    <string name="permission_description">Consenti all\'app di usare Shizuku™.</string>
     <string name="grant_dialog_button_deny">Nega</string>
     <string name="starter">Accensione</string>
     <string name="notification_channel_adb_pairing">Accoppiamento debug wireless</string>
@@ -125,14 +125,14 @@
     <string name="notification_adb_pairing_failed_title">Accoppiamento non riuscito</string>
     <string name="start_with_root_failed">Impossibile avviare il servizio poiché i permessi di root non sono stati concessi o questo dispositivo non è rootato.</string>
     <string name="dialog_cannot_open_browser_title">Impossibile avviare il browser</string>
-    <string name="dialog_legacy_not_support_title">%1$s non supporta il moderno Shizuku</string>
-    <string name="dialog_legacy_not_support_message">Shizuku legacy è stato deprecato a marzo 2019. Inoltre, Shizuku legacy non funziona sui sistemi Android più recenti.&lt;p&gt;Chiedi allo sviluppatore&lt;b&gt;%1$s&lt;/b&gt; di aggiornare.</string>
+    <string name="dialog_legacy_not_support_title">%1$s non supporta il moderno Shizuku™</string>
+    <string name="dialog_legacy_not_support_message">Shizuku™ legacy è stato deprecato a marzo 2019. Inoltre, Shizuku™ legacy non funziona sui sistemi Android più recenti.&lt;p&gt;Chiedi allo sviluppatore&lt;b&gt;%1$s&lt;/b&gt; di aggiornare.</string>
     <string name="home_adb_is_limited_title">Devi fare un passo in più</string>
-    <string name="home_adb_is_limited_description">Il produttore del dispositivo dispone di autorizzazioni adb limitate e le app che utilizzano Shizuku non funzioneranno correttamente.
+    <string name="home_adb_is_limited_description">Il produttore del dispositivo dispone di autorizzazioni adb limitate e le app che utilizzano Shizuku™ non funzioneranno correttamente.
 \n
 \nDi solito, questa limitazione può essere rimossa regolando alcune opzioni in \"Opzioni sviluppatore\". Si prega di leggere la guida per i dettagli su come eseguire questa operazione.
 \n
-\nPotrebbe essere necessario riavviare Shizuku per rendere effettiva l\'operazione.</string>
-    <string name="home_app_management_empty">Le app che hanno richiesto o dichiarato Shizuku verranno visualizzate qui</string>
+\nPotrebbe essere necessario riavviare Shizuku™ per rendere effettiva l\'operazione.</string>
+    <string name="home_app_management_empty">Le app che hanno richiesto o dichiarato Shizuku™ verranno visualizzate qui</string>
     <string name="dialog_adb_discovery_message_toggle_wireless_debugging">Prova a disabilitare e abilitare \"Debug Wireless\" se continua a cercare.</string>
 </resources>

--- a/manager/src/main/res/values-ja/strings.xml
+++ b/manager/src/main/res/values-ja/strings.xml
@@ -4,7 +4,7 @@
     <string name="toast_copied_to_clipboard">%s
 \nはクリップボードにコピーされました。</string>
     <string name="toast_copied_to_clipboard_with_text">&lt;b&gt;%s&lt;/b&gt; はクリップボードにコピーされました。</string>
-    <string name="dialog_requesting_legacy_button_open_shizuku">Shizukuを開く</string>
+    <string name="dialog_requesting_legacy_button_open_shizuku">Shizuku™を開く</string>
     <string name="home_status_service_is_running">%1$s は実行中</string>
     <string name="home_adb_dialog_view_command_copy_button">コピー</string>
     <string name="home_adb_title">コンピュータに接続して開始する</string>
@@ -14,25 +14,25 @@
     <plurals name="home_app_management_authorized_apps_count">
         <item quantity="other">承認された %d 個のアプリケーション</item>
     </plurals>
-    <string name="dialog_requesting_legacy_title">%1$s は古いバージョンのShizukuを要求しています</string>
-    <string name="dialog_requesting_legacy_message">&lt;b&gt;%1$s&lt;/b&gt;は最新のShizukuをサポートしていますが、古いバージョンのShizukuを要求しています。これは、Shizukuが実行されていない可能性があります。Shizukuアプリで確認してください。&lt;p&gt;古いバージョンのShizukuは2019年3月から非推奨となっています。</string>
+    <string name="dialog_requesting_legacy_title">%1$s は古いバージョンのShizuku™を要求しています</string>
+    <string name="dialog_requesting_legacy_message">&lt;b&gt;%1$s&lt;/b&gt;は最新のShizuku™をサポートしていますが、古いバージョンのShizuku™を要求しています。これは、Shizuku™が実行されていない可能性があります。Shizuku™アプリで確認してください。&lt;p&gt;古いバージョンのShizuku™は2019年3月から非推奨となっています。</string>
     <string name="terminal_tutorial_3_description">ヒント: %1$s に実行権限を与え、それを %2$s に追加すると、%1$s を直接使用できるようになります。</string>
-    <string name="terminal_tutorial_3">最後に、ファイルをターミナルアプリがアクセスできる場所に移動させると、%1$sを使ってShizukuでコマンドを実行できるようになります。</string>
-    <string name="terminal_tutorial_2_description">例えば、%1$sでShizukuを使いたい場合は、%2$sを%3$sに置き換えてください（%4$sは%1$sのパッケージ名です）。</string>
+    <string name="terminal_tutorial_3">最後に、ファイルをターミナルアプリがアクセスできる場所に移動させると、%1$sを使ってShizuku™でコマンドを実行できるようになります。</string>
+    <string name="terminal_tutorial_2_description">例えば、%1$sでShizuku™を使いたい場合は、%2$sを%3$sに置き換えてください（%4$sは%1$sのパッケージ名です）。</string>
     <string name="terminal_tutorial_2">その後、任意のテキストエディタで%1$sを開いて編集します。</string>
     <string name="terminal_export_files">ファイルのエクスポート</string>
     <string name="terminal_tutorial_1_description">選択したフォルダー内に同名のファイルがある場合は、そのファイルは削除されます。
 \n
-\nエクスポート機能には、SAF（Storage Access Framework）が使用されています。MIUIではSAFの機能が壊れることが報告されています。MIUIをお使いの方は、Shizukuのapkからファイルを抽出するか、GitHubからダウンロードする必要があるかもしれません。</string>
+\nエクスポート機能には、SAF（Storage Access Framework）が使用されています。MIUIではSAFの機能が壊れることが報告されています。MIUIをお使いの方は、Shizuku™のapkからファイルを抽出するか、GitHubからダウンロードする必要があるかもしれません。</string>
     <string name="terminal_tutorial_1">まず、ファイルを任意の場所にエクスポートします。%1$sと%2$sの2つのファイルがあります。</string>
-    <string name="home_terminal_title">ターミナルアプリで「Shizuku」を利用する</string>
-    <string name="home_terminal_description">Shizukuを介して、好きなターミナルアプリでコマンドを実行する</string>
+    <string name="home_terminal_title">ターミナルアプリで「Shizuku™」を利用する</string>
+    <string name="home_terminal_description">Shizuku™を介して、好きなターミナルアプリでコマンドを実行する</string>
     <string name="home_app_management_title">アプリケーション管理</string>
     <string name="home_app_management_view_authorized_apps">タップで許可されたアプリを管理</string>
-    <string name="home_learn_more_title">Shizukuについて学ぶ</string>
+    <string name="home_learn_more_title">Shizuku™について学ぶ</string>
     <string name="home_root_button_start">開始</string>
     <string name="home_root_button_restart">再起動</string>
-    <string name="home_root_description">また、起動時にShizukuを自動的に起動することもできます。もし、起動しない場合は、システムやサードパーティのツールがShizukuを制限していないか確認してください。&lt;br&gt;一部古い情報ですが%sを参考にしてください。</string>
+    <string name="home_root_description">また、起動時にShizuku™を自動的に起動することもできます。もし、起動しない場合は、システムやサードパーティのツールがShizuku™を制限していないか確認してください。&lt;br&gt;一部古い情報ですが%sを参考にしてください。</string>
     <string name="adb_pair_required">まずはペアリングの手順を行ってください。</string>
     <string name="development_settings">開発者向けオプション</string>
     <string name="home_root_title">開始(Root化された端末の場合のみ)</string>
@@ -59,22 +59,22 @@
     <string name="home_adb_dialog_view_command_message">&lt;font face=monospace&gt;%1$s&lt;/font&gt;&lt;br&gt;&lt;br&gt;* 他にもいくつか注意点がありますので、まずはヘルプを読んで確認してください。</string>
     <string name="home_adb_button_view_help">ヘルプ</string>
     <string name="home_adb_button_view_command">コマンドを表示する</string>
-    <string name="home_adb_description">root権限を持たないデバイスの場合、adbを使ってShizukuを起動する必要があります（コンピュータへの接続が必要）。この作業は、端末を再起動するたびに繰り返す必要があります。<b><a href="%1$s">詳しくはヘルプをお読みください</a></b>。</string>
-    <string name="home_root_description_sui">Magiskをお使いの方は、%1$sをお試しください。rootユーザにとっては、最終的にShizukuを置き換えることになるでしょう。なお、%2$sを使用するには、既存のアプリケーションを少し変更する必要があります。</string>
+    <string name="home_adb_description">root権限を持たないデバイスの場合、adbを使ってShizuku™を起動する必要があります（コンピュータへの接続が必要）。この作業は、端末を再起動するたびに繰り返す必要があります。<b><a href="%1$s">詳しくはヘルプをお読みください</a></b>。</string>
+    <string name="home_root_description_sui">Magiskをお使いの方は、%1$sをお試しください。rootユーザにとっては、最終的にShizuku™を置き換えることになるでしょう。なお、%2$sを使用するには、既存のアプリケーションを少し変更する必要があります。</string>
     <string name="dialog_adb_discovery_message">「開発者向けオプション」で「ワイヤレスデバッグ」を有効にしてください。ネットワークが変更されると、「ワイヤレスデバッグ」は自動的に無効になります。
 \n
-\n注意:「開発者向けオプション」や「USBデバッグ」を無効にしないでください。無効にすると、Shizukuが停止してしまいます。</string>
-    <string name="dialog_legacy_not_support_title">%1$s は最新の Shizuku をサポートしていません</string>
-    <string name="dialog_legacy_not_support_message">古いバージョンのShizukuは2019年3月より非推奨となりました。また、古いバージョンのShizukuは新しいAndroidシステムでは動作しません。&lt;p&gt;&lt;b&gt;%1$s&lt;/b&gt;の開発者にアップデートを依頼してください。</string>
+\n注意:「開発者向けオプション」や「USBデバッグ」を無効にしないでください。無効にすると、Shizuku™が停止してしまいます。</string>
+    <string name="dialog_legacy_not_support_title">%1$s は最新の Shizuku™ をサポートしていません</string>
+    <string name="dialog_legacy_not_support_message">古いバージョンのShizuku™は2019年3月より非推奨となりました。また、古いバージョンのShizuku™は新しいAndroidシステムでは動作しません。&lt;p&gt;&lt;b&gt;%1$s&lt;/b&gt;の開発者にアップデートを依頼してください。</string>
     <string name="home_status_service_not_running">%1$s は停止中</string>
     <string name="home_status_service_version_update">バージョン %2$s, %1$s&lt;br&gt;バージョン %3$s にアップデートするには、再度起動してください</string>
     <string name="translation_contributors">IMES-mitutti</string>
-    <string name="home_learn_more_description">Shizukuを使った開発方法、Shizukuを使ったアプリの入手方法について学ぶことができます</string>
+    <string name="home_learn_more_description">Shizuku™を使った開発方法、Shizuku™を使ったアプリの入手方法について学ぶことができます</string>
     <string name="app_management_dialog_adb_is_limited_title">adbの権限が制限されています</string>
     <string name="app_management_dialog_adb_is_limited_message">端末の製造元がadbの権限を制限している可能性が高いです。&lt;p&gt; &lt;b&gt;&lt;a href=\"%1$s\"&gt;このドキュメント&lt;/a&gt;&lt;/b&gt;の中に、あなたのシステムに合った解決策があるかもしれません。</string>
-    <string name="app_management_item_summary_requires_root">* root権限でShizukuを実行する必要があります</string>
+    <string name="app_management_item_summary_requires_root">* root権限でShizuku™を実行する必要があります</string>
     <string name="about_view_source_code">%sでソースコードを見る</string>
-    <string name="action_stop">Shizukuを停止する</string>
+    <string name="action_stop">Shizuku™を停止する</string>
     <string name="settings_title">設定</string>
     <string name="settings_language">言語</string>
     <string name="settings_black_night_theme">Black night テーマ</string>
@@ -85,52 +85,52 @@
     <string name="settings_translation">翻訳作業に参加</string>
     <string name="settings_translation_summary">%sをあなたの言語に翻訳するのを手伝ってください</string>
     <string name="settings_start_on_boot">起動時にスタート（要root)</string>
-    <string name="settings_start_on_boot_summary">root化された端末では、起動時に自動的にShizukuを起動できます</string>
+    <string name="settings_start_on_boot_summary">root化された端末では、起動時に自動的にShizuku™を起動できます</string>
     <string name="action_about">このアプリについて</string>
-    <string name="dialog_stop_message">Shizukuのサービスを停止します。</string>
+    <string name="dialog_stop_message">Shizuku™のサービスを停止します。</string>
     <string name="notification_channel_service_status">サービス開始状況</string>
-    <string name="notification_service_starting">Shizukuを開始しています…</string>
-    <string name="notification_service_start_failed">Shizukuを開始することができませんでした。</string>
+    <string name="notification_service_starting">Shizuku™を開始しています…</string>
+    <string name="notification_service_start_failed">Shizuku™を開始することができませんでした。</string>
     <string name="notification_service_start_no_root">root権限の要求に失敗しました。</string>
     <string name="notification_working">実行中…</string>
-    <string name="permission_description">アプリでShizukuの使用を許可します。</string>
+    <string name="permission_description">アプリでShizuku™の使用を許可します。</string>
     <string name="start_with_root_failed">root権限が付与されていないか、端末がroot化されていないため、サービスを開始できません。</string>
-    <string name="permission_label">Shizukuにアクセスする</string>
+    <string name="permission_label">Shizuku™にアクセスする</string>
     <string name="starter">起動</string>
     <string name="dialog_cannot_open_browser_title">ブラウザが起動することができません</string>
-    <string name="rish_description">%1$sを使えば、任意のターミナルアプリで、Shizukuが実行するシェルに接続し、対話することができます。&lt;p&gt;詳しい使い方については、%1$sをタップするとドキュメントが表示されます。</string>
-    <string name="home_wireless_adb_description">Android 11以上ではワイヤレスデバッグを有効にして、コンピュータに接続することなくデバイスから直接Shizukuを起動できます。&lt;p&gt;詳しくはガイドをご覧ください。</string>
+    <string name="rish_description">%1$sを使えば、任意のターミナルアプリで、Shizuku™が実行するシェルに接続し、対話することができます。&lt;p&gt;詳しい使い方については、%1$sをタップするとドキュメントが表示されます。</string>
+    <string name="home_wireless_adb_description">Android 11以上ではワイヤレスデバッグを有効にして、コンピュータに接続することなくデバイスから直接Shizuku™を起動できます。&lt;p&gt;詳しくはガイドをご覧ください。</string>
     <string name="notification_settings">通知オプション</string>
     <string name="home_wireless_adb_description_pre_11">Android 11以前では、ワイヤレスデバッグを有効にするためにパソコンとの接続が必要です。</string>
     <string name="home_wireless_adb_view_guide_button">ガイド</string>
     <string name="notification_adb_pairing_working_title">ペアリング中</string>
     <string name="notification_adb_pairing_succeed_title">ペアリングしました</string>
     <string name="adb_pairing_tutorial_content_steps">「開発者向けオプション」&gt;「ワイヤレスデバック」を選択し、「ペア設定コードによるデバイスのペア設定」をタップすると、6桁のコードが表示されます。</string>
-    <string name="adb_pairing_tutorial_content_notification">Shizukuからの通知でペアリングが完了します。</string>
+    <string name="adb_pairing_tutorial_content_notification">Shizuku™からの通知でペアリングが完了します。</string>
     <string name="adb_pairing_tutorial_content_enter_pairing_code">通知にコードを入力してペアリングします。</string>
     <string name="adb_pairing_tutorial_content_miui">MIUIユーザーはシステムの設定から「通知」→「通知のシェード」から通知スタイルを「Android」に変更する必要がある場合があります。</string>
     <string name="notification_channel_adb_pairing">ワイヤレスデバックペアリング</string>
     <string name="notification_adb_pairing_input_paring_code">ペアリングコードを入力</string>
     <string name="notification_adb_pairing_searching_for_service_title">ペアリングサービスを探しています</string>
     <string name="notification_adb_pairing_stop_searching">探すことを停止しています</string>
-    <string name="notification_adb_pairing_succeed_text">Shizukuサービスをスタートさせられます。</string>
+    <string name="notification_adb_pairing_succeed_text">Shizuku™サービスをスタートさせられます。</string>
     <string name="notification_adb_pairing_failed_title">ペアリングに失敗しました</string>
     <string name="notification_adb_pairing_retry">再試行</string>
-    <string name="adb_pairing_tutorial_title">お使いのデバイスとShizukuをペアリングする</string>
-    <string name="adb_pairing_tutorial_content_notification_blocked">ペアリング手順はShizukuからの通知を操作する必要があります。Shizukuからの通知を許可してください。</string>
-    <string name="adb_pairing_tutorial_content_finish">Shizukuに戻り、スタートします。</string>
+    <string name="adb_pairing_tutorial_title">お使いのデバイスとShizuku™をペアリングする</string>
+    <string name="adb_pairing_tutorial_content_notification_blocked">ペアリング手順はShizuku™からの通知を操作する必要があります。Shizuku™からの通知を許可してください。</string>
+    <string name="adb_pairing_tutorial_content_finish">Shizuku™に戻り、スタートします。</string>
     <string name="notification_adb_pairing_service_found_title">ペアリングサービスを見つけました</string>
     <string name="settings_use_system_color">システムテーマカラー</string>
     <string name="home_adb_is_limited_title">もう一段階行う必要がある</string>
-    <string name="home_app_management_empty">Shizukuを権限をリクエストしたアプリはここに表示されます。</string>
-    <string name="adb_pairing_tutorial_content_network_limation_not_foreground">一部のシステム（MIUIなど）では、アプリが標準でフォアグラウンドサービスを使用していても、アプリが表示されていないときはネットワークにアクセスすることを許可しないようになっています。そのようなシステムでは、Shizukuのバッテリー最適化機能を無効にしてください。</string>
-    <string name="adb_pairing_tutorial_content_network">Shizukuはローカルネットワークにアクセスする必要があります。ネットワーク権限で管理されています。</string>
+    <string name="home_app_management_empty">Shizuku™を権限をリクエストしたアプリはここに表示されます。</string>
+    <string name="adb_pairing_tutorial_content_network_limation_not_foreground">一部のシステム（MIUIなど）では、アプリが標準でフォアグラウンドサービスを使用していても、アプリが表示されていないときはネットワークにアクセスすることを許可しないようになっています。そのようなシステムでは、Shizuku™のバッテリー最適化機能を無効にしてください。</string>
+    <string name="adb_pairing_tutorial_content_network">Shizuku™はローカルネットワークにアクセスする必要があります。ネットワーク権限で管理されています。</string>
     <string name="adb_pairing_tutorial_content_left_is_clickable">なお、「ワイヤレスデバッグ」オプションの左側はクリック可能で、タップすると新しいページが表示されます。右側のスイッチだけをオンにするのは誤りです。</string>
     <string name="adb_pairing_tutorial_content_miui_2">場合によっては、通知からペアリングコードを入力できないことがあります。</string>
-    <string name="home_adb_is_limited_description">お使いの端末製造元は adb 権限を制限しており､ Shizuku を使用するアプリは正しく動作しません。
+    <string name="home_adb_is_limited_description">お使いの端末製造元は adb 権限を制限しており､ Shizuku™ を使用するアプリは正しく動作しません。
 \n
 \n通常､ この制限は「開発者向けオプション」のいくつかの項目を調整することで解除できます。これを行う方法の詳細については､ ヘルプをお読みください。
 \n
-\n操作を有効にするために､ Shizukuを再起動する必要がある場合があります。</string>
+\n操作を有効にするために､ Shizuku™を再起動する必要がある場合があります。</string>
     <string name="dialog_adb_discovery_message_toggle_wireless_debugging">検索され続ける場合は、「ワイヤレスデバッグ」の無効化と有効化をしてみてください。</string>
 </resources>

--- a/manager/src/main/res/values-ka/strings.xml
+++ b/manager/src/main/res/values-ka/strings.xml
@@ -2,7 +2,7 @@
 <resources>
     <string name="home_adb_button_view_command">ბრძანების ნახვა</string>
     <string name="home_adb_button_view_help">წაიკითხეთ დახმარება</string>
-    <string name="home_adb_description">არა დარუთული მოწყობილობებისთვის, Shizuku რომ ჩართო შენ გჭირდება ადბ-ს გამოყენება(საჭიროებს კომპიუტერთან კავშირს). ეს პროცესი უნდა გაიმეოროთ თქვენი მოწყობილობის ყოველ გადატვირთვაზე. გთხოვთ <b><a href="%1$s">წაიკითხოთ დახმარება</a></b>.</string>
+    <string name="home_adb_description">არა დარუთული მოწყობილობებისთვის, Shizuku™ რომ ჩართო შენ გჭირდება ადბ-ს გამოყენება(საჭიროებს კომპიუტერთან კავშირს). ეს პროცესი უნდა გაიმეოროთ თქვენი მოწყობილობის ყოველ გადატვირთვაზე. გთხოვთ <b><a href="%1$s">წაიკითხოთ დახმარება</a></b>.</string>
     <string name="home_adb_title">დაიწყე კომპიუტერთან დაკავშირებით</string>
     <string name="home_status_service_version_update">ვერსია %2$, %1$&lt;br&gt;თავიდან ჩართე, რომ განაახლო %3$s ვერსიაზე</string>
     <string name="home_status_service_version">ვერსია</string>

--- a/manager/src/main/res/values-ko/strings.xml
+++ b/manager/src/main/res/values-ko/strings.xml
@@ -27,7 +27,7 @@
     <string name="adb_pair_required">페어링 단계를 먼저 진행하세요.</string>
     <string name="development_settings">개발자 옵션</string>
     <string name="home_root_title">시작 (루팅된 기기용)</string>
-    <string name="home_root_description">Shizuku는 부팅 시 자동으로 시작됩니다. 그렇지 않을 경우, 시스템 또는 제 3자 도구에서 Shizuku를 제한하고 있는지 확인하세요.&lt;br&gt;%s를 참조할 수 있습니다.</string>
+    <string name="home_root_description">Shizuku™는 부팅 시 자동으로 시작됩니다. 그렇지 않을 경우, 시스템 또는 제 3자 도구에서 Shizuku™를 제한하고 있는지 확인하세요.&lt;br&gt;%s를 참조할 수 있습니다.</string>
     <string name="home_root_button_start">시작</string>
     <string name="home_root_button_restart">재시작</string>
     <string name="home_app_management_title">어플리케이션 관리</string>
@@ -35,102 +35,102 @@
     <plurals name="home_app_management_authorized_apps_count">
         <item quantity="other">%d개 앱 인증됨</item>
     </plurals>
-    <string name="home_learn_more_title">Shizuku 알아보기</string>
+    <string name="home_learn_more_title">Shizuku™ 알아보기</string>
     <string name="settings_title">설정</string>
-    <string name="home_learn_more_description">Shizuku로 개발하는 방법 알아보기</string>
-    <string name="app_management_item_summary_requires_root">* 루트 권한으로 실행된 Shizuku 필요</string>
+    <string name="home_learn_more_description">Shizuku™로 개발하는 방법 알아보기</string>
+    <string name="app_management_item_summary_requires_root">* 루트 권한으로 실행된 Shizuku™ 필요</string>
     <string name="notification_working">진행 중…</string>
     <string name="settings_startup">시작</string>
     <string name="settings_translation_contributors">번역 기여자</string>
     <string name="settings_translation">번역 참여</string>
     <string name="action_about">정보</string>
     <string name="about_view_source_code">%s에서 소스코드 보기</string>
-    <string name="action_stop">Shizuku 중지</string>
-    <string name="dialog_stop_message">Shizuku 서비스가 중지됩니다.</string>
+    <string name="action_stop">Shizuku™ 중지</string>
+    <string name="dialog_stop_message">Shizuku™ 서비스가 중지됩니다.</string>
     <string name="notification_channel_service_status">서비스 시작 상태</string>
-    <string name="notification_service_starting">Shizuku 서비스가 시작 중입니다…</string>
+    <string name="notification_service_starting">Shizuku™ 서비스가 시작 중입니다…</string>
     <string name="settings_user_interface">화면</string>
-    <string name="permission_label">Shizuku에 접근</string>
+    <string name="permission_label">Shizuku™에 접근</string>
     <string name="notification_service_start_no_root">루트 권한을 요청하지 못했습니다.</string>
     <string name="settings_start_on_boot">부팅 시 시작 (루팅)</string>
-    <string name="settings_start_on_boot_summary">루팅된 기기의 경우, Shizuku는 부팅 시 자동으로 시작할 수 있습니다</string>
+    <string name="settings_start_on_boot_summary">루팅된 기기의 경우, Shizuku™는 부팅 시 자동으로 시작할 수 있습니다</string>
     <string name="settings_translation_summary">%s를 당신의 언어로 번역할 수 있도록 도와주세요</string>
     <string name="start_with_root_failed">루트 권한이 부여되지 않았거나 이 기기가 루팅되지 않아서 서비스를 시작할 수 없습니다.</string>
     <string name="dialog_cannot_open_browser_title">브라우저를 실행할 수 없음</string>
     <string name="toast_copied_to_clipboard">%s
 \n클립보드로 복사됨.</string>
     <string name="toast_copied_to_clipboard_with_text">&lt;b&gt;%s&lt;/b&gt;가 클립보드로 복사되었습니다.</string>
-    <string name="dialog_requesting_legacy_title">%1$s가 구형 Shizuku를 요청하고 있음</string>
+    <string name="dialog_requesting_legacy_title">%1$s가 구형 Shizuku™를 요청하고 있음</string>
     <string name="settings_black_night_theme">검은 테마</string>
     <string name="starter">실행기</string>
-    <string name="dialog_requesting_legacy_button_open_shizuku">Shizuku 열기</string>
+    <string name="dialog_requesting_legacy_button_open_shizuku">Shizuku™ 열기</string>
     <string name="home_status_service_is_running">%1$s가 실행 중입니다</string>
     <string name="home_adb_title">컴퓨터에 연결하여 시작</string>
     <string name="dialog_adb_discovery_message">\"개발자 옵션\"에서 \"무선 디버깅\"을 사용으로 설정하세요. \"무선 디버깅\"은 네트워크가 변경될 때 자동으로 사용 안 함으로 변경됩니다.
 \n
-\n\"개발자 옵션\"이나 \"USB 디버깅\"을 사용 안 함으로 하면 Shizuku가 중지됩니다.</string>
+\n\"개발자 옵션\"이나 \"USB 디버깅\"을 사용 안 함으로 하면 Shizuku™가 중지됩니다.</string>
     <string name="dialog_wireless_adb_not_enabled">무선 디버깅을 사용하고 있지 않습니다.
 \n안드로이드 11 이전은 무선 디버깅을 사용하기 위해서 컴퓨터 연결을 필수로 해야 합니다.</string>
     <string name="settings_language">언어</string>
     <string name="settings_black_night_theme_summary">어두운 테마가 사용될 때 검은 테마를 사용</string>
-    <string name="notification_service_start_failed">Shizuku 서비스를 시작할 수 없습니다.</string>
+    <string name="notification_service_start_failed">Shizuku™ 서비스를 시작할 수 없습니다.</string>
     <string name="home_status_service_version">%1$s, 버전 %2$s</string>
-    <string name="home_adb_description">루링 없이 Shizuku를 시작하기 위해 adb가 필요합니다. (컴퓨터 연결 필수) 이 작업은 다시 시작 시 마다 필요로 합니다. 자세한 정보는 <b><a href="%1$s">도움말</a></b>을 확인하세요.</string>
+    <string name="home_adb_description">루링 없이 Shizuku™를 시작하기 위해 adb가 필요합니다. (컴퓨터 연결 필수) 이 작업은 다시 시작 시 마다 필요로 합니다. 자세한 정보는 <b><a href="%1$s">도움말</a></b>을 확인하세요.</string>
     <string name="home_status_service_version_update">%1$s, 버전 %2$s&lt;br&gt;다시 시작하여 버전 %3$s로 업데이트</string>
     <string name="app_management_dialog_adb_is_limited_title">ADB의 권한이 제한됨</string>
     <string name="app_management_dialog_adb_is_limited_message">기기 제조사에서 ADB의 권한을 제한하고 있을 가능성이 높습니다.&lt;p&gt;&lt;b&gt;&lt;a href=\"%1$s\"&gt;이 문서&lt;/a&gt;&lt;/b&gt;에 시스템에 대한 해결 방안이 있을 수 있습니다.</string>
-    <string name="dialog_legacy_not_support_title">%1$s는 최신 Shizuku를 지원하지 않음</string>
-    <string name="dialog_legacy_not_support_message">구형 Shizuku는 2019년 3월에 지원이 중단되었습니다. 또한, 구형 Shizuku는 새로운 안드로이드 시스템에서 동작하지 않습니다.&lt;p&gt;&lt;b&gt;%1$s&lt;/b&gt; 개발자에게 업데이트를 문의하세요.</string>
-    <string name="dialog_requesting_legacy_message">&lt;b&gt;%1$s&lt;/b&gt;가 최신 Shizuku를 지원하지만, 구형 Shizuku를 요청하고 있습니다. Shizuku가 실행 중이지 않아서 발생할 수 있으니 Shizuku 앱에서 확인하세요.&lt;p&gt;구형 Shizuku는 2019년 3월 부터 지원이 중단되었습니다.</string>
+    <string name="dialog_legacy_not_support_title">%1$s는 최신 Shizuku™를 지원하지 않음</string>
+    <string name="dialog_legacy_not_support_message">구형 Shizuku™는 2019년 3월에 지원이 중단되었습니다. 또한, 구형 Shizuku™는 새로운 안드로이드 시스템에서 동작하지 않습니다.&lt;p&gt;&lt;b&gt;%1$s&lt;/b&gt; 개발자에게 업데이트를 문의하세요.</string>
+    <string name="dialog_requesting_legacy_message">&lt;b&gt;%1$s&lt;/b&gt;가 최신 Shizuku™를 지원하지만, 구형 Shizuku™를 요청하고 있습니다. Shizuku™가 실행 중이지 않아서 발생할 수 있으니 Shizuku™ 앱에서 확인하세요.&lt;p&gt;구형 Shizuku™는 2019년 3월 부터 지원이 중단되었습니다.</string>
     <string name="grant_dialog_button_allow_always">항상 허용</string>
     <string name="grant_dialog_button_deny">거부</string>
     <string name="permission_warning_template"><b>%1$s</b>을(를) %2$s에 허용하시겠습니까\?</string>
-    <string name="adb_pairing_tutorial_content_notification">Shizuku의 알림이 페어링을 완료하는 데 도움이 될 수도 있습니다.</string>
+    <string name="adb_pairing_tutorial_content_notification">Shizuku™의 알림이 페어링을 완료하는 데 도움이 될 수도 있습니다.</string>
     <string name="adb_pairing_tutorial_content_enter_pairing_code">알림에 코드를 입력하면 페어링이 완료됩니다.</string>
     <string name="adb_pairing_tutorial_content_miui">MIUI 사용자는 시스템 설정의 \"알림\" - \"알림 창\"에서 알림 스타일을 \"Android\"로 전환해야 합니다.</string>
     <string name="adb_pairing_tutorial_content_miui_2">그렇지 않으면 알림에서 페어링 코드를 입력하지 못할 수 있습니다.</string>
     <string name="terminal_tutorial_1_description">선택한 폴더에 같은 이름의 파일이 있으면 삭제됩니다.
 \n
-\n내보내기 기능은 SAF(Storage Access Framework)를 사용합니다. MIUI가 SAF의 기능을 중단시키는 것으로 보고되었습니다. MIUI를 사용하는 경우 Shizuku의 apk에서 파일을 추출하거나 GitHub에서 다운로드해야 할 수 있습니다.</string>
+\n내보내기 기능은 SAF(Storage Access Framework)를 사용합니다. MIUI가 SAF의 기능을 중단시키는 것으로 보고되었습니다. MIUI를 사용하는 경우 Shizuku™의 apk에서 파일을 추출하거나 GitHub에서 다운로드해야 할 수 있습니다.</string>
     <string name="terminal_export_files">파일 내보내기</string>
     <string name="notification_adb_pairing_searching_for_service_title">페어링 서비스 검색중</string>
     <string name="notification_adb_pairing_failed_title">페어링 실패</string>
-    <string name="permission_description">앱이 Shizuku를 사용하도록 허용합니다.</string>
-    <string name="terminal_tutorial_2_description">예를 들어, %1$s에서 Shizuku를 사용하려면 %2$s를 %3$s로 바꿔야 합니다(%4$s는 %1$s의 패키지 이름입니다).</string>
-    <string name="rish_description">%1$s를 사용하면 모든 터미널 앱에서 Shizuku가 실행하는 셸에 연결하고 상호 작용할 수 있습니다. &lt;p&gt;자세한 사용법 %1$s에 대해 문서를 보려면 탭하세요.</string>
+    <string name="permission_description">앱이 Shizuku™를 사용하도록 허용합니다.</string>
+    <string name="terminal_tutorial_2_description">예를 들어, %1$s에서 Shizuku™를 사용하려면 %2$s를 %3$s로 바꿔야 합니다(%4$s는 %1$s의 패키지 이름입니다).</string>
+    <string name="rish_description">%1$s를 사용하면 모든 터미널 앱에서 Shizuku™가 실행하는 셸에 연결하고 상호 작용할 수 있습니다. &lt;p&gt;자세한 사용법 %1$s에 대해 문서를 보려면 탭하세요.</string>
     <string name="terminal_tutorial_2">그런 다음 텍스트 편집기를 사용하여 %1$s을 열고 편집하십시오.</string>
-    <string name="terminal_tutorial_3">마지막으로 터미널 앱이 액세스할 수 있는 위치로 파일을 이동하면 %1$s를 사용하여 Shizuku를 통해 명령을 실행할 수 있습니다.</string>
+    <string name="terminal_tutorial_3">마지막으로 터미널 앱이 액세스할 수 있는 위치로 파일을 이동하면 %1$s를 사용하여 Shizuku™를 통해 명령을 실행할 수 있습니다.</string>
     <string name="terminal_tutorial_3_description">몇 가지 팁: %1$s에 실행 권한을 부여하고 %2$s에 추가하면 %1$s를 직접 사용할 수 있습니다.</string>
     <string name="notification_channel_adb_pairing">무선 디버깅 페어링</string>
     <string name="notification_adb_pairing_input_paring_code">페어링 코드 입력</string>
-    <string name="adb_pairing_tutorial_title">기기와 Shizuku 페어링</string>
+    <string name="adb_pairing_tutorial_title">기기와 Shizuku™ 페어링</string>
     <string name="notification_adb_pairing_working_title">페어링 진행 중</string>
     <string name="notification_adb_pairing_succeed_title">페어링 성공</string>
-    <string name="notification_adb_pairing_succeed_text">지금 Shizuku 서비스를 시작할 수 있습니다.</string>
+    <string name="notification_adb_pairing_succeed_text">지금 Shizuku™ 서비스를 시작할 수 있습니다.</string>
     <string name="adb_pairing_tutorial_content_steps">\"개발자 옵션\" - \"무선 디버깅\"을 선택합니다. \"페어링 코드로 장치 페어링\"을 탭하면 6자리 코드가 표시됩니다.</string>
-    <string name="home_wireless_adb_description">Android 11 또는 그 이상 버전에서는 컴퓨터에 연결하지 않아도 무선 디버깅을 활성화하하여 기기에서 직접 Shizuku를 시작할 수 있습니다.&lt;p&gt;단계별 가이드를 먼저 확인하세요.</string>
+    <string name="home_wireless_adb_description">Android 11 또는 그 이상 버전에서는 컴퓨터에 연결하지 않아도 무선 디버깅을 활성화하하여 기기에서 직접 Shizuku™를 시작할 수 있습니다.&lt;p&gt;단계별 가이드를 먼저 확인하세요.</string>
     <string name="home_wireless_adb_description_pre_11">Android 11 이전에서는 무선 디버깅을 활성화하기 위해 컴퓨터에 연결해야 합니다.</string>
     <string name="home_wireless_adb_view_guide_button">단계별 가이드</string>
-    <string name="adb_pairing_tutorial_content_finish">Shizuku로 돌아가서 Shizuku를 시작하세요.</string>
+    <string name="adb_pairing_tutorial_content_finish">Shizuku™로 돌아가서 Shizuku™를 시작하세요.</string>
     <string name="notification_adb_pairing_service_found_title">페어링 서비스를 찾았습니다</string>
     <string name="notification_adb_pairing_stop_searching">검색 중지</string>
     <string name="notification_adb_pairing_retry">재시도</string>
     <string name="notification_settings">알림 옵션</string>
-    <string name="adb_pairing_tutorial_content_notification_blocked">페어링 프로세스에서는 Shizuku의 알림과 상호 작용해야 합니다. Shizuku가 알림을 게시하도록 허용하십시오.</string>
-    <string name="home_root_description_sui">Magisk를 사용하는 경우 %1$s 을 사용해 볼 수 있습니다. 루팅 사용자의 경우 결국 Shizuku를 대체하게 됩니다. %2$s를 사용하려면 기존 어플리케이션을 약간 변경해야 합니다.</string>
-    <string name="home_terminal_title">터미널에서 Shizuku 사용</string>
-    <string name="home_terminal_description">좋아하는 터미널 앱에서 Shizuku를 통해 명령 실행</string>
+    <string name="adb_pairing_tutorial_content_notification_blocked">페어링 프로세스에서는 Shizuku™의 알림과 상호 작용해야 합니다. Shizuku™가 알림을 게시하도록 허용하십시오.</string>
+    <string name="home_root_description_sui">Magisk를 사용하는 경우 %1$s 을 사용해 볼 수 있습니다. 루팅 사용자의 경우 결국 Shizuku™를 대체하게 됩니다. %2$s를 사용하려면 기존 어플리케이션을 약간 변경해야 합니다.</string>
+    <string name="home_terminal_title">터미널에서 Shizuku™ 사용</string>
+    <string name="home_terminal_description">좋아하는 터미널 앱에서 Shizuku™를 통해 명령 실행</string>
     <string name="terminal_tutorial_1">먼저 원하는 곳으로 파일을 내보냅니다. %1$s 및 %2$s의 두 파일을 찾을 수 있습니다.</string>
     <string name="adb_pairing_tutorial_content_left_is_clickable">\"무선 디버깅\" 옵션의 왼쪽 부분을 클릭할 수 있으며, 탭하면 새 페이지가 열립니다. 오른쪽의 스위치를 켜는 것만으로는 올바르지 않습니다.</string>
-    <string name="adb_pairing_tutorial_content_network">Shizuku는 로컬 네트워크에 액세스해야 합니다. 네트워크 권한에 의해 제어됩니다.</string>
-    <string name="adb_pairing_tutorial_content_network_limation_not_foreground">일부 시스템(예: MIUI)은 앱이 포그라운드 서비스를 표준으로 사용하더라도 앱이 보이지 않을 때 네트워크에 액세스하는 것을 허용하지 않습니다. 이러한 시스템에서 Shizuku의 배터리 최적화 기능을 비활성화하세요.</string>
-    <string name="home_adb_is_limited_description">디바이스 제조업체에서 ADB 권한을 제한하여 Shizuku를 사용하는 앱이 제대로 작동하지 않습니다.
+    <string name="adb_pairing_tutorial_content_network">Shizuku™는 로컬 네트워크에 액세스해야 합니다. 네트워크 권한에 의해 제어됩니다.</string>
+    <string name="adb_pairing_tutorial_content_network_limation_not_foreground">일부 시스템(예: MIUI)은 앱이 포그라운드 서비스를 표준으로 사용하더라도 앱이 보이지 않을 때 네트워크에 액세스하는 것을 허용하지 않습니다. 이러한 시스템에서 Shizuku™의 배터리 최적화 기능을 비활성화하세요.</string>
+    <string name="home_adb_is_limited_description">디바이스 제조업체에서 ADB 권한을 제한하여 Shizuku™를 사용하는 앱이 제대로 작동하지 않습니다.
 \n
 \n일반적으로 \'개발자 옵션\'에서 일부 옵션을 조정하여 이 제한을 해제할 수 있습니다. 자세한 방법은 도움말을 참조하세요.
 \n
-\n작업을 적용하려면 Shizuku를 다시 시작해야 할 수도 있습니다.</string>
+\n작업을 적용하려면 Shizuku™를 다시 시작해야 할 수도 있습니다.</string>
     <string name="settings_use_system_color">시스템 테마 색상 사용</string>
     <string name="home_adb_is_limited_title">추가 단계를 진행해야 합니다</string>
-    <string name="home_app_management_empty">Shizuku에 요청 또는 선언한 앱들이 여기에 표시됩니다.</string>
+    <string name="home_app_management_empty">Shizuku™에 요청 또는 선언한 앱들이 여기에 표시됩니다.</string>
     <string name="dialog_adb_discovery_message_toggle_wireless_debugging">\"무선 디버깅\"이 검색중으로 유지된다면 비활성화했다가 다시 활성화해 보세요.</string>
 </resources>

--- a/manager/src/main/res/values-pl/strings.xml
+++ b/manager/src/main/res/values-pl/strings.xml
@@ -6,15 +6,15 @@
     <string name="home_status_service_not_running">%1$s nie działa</string>
     <string name="home_status_service_is_running">%1$s działa</string>
     <string name="home_adb_button_view_command">Zobacz komendę</string>
-    <string name="home_adb_description">Dla urządzeń bez roota musisz użyć adb aby uruchomić Shizuku (wymaga podłączenia do komputera). Ten proces musi być powtarzany za każdym razem kiedy urządzenie jest uruchamiane ponownie. <b><a href="%1$s">Przeczytaj o tym artykuł</a></b>.</string>
+    <string name="home_adb_description">Dla urządzeń bez roota musisz użyć adb aby uruchomić Shizuku™ (wymaga podłączenia do komputera). Ten proces musi być powtarzany za każdym razem kiedy urządzenie jest uruchamiane ponownie. <b><a href="%1$s">Przeczytaj o tym artykuł</a></b>.</string>
     <string name="dialog_adb_port">Port</string>
     <string name="home_wireless_adb_title">Uruchom przez debugowanie bezprzewodowe</string>
     <string name="home_adb_dialog_view_command_button_send">Wyślij</string>
     <string name="home_adb_dialog_view_command_copy_button">Kopiuj</string>
     <string name="dialog_wireless_adb_not_enabled">Debugowanie bezprzewodowe jest wyłączone.
 \nPrzed Android 11 żeby włączyć debugowanie bezprzewodowe musisz mieć polączenie z komputerem.</string>
-    <string name="notification_service_starting">Usługa Shizuku się uruchamia…</string>
-    <string name="action_stop">Zatrzymaj Shizuku</string>
+    <string name="notification_service_starting">Usługa Shizuku™ się uruchamia…</string>
+    <string name="action_stop">Zatrzymaj Shizuku™</string>
     <string name="action_about">O aplikacji</string>
     <string name="settings_start_on_boot">Uruchom przy starcie systemu (tylko dla urządzeń z rootem)</string>
     <string name="settings_black_night_theme">Motyw ciemny</string>
@@ -30,7 +30,7 @@
     <string name="dialog_adb_pairing_discovery">Szukanie usługi parowania</string>
     <string name="dialog_adb_pairing_title">Sparuj z urządzeniem</string>
     <string name="adb_pairing">Parowanie</string>
-    <string name="dialog_requesting_legacy_button_open_shizuku">Otwórz Shizuku</string>
+    <string name="dialog_requesting_legacy_button_open_shizuku">Otwórz Shizuku™</string>
     <string name="dialog_cannot_open_browser_title">Nie można uruchomić przeglądarki</string>
     <string name="start_with_root_failed">Nie można uruchomić usługi ponieważ nie przyznano uprawnień root lub urządzenie nie jest zrootowane.</string>
     <string name="home_app_management_view_authorized_apps">Kliknij aby zarządzać autoryzowanymi aplikacjami</string>
@@ -43,15 +43,15 @@
     <string name="toast_copied_to_clipboard">%s
 \nzostał skopiowany do schowka.</string>
     <string name="notification_working">Działa…</string>
-    <string name="notification_service_start_failed">Błąd przy starcie usługi Shizuku.</string>
+    <string name="notification_service_start_failed">Błąd przy starcie usługi Shizuku™.</string>
     <string name="settings_startup">Rozruch</string>
-    <string name="app_management_item_summary_requires_root">* wymaga by Shizuku działało z rootem</string>
+    <string name="app_management_item_summary_requires_root">* wymaga by Shizuku™ działało z rootem</string>
     <string name="app_management_dialog_adb_is_limited_title">Uprawnienia adb są ograniczone</string>
-    <string name="home_learn_more_title">Dowiedz się więcej o Shizuku</string>
+    <string name="home_learn_more_title">Dowiedz się więcej o Shizuku™</string>
     <string name="dialog_adb_discovery_message">Proszę włączyć \"Debugowanie bezprzewodowe\" w \"Ustawieniach developerskich\". Debugowanie bezprzewodowe jest automatycznie wyłączane gdy przełączasz się między sieciami.
 \n
-\nNIE wyłączaj \"Ustawień developerskich\" lub \" Debugowania USB\" ponieważ jest wymagane do prawidłowego działania Shizuku.</string>
-    <string name="permission_label">Dostęp Shizuku</string>
+\nNIE wyłączaj \"Ustawień developerskich\" lub \" Debugowania USB\" ponieważ jest wymagane do prawidłowego działania Shizuku™.</string>
+    <string name="permission_label">Dostęp Shizuku™</string>
     <string name="grant_dialog_button_allow_always">Zawsze zezwalaj</string>
     <string name="grant_dialog_button_deny">Odmów</string>
     <string name="permission_warning_template">Zezwolić aplikacji <b>%1$s</b> na %2$s\?</string>
@@ -64,10 +64,10 @@
 \nPo rozpoczęciu procesu parowania będziesz w stanie wpisać kod parowania.</string>
     <string name="adb_pairing_requires_multi_window">Proszę, uruchom najpierw tryb podzielonego ekranu.</string>
     <string name="settings_user_interface">Wygląd</string>
-    <string name="home_root_description_sui">Jeśli używasz Magisk, możesz spróbować %1$s. Dla użytkowników roota, zamieni to Shizuku. Uwaga, istniejące aplikację muszą się dostosować by używać %2$s.</string>
-    <string name="home_terminal_title">Używaj Shizuku w aplikacjach terminala</string>
-    <string name="home_terminal_description">Uruchamiaj komendy przez Shizuku w aplikacjach terminala jakie lubisz</string>
-    <string name="home_learn_more_description">Dowiedz się, jak programować za pomocą Shizuku</string>
+    <string name="home_root_description_sui">Jeśli używasz Magisk, możesz spróbować %1$s. Dla użytkowników roota, zamieni to Shizuku™. Uwaga, istniejące aplikację muszą się dostosować by używać %2$s.</string>
+    <string name="home_terminal_title">Używaj Shizuku™ w aplikacjach terminala</string>
+    <string name="home_terminal_description">Uruchamiaj komendy przez Shizuku™ w aplikacjach terminala jakie lubisz</string>
+    <string name="home_learn_more_description">Dowiedz się, jak programować za pomocą Shizuku™</string>
     <string name="terminal_tutorial_1">Po pierwsze, Wyeksportuj pliki gdzie chcesz. Znajdziesz tam dwa pliki, %1$s i %2$s.</string>
     <plurals name="home_app_management_authorized_apps_count">
         <item quantity="one">Autoryzowano aplikację %d</item>
@@ -77,61 +77,61 @@
     </plurals>
     <string name="terminal_tutorial_1_description">Jeśli są tam pliki o takich samych nazwach, zostaną one usunięte.
 \n
-\nFunkcja eksportowania używa SAF (Storage Access Framework). Wiemy, że MIUI psuje funkcje SAF. Jeśli używasz MIUI, lepiej będzie, gdy wypakujesz pliki z pliku APK Shizuku, lub pobierzesz je z GitHuba.</string>
+\nFunkcja eksportowania używa SAF (Storage Access Framework). Wiemy, że MIUI psuje funkcje SAF. Jeśli używasz MIUI, lepiej będzie, gdy wypakujesz pliki z pliku APK Shizuku™, lub pobierzesz je z GitHuba.</string>
     <string name="terminal_tutorial_2">Wtedy, użyj edytora tekstu, by otworzyć i wyedytować %1$s.</string>
-    <string name="terminal_tutorial_2_description">Na przykład, jeśli chcesz używać Shizuku w %1$s, musisz podmienić %2$s na %3$s (%4$s jest nazwą pakietu %1$s).</string>
-    <string name="terminal_tutorial_3">Na koniec, przenieś pliki gdzieś, gdzie aplikacja terminala może się dostać, będziesz mógł użyć %1$s by uruchamiać komendy przez Shizuku.</string>
+    <string name="terminal_tutorial_2_description">Na przykład, jeśli chcesz używać Shizuku™ w %1$s, musisz podmienić %2$s na %3$s (%4$s jest nazwą pakietu %1$s).</string>
+    <string name="terminal_tutorial_3">Na koniec, przenieś pliki gdzieś, gdzie aplikacja terminala może się dostać, będziesz mógł użyć %1$s by uruchamiać komendy przez Shizuku™.</string>
     <string name="terminal_tutorial_3_description">Wskazówka: nadaj pozwolenie uruchamiania %1$s i dodaj do %2$s, mędziesz móg używać %1$s bezpośrednio.</string>
     <string name="settings_translation_contributors">Pomogli w tłumaczeniu</string>
     <string name="settings_translation_summary">Pomóż nam tłumaczyć %s na Twój język</string>
-    <string name="dialog_stop_message">Usługa Shizuku zostanie zatrzymana.</string>
+    <string name="dialog_stop_message">Usługa Shizuku™ zostanie zatrzymana.</string>
     <string name="notification_channel_service_status">Stan uruchomienia usługi</string>
-    <string name="permission_description">Pozwól aplikacji używać Shizuku.</string>
+    <string name="permission_description">Pozwól aplikacji używać Shizuku™.</string>
     <string name="notification_service_start_no_root">Nie udało się uzyskać uprawnień roota.</string>
-    <string name="dialog_legacy_not_support_title">%1$s nie wspiera nowego Shizuku</string>
-    <string name="dialog_requesting_legacy_title">%1$s żąda starego Shizuku</string>
-    <string name="dialog_requesting_legacy_message">&lt;b&gt;%1$s&lt;/b&gt; ma wsparcie dla nowego Shizuku, ale żąda starego Shizuku. Może to być spowodowane tym, że Shizuku nie działa. Prosimy o sprawdzenie w aplikacji.&lt;p&gt;Stare Shizuku nie jest wspierane od marca 2019.</string>
+    <string name="dialog_legacy_not_support_title">%1$s nie wspiera nowego Shizuku™</string>
+    <string name="dialog_requesting_legacy_title">%1$s żąda starego Shizuku™</string>
+    <string name="dialog_requesting_legacy_message">&lt;b&gt;%1$s&lt;/b&gt; ma wsparcie dla nowego Shizuku™, ale żąda starego Shizuku™. Może to być spowodowane tym, że Shizuku™ nie działa. Prosimy o sprawdzenie w aplikacji.&lt;p&gt;Stare Shizuku™ nie jest wspierane od marca 2019.</string>
     <string name="toast_copied_to_clipboard_with_text"><b>%s</b> został skopiowany do schowka.</string>
     <string name="starter">Uruchamiacz</string>
-    <string name="home_root_description">W dodatku, Shizuku może wystartować automatycznie przy starcie systemu. Jeśli nie, sprawdź czy system lub inne narzędzia zablokowały Shizuku.&lt;br&gt;Możesz odwołać się do%s.</string>
+    <string name="home_root_description">W dodatku, Shizuku™ może wystartować automatycznie przy starcie systemu. Jeśli nie, sprawdź czy system lub inne narzędzia zablokowały Shizuku™.&lt;br&gt;Możesz odwołać się do%s.</string>
     <string name="settings_translation">Przyłącz się do tłumaczenia</string>
-    <string name="settings_start_on_boot_summary">W urządzeniach zrootowanych, Shizuku może się uruchamiać automatycznie</string>
+    <string name="settings_start_on_boot_summary">W urządzeniach zrootowanych, Shizuku™ może się uruchamiać automatycznie</string>
     <string name="about_view_source_code">Zobacz kod źródłowy na %s</string>
     <string name="adb_error_key_store">Nie można wygenerować klucza debugowania bezprzewodowego.
 \nMoże to być spowodowane tym, że mechanizm KeyStore urządzenia jest zepsuty.</string>
     <string name="app_management_dialog_adb_is_limited_message">Jest duże prawdopodobieństwo, że producent urządzenia ogranicza możliwości ADB.&lt;p&gt;Może być rozwiązanie dla twojego systemu w &lt;b&gt; &lt;a href=\"%1$s\"&gt;tym dokumencie&lt;/a&gt;&lt;/b&gt;.</string>
-    <string name="rish_description">Z %1$s, w każdej aplikacji terminala, będziesz mógł połączyć się i wykonywać interakcje z shellem działającym w Shizuku.&lt;p&gt;O szczegółowym użyciu %1$s, dotknij by pokazać dokument.</string>
-    <string name="dialog_legacy_not_support_message">Stare Shizuku utraciło wsparcie w marcu 2019 roku. Oraz stare Shizuku nie działa na nowszych wersjach Androida.&lt;p&gt;Poproś developera &lt;b&gt;%1$s&lt;/b&gt; o aktualizację.</string>
-    <string name="home_wireless_adb_description">Od systemu Android w wersji 11 możesz używać debugowania za pomocą sieci Wifi i za pomocą tego uruchamiać Shizuku bezpośrednio z urządzenia, bez potrzeby podłączania do komputera.&lt;p&gt;Przejrzyj instrukcje krok po kroku żeby dowiedzieć się jak to skonfigurować.</string>
+    <string name="rish_description">Z %1$s, w każdej aplikacji terminala, będziesz mógł połączyć się i wykonywać interakcje z shellem działającym w Shizuku™.&lt;p&gt;O szczegółowym użyciu %1$s, dotknij by pokazać dokument.</string>
+    <string name="dialog_legacy_not_support_message">Stare Shizuku™ utraciło wsparcie w marcu 2019 roku. Oraz stare Shizuku™ nie działa na nowszych wersjach Androida.&lt;p&gt;Poproś developera &lt;b&gt;%1$s&lt;/b&gt; o aktualizację.</string>
+    <string name="home_wireless_adb_description">Od systemu Android w wersji 11 możesz używać debugowania za pomocą sieci Wifi i za pomocą tego uruchamiać Shizuku™ bezpośrednio z urządzenia, bez potrzeby podłączania do komputera.&lt;p&gt;Przejrzyj instrukcje krok po kroku żeby dowiedzieć się jak to skonfigurować.</string>
     <string name="home_wireless_adb_description_pre_11">Dla systemów Android w wersji 10 i starszej wymagane jest podłączenie do komputera w celu uruchomienia debugowania za pomocą sieci Wifi.</string>
     <string name="adb_pairing_tutorial_content_miui">Użytkownicy MIUI mogą potrzebować zmiany stylu powiadomień na \"Android\". Zmiana ta jest możliwa w menu ustawień systemu \"Powiadomienia\" - \"Styl powiadomień\".</string>
     <string name="notification_channel_adb_pairing">Parowanie debugowania bezprzewodowego</string>
     <string name="notification_adb_pairing_input_paring_code">Wprowadź kod parowania</string>
     <string name="adb_pairing_tutorial_content_enter_pairing_code">Wprowadź kod parowania w okienku powiadomienia aby ukończyć parowanie.</string>
-    <string name="adb_pairing_tutorial_content_notification">Powiadomienie od Shizuku pomoże w dokończeniu parowania.</string>
+    <string name="adb_pairing_tutorial_content_notification">Powiadomienie od Shizuku™ pomoże w dokończeniu parowania.</string>
     <string name="adb_pairing_tutorial_content_steps">Wejdź w menu \"Opcje programistyczne\" - \"Debugowanie bezprzewodowe\". Tapnij \"Sparuj urządzenie przy pomocy kodu parowania\" i zobaczysz 6-cio cyfrowy kod parowania.</string>
     <string name="notification_adb_pairing_retry">Ponów</string>
     <string name="notification_adb_pairing_failed_title">Parowanie nie powiodło się</string>
-    <string name="adb_pairing_tutorial_title">Sparuj Shizuku ze swoim urządzeniem</string>
+    <string name="adb_pairing_tutorial_title">Sparuj Shizuku™ ze swoim urządzeniem</string>
     <string name="home_wireless_adb_view_guide_button">Instrukcja krok po kroku</string>
-    <string name="adb_pairing_tutorial_content_finish">Wróć do aplikacji Shizuku i uruchom Shizuku.</string>
+    <string name="adb_pairing_tutorial_content_finish">Wróć do aplikacji Shizuku™ i uruchom Shizuku™.</string>
     <string name="notification_adb_pairing_searching_for_service_title">Wyszukiwanie usługi parowania</string>
     <string name="notification_adb_pairing_service_found_title">Znaleziono usługę parowania</string>
     <string name="notification_adb_pairing_stop_searching">Przestań szukać</string>
     <string name="notification_adb_pairing_working_title">Parowanie w trakcie</string>
     <string name="notification_adb_pairing_succeed_title">Parowanie przebiegło pomyślnie</string>
-    <string name="notification_adb_pairing_succeed_text">Możesz teraz wystartować usługę Shizuku.</string>
+    <string name="notification_adb_pairing_succeed_text">Możesz teraz wystartować usługę Shizuku™.</string>
     <string name="notification_settings">Ustawienia powiadomień</string>
-    <string name="adb_pairing_tutorial_content_notification_blocked">Proces parowania wymaga twojej interakcji z powiadomieniem od Shizuku. Zezwol Shizuku na wyświetlanie powiadomień.</string>
-    <string name="home_adb_is_limited_description">Producent Twojego urządzenia ograniczył uprawnienia adb, a aplikacje korzystające z Shizuku nie będą działać poprawnie.
+    <string name="adb_pairing_tutorial_content_notification_blocked">Proces parowania wymaga twojej interakcji z powiadomieniem od Shizuku™. Zezwol Shizuku™ na wyświetlanie powiadomień.</string>
+    <string name="home_adb_is_limited_description">Producent Twojego urządzenia ograniczył uprawnienia adb, a aplikacje korzystające z Shizuku™ nie będą działać poprawnie.
 \n
 \nZwykle to ograniczenie można znieść, dostosowując niektóre opcje w „Opcjach programisty”. Przeczytaj pomoc, aby dowiedzieć się, jak to zrobić.
 \n
-\nMoże być konieczne ponowne uruchomienie Shizuku, aby operacja zaczęła obowiązywać.</string>
+\nMoże być konieczne ponowne uruchomienie Shizuku™, aby operacja zaczęła obowiązywać.</string>
     <string name="home_adb_is_limited_title">Musisz zrobić dodatkowy krok</string>
-    <string name="home_app_management_empty">Tutaj pojawią się aplikacje, które zażądały lub zadeklarowały Shizuku.</string>
-    <string name="adb_pairing_tutorial_content_network_limation_not_foreground">Niektóre systemy (takie jak MIUI) nie zezwalają aplikacjom na dostęp do sieci, gdy nie są one widoczne, nawet jeśli aplikacja standardowo korzysta z usługi pierwszego planu. Proszę wyłączyć funkcje optymalizacji baterii dla Shizuku w takich systemach.</string>
-    <string name="adb_pairing_tutorial_content_network">Shizuku potrzebuje dostęp do sieci lokalnej. Jest kontrolowany przez pozwolenie sieciowe.</string>
+    <string name="home_app_management_empty">Tutaj pojawią się aplikacje, które zażądały lub zadeklarowały Shizuku™.</string>
+    <string name="adb_pairing_tutorial_content_network_limation_not_foreground">Niektóre systemy (takie jak MIUI) nie zezwalają aplikacjom na dostęp do sieci, gdy nie są one widoczne, nawet jeśli aplikacja standardowo korzysta z usługi pierwszego planu. Proszę wyłączyć funkcje optymalizacji baterii dla Shizuku™ w takich systemach.</string>
+    <string name="adb_pairing_tutorial_content_network">Shizuku™ potrzebuje dostęp do sieci lokalnej. Jest kontrolowany przez pozwolenie sieciowe.</string>
     <string name="adb_pairing_tutorial_content_left_is_clickable">Należy pamiętać, że lewą część opcji „Debugowanie sieci bezprzewodowej” można kliknąć, dotknięcie jej spowoduje otwarcie nowej strony. Jedynie włączenie przełącznika po prawej stronie jest nieprawidłowe.</string>
     <string name="adb_pairing_tutorial_content_miui_2">W przeciwnym razie wprowadzenie kodu parowania z powiadomienia może nie być możliwe.</string>
     <string name="dialog_adb_discovery_message_toggle_wireless_debugging">Proszę spróbować wyłączyć i włączyć ponownie \"Debugowanie bezprzewodowe\" jeśli nadal szuka.</string>

--- a/manager/src/main/res/values-pt-rBR/strings.xml
+++ b/manager/src/main/res/values-pt-rBR/strings.xml
@@ -8,29 +8,29 @@
     <string name="grant_dialog_button_deny">Negar</string>
     <string name="grant_dialog_button_allow_always">Permitir o tempo todo</string>
     <string name="permission_warning_template">Permitir que o app &lt;b&gt;%1$s&lt;/b&gt; %2$s\?</string>
-    <string name="dialog_requesting_legacy_button_open_shizuku">Abrir Shizuku</string>
-    <string name="dialog_requesting_legacy_message">&lt;b&gt;%1$s&lt;/b&gt; tem suporte a Shizuku moderno, mas está solicitando o Shizuku legado. Isso pode acontecer porque o Shizuku não está funcionando, verifique no aplicativo Shizuku.&lt;p&gt;O Shizuku legado foi descontinuado desde março de 2019.</string>
-    <string name="dialog_requesting_legacy_title">%1$s está pedindo o Shizuku legado</string>
-    <string name="dialog_legacy_not_support_message">O Shizuku legado está obsoleto desde março de 2019. Além disso, o Shizuku legado não funciona em sistemas Android mais recentes.&lt;p&gt;Peça ao desenvolvedor de &lt;b&gt;%1$s&lt;/b&gt; para atualizar.</string>
-    <string name="dialog_legacy_not_support_title">%1$s não suporta as versões novas do Shizuku</string>
+    <string name="dialog_requesting_legacy_button_open_shizuku">Abrir Shizuku™</string>
+    <string name="dialog_requesting_legacy_message">&lt;b&gt;%1$s&lt;/b&gt; tem suporte a Shizuku™ moderno, mas está solicitando o Shizuku™ legado. Isso pode acontecer porque o Shizuku™ não está funcionando, verifique no aplicativo Shizuku™.&lt;p&gt;O Shizuku™ legado foi descontinuado desde março de 2019.</string>
+    <string name="dialog_requesting_legacy_title">%1$s está pedindo o Shizuku™ legado</string>
+    <string name="dialog_legacy_not_support_message">O Shizuku™ legado está obsoleto desde março de 2019. Além disso, o Shizuku™ legado não funciona em sistemas Android mais recentes.&lt;p&gt;Peça ao desenvolvedor de &lt;b&gt;%1$s&lt;/b&gt; para atualizar.</string>
+    <string name="dialog_legacy_not_support_title">%1$s não suporta as versões novas do Shizuku™</string>
     <string name="toast_copied_to_clipboard_with_text"><b>%s</b> copiado com sucesso.</string>
     <string name="toast_copied_to_clipboard">%s
 \nfoi copiado com sucesso.</string>
     <string name="dialog_cannot_open_browser_title">Não consigo iniciar o navegador</string>
     <string name="start_with_root_failed">Não é possível iniciar o serviço porque a permissão de root não foi concedida ou este aparelho não está rooteado.</string>
     <string name="starter">Iniciante</string>
-    <string name="permission_description">Permita que o aplicativo use o Shizuku.</string>
-    <string name="permission_label">acessar Shizuku</string>
+    <string name="permission_description">Permita que o aplicativo use o Shizuku™.</string>
+    <string name="permission_label">acessar Shizuku™</string>
     <string name="notification_working">Em andamento…</string>
     <string name="notification_service_start_no_root">Falha ao solicitar acesso ao root.</string>
-    <string name="notification_service_start_failed">Falha ao iniciar o serviço do Shizuku.</string>
-    <string name="notification_service_starting">O serviço do Shizuku está iniciando…</string>
+    <string name="notification_service_start_failed">Falha ao iniciar o serviço do Shizuku™.</string>
+    <string name="notification_service_starting">O serviço do Shizuku™ está iniciando…</string>
     <string name="notification_channel_service_status">Status de início do serviço</string>
-    <string name="dialog_stop_message">O serviço do Shizuku será interrompido.</string>
-    <string name="action_stop">Parar o Shizuku</string>
+    <string name="dialog_stop_message">O serviço do Shizuku™ será interrompido.</string>
+    <string name="action_stop">Parar o Shizuku™</string>
     <string name="about_view_source_code">Ver o código-fonte no %s</string>
     <string name="action_about">Sobre</string>
-    <string name="settings_start_on_boot_summary">Para dispositivos com acesso root, o Shizuku é capaz de abrir automaticamente na inicialização do sistema</string>
+    <string name="settings_start_on_boot_summary">Para dispositivos com acesso root, o Shizuku™ é capaz de abrir automaticamente na inicialização do sistema</string>
     <string name="settings_start_on_boot">Iniciar APP no boot (apenas com root)</string>
     <string name="settings_translation_summary">Ajude-nos à traduzir %s para o seu idioma</string>
     <string name="settings_translation">Contribua com a tradução</string>
@@ -41,11 +41,11 @@
     <string name="settings_user_interface">Aparência</string>
     <string name="settings_language">Idioma</string>
     <string name="settings_title">Configurações</string>
-    <string name="app_management_item_summary_requires_root">* precisa do Shizuku executado com privilégios de root</string>
+    <string name="app_management_item_summary_requires_root">* precisa do Shizuku™ executado com privilégios de root</string>
     <string name="app_management_dialog_adb_is_limited_message">É bem provável que o fabricante do seu dispositivo limite a permissão do ADB.&lt;p&gt;Pode haver uma solução para seu sistema &lt;b&gt;&lt;a href=\"%1$s\"&gt;neste documento&lt;/a&gt;&lt;/b&gt;.</string>
     <string name="app_management_dialog_adb_is_limited_title">A permissão do ADB é limitada</string>
-    <string name="home_learn_more_description">Aprenda a desenvolver com Shizuku</string>
-    <string name="home_learn_more_title">Aprenda sobre Shizuku</string>
+    <string name="home_learn_more_description">Aprenda a desenvolver com Shizuku™</string>
+    <string name="home_learn_more_title">Aprenda sobre Shizuku™</string>
     <string name="home_app_management_view_authorized_apps">Toque para gerenciar os aplicativos autorizados</string>
     <plurals name="home_app_management_authorized_apps_count">
         <item quantity="one">%d aplicativo autorizado</item>
@@ -54,8 +54,8 @@
     <string name="home_app_management_title">Gerenciador de aplicativos</string>
     <string name="home_root_button_restart">Reiniciar</string>
     <string name="home_root_button_start">Começar</string>
-    <string name="home_root_description_sui">Se você estiver usando Magisk, você pode tentar %1$s. Para usuários rooteados, ele eventualmente substituirá Shizuku. Observe: os aplicativos existentes precisam mudar um pouco para usar %2$s.</string>
-    <string name="home_root_description">Além disso, o Shizuku pode ser iniciado automaticamente ao ligar o aparelho. Caso contrário, verifique se o seu sistema ou ferramentas de terceiros restringem Shizuku.&lt;br&gt;Você pode se referir a %s.</string>
+    <string name="home_root_description_sui">Se você estiver usando Magisk, você pode tentar %1$s. Para usuários rooteados, ele eventualmente substituirá Shizuku™. Observe: os aplicativos existentes precisam mudar um pouco para usar %2$s.</string>
+    <string name="home_root_description">Além disso, o Shizuku™ pode ser iniciado automaticamente ao ligar o aparelho. Caso contrário, verifique se o seu sistema ou ferramentas de terceiros restringem Shizuku™.&lt;br&gt;Você pode se referir a %s.</string>
     <string name="home_root_title">Começar (para aparelhos rooteados)</string>
     <string name="development_settings">Opções do Desenvolvedor</string>
     <string name="adb_pair_required">Execute o primeiro passo de pareamento.</string>
@@ -78,7 +78,7 @@
     <string name="dialog_adb_invalid_port">A porta é um número inteiro que varia de 1 a 65535.</string>
     <string name="dialog_adb_discovery_message">Por favor, ative \"Depuração via Wireless\" ou \"Depuração via Wi-Fi\" nas \"Opções do Desenvolvedor\". A Depuração via Wireless é, automaticamente, desativada ao trocar de rede.
 \n
-\nObserve, não desative \"Opções do Desenvolvedor\" ou \"Depuração via USB\", ou o Shizuku será interrompido.</string>
+\nObserve, não desative \"Opções do Desenvolvedor\" ou \"Depuração via USB\", ou o Shizuku™ será interrompido.</string>
     <string name="dialog_adb_discovery">Procurando o serviço de Depuração via Wireless</string>
     <string name="home_adb_dialog_view_command_message">&lt;font face=monospace&gt;%1$s&lt;/font&gt;&lt;br&gt;&lt;br&gt;* Existem algumas outras considerações, por favor confirme se você leu o documento de ajuda primeiro.</string>
     <string name="home_wireless_adb_title">Começar pela Depuração via Wireless</string>
@@ -86,52 +86,52 @@
     <string name="home_adb_dialog_view_command_copy_button">Copiar</string>
     <string name="home_adb_button_view_command">Ver o comando</string>
     <string name="home_adb_button_view_help">Ler a ajuda</string>
-    <string name="home_adb_description">Para aparelhos sem ROOT, será necessário usar o ADB para iniciar o Shizuku (requer conexão ao computador). Este processo precisa ser repetido sempre que o aparelho for reiniciado. Por favor <b><a href="%1$s">leia a ajuda</a></b>.</string>
+    <string name="home_adb_description">Para aparelhos sem ROOT, será necessário usar o ADB para iniciar o Shizuku™ (requer conexão ao computador). Este processo precisa ser repetido sempre que o aparelho for reiniciado. Por favor <b><a href="%1$s">leia a ajuda</a></b>.</string>
     <string name="home_adb_title">Comece conectando-se a um computador</string>
-    <string name="terminal_tutorial_3">Finalmente, mova os arquivos para algum lugar onde seu aplicativo terminal possa acessar, você poderá usar %1$s para executar comandos através do Shizuku.</string>
+    <string name="terminal_tutorial_3">Finalmente, mova os arquivos para algum lugar onde seu aplicativo terminal possa acessar, você poderá usar %1$s para executar comandos através do Shizuku™.</string>
     <string name="terminal_tutorial_3_description">Algumas dicas: conceda permissão de execução a %1$s e adicione-a a %2$s, você poderá usar %1$s diretamente.</string>
-    <string name="terminal_tutorial_2_description">Por exemplo, se quiser usar o Shizuku em %1$s, você deve substituir %2$s por %3$s (%4$s é o nome de pacote de %1$s).</string>
+    <string name="terminal_tutorial_2_description">Por exemplo, se quiser usar o Shizuku™ em %1$s, você deve substituir %2$s por %3$s (%4$s é o nome de pacote de %1$s).</string>
     <string name="terminal_tutorial_2">Agora, use algum editor de texto para abrir e editar %1$s.</string>
     <string name="terminal_export_files">Exportar arquivos</string>
     <string name="terminal_tutorial_1_description">Se houver arquivos com o mesmo nome na pasta selecionada, eles serão excluídos.
 \n
-\nA função de exportação usa SAF (Storage Access Framework). É relatado que a MIUI quebra as funções do SAF. Se você estiver usando a MIUI, você pode ter que extrair o arquivo do apk do Shizuku ou baixar do GitHub.</string>
-    <string name="home_terminal_description">Executar comandos pelo Shizuku no seu app de terminal preferido</string>
+\nA função de exportação usa SAF (Storage Access Framework). É relatado que a MIUI quebra as funções do SAF. Se você estiver usando a MIUI, você pode ter que extrair o arquivo do apk do Shizuku™ ou baixar do GitHub.</string>
+    <string name="home_terminal_description">Executar comandos pelo Shizuku™ no seu app de terminal preferido</string>
     <string name="terminal_tutorial_1">Primeiro, exporte os arquivos para onde quiser. Serão dois arquivos: %1$s e %2$s.</string>
-    <string name="home_terminal_title">Usar o Shizuku em apps de terminal</string>
-    <string name="rish_description">Com %1$s, em qualquer aplicativo de terminal, você pode se conectar e interagir com o shell executado pelo Shizuku. &lt;p&gt; Sobre o uso detalhado %1$s, toque para ver o documento.</string>
+    <string name="home_terminal_title">Usar o Shizuku™ em apps de terminal</string>
+    <string name="rish_description">Com %1$s, em qualquer aplicativo de terminal, você pode se conectar e interagir com o shell executado pelo Shizuku™. &lt;p&gt; Sobre o uso detalhado %1$s, toque para ver o documento.</string>
     <string name="notification_adb_pairing_failed_title">Falha no pareamento</string>
     <string name="adb_pairing_tutorial_content_miui">Os usuários da MIUI podem precisar mudar o estilo de notificação de \"MIUI\" para \"Android\". Para isso, acesse \"Configurações\", em seguida toque em \"Notificações\", em seguida toque em \"Área de Notificação\". Se você não usa MIUI, ignore isso.</string>
     <string name="notification_adb_pairing_succeed_title">Pareamento concluído</string>
     <string name="adb_pairing_tutorial_content_steps">Acesse as \"Opções do desenvolvedor\", em seguida \"Depuração por Wi-Fi\". Toque em \"Parear o dispositivo com código de pareamento\", você verá um código de seis dígitos.</string>
     <string name="adb_pairing_tutorial_content_enter_pairing_code">Digite o código de 6 dígitos na notificação para concluir o pareamento.</string>
-    <string name="adb_pairing_tutorial_content_notification">Uma notificação do Shizuku ajudará você a concluir o pareamento.</string>
+    <string name="adb_pairing_tutorial_content_notification">Uma notificação do Shizuku™ ajudará você a concluir o pareamento.</string>
     <string name="notification_adb_pairing_service_found_title">Serviço de pareamento encontrado</string>
     <string name="notification_adb_pairing_stop_searching">Parar de procurar</string>
     <string name="notification_adb_pairing_working_title">Processando pareamento</string>
-    <string name="notification_adb_pairing_succeed_text">Agora, você pode iniciar o serviço do Shizuku.</string>
-    <string name="adb_pairing_tutorial_title">Parear Shizuku com seu dispositivo</string>
-    <string name="home_wireless_adb_description">No Android 11 ou superior, você pode ativar a Depuração via Wireless e iniciar o Shizuku diretamente do seu dispositivo, sem se conectar a um computador. &lt;p&gt; Primeiro, consulte esse guia passo a passo.</string>
+    <string name="notification_adb_pairing_succeed_text">Agora, você pode iniciar o serviço do Shizuku™.</string>
+    <string name="adb_pairing_tutorial_title">Parear Shizuku™ com seu dispositivo</string>
+    <string name="home_wireless_adb_description">No Android 11 ou superior, você pode ativar a Depuração via Wireless e iniciar o Shizuku™ diretamente do seu dispositivo, sem se conectar a um computador. &lt;p&gt; Primeiro, consulte esse guia passo a passo.</string>
     <string name="home_wireless_adb_description_pre_11">Antes do Android 11, é necessário conectar-se a um computador para habilitar a Depuração via Wireless.</string>
     <string name="home_wireless_adb_view_guide_button">Guia passo a passo</string>
-    <string name="adb_pairing_tutorial_content_finish">Volte para Shizuku e inicie o Shizuku.</string>
+    <string name="adb_pairing_tutorial_content_finish">Volte para Shizuku™ e inicie o Shizuku™.</string>
     <string name="notification_settings">Opções de notificações</string>
-    <string name="adb_pairing_tutorial_content_notification_blocked">O processo de pareamento precisa que você interaja com uma notificação do Shizuku. Por favor, permita que o Shizuku envie notificações.</string>
+    <string name="adb_pairing_tutorial_content_notification_blocked">O processo de pareamento precisa que você interaja com uma notificação do Shizuku™. Por favor, permita que o Shizuku™ envie notificações.</string>
     <string name="notification_channel_adb_pairing">Pareamento da Depuração via Wireless</string>
     <string name="notification_adb_pairing_input_paring_code">Digite o código de pareamento</string>
     <string name="notification_adb_pairing_searching_for_service_title">Procurando serviço de pareamento</string>
     <string name="notification_adb_pairing_retry">Tentar novamente</string>
-    <string name="adb_pairing_tutorial_content_network_limation_not_foreground">‎Alguns sistemas (como a MIUI) não permitem que aplicativos acessem a rede quando não estão visíveis, mesmo que o aplicativo use o serviço em primeiro plano como padrão. Por favor, desabilitar os recursos de otimização da bateria para o Shizuku em tais sistemas.</string>
+    <string name="adb_pairing_tutorial_content_network_limation_not_foreground">‎Alguns sistemas (como a MIUI) não permitem que aplicativos acessem a rede quando não estão visíveis, mesmo que o aplicativo use o serviço em primeiro plano como padrão. Por favor, desabilitar os recursos de otimização da bateria para o Shizuku™ em tais sistemas.</string>
     <string name="adb_pairing_tutorial_content_left_is_clickable">‎Por favor, note que a parte esquerda da opção \"Depuração sem fio\" é clicável, tocando nela abrirá uma nova página. Apenas ligar o interruptor à direita está incorreto.</string>
     <string name="adb_pairing_tutorial_content_miui_2">‎Caso contrário, você pode não conseguir inserir o código de paring a partir da notificação.</string>
-    <string name="adb_pairing_tutorial_content_network">Shizuku precisa acessar a rede local. É controlado pela permissão da rede.</string>
+    <string name="adb_pairing_tutorial_content_network">Shizuku™ precisa acessar a rede local. É controlado pela permissão da rede.</string>
     <string name="settings_use_system_color">Usar tema do sistema</string>
     <string name="home_adb_is_limited_title">Você precisa de um passo adicional</string>
-    <string name="home_app_management_empty">Apps que solicitaram ou declararam acesso ao Shizuku aparecerão aqui.</string>
+    <string name="home_app_management_empty">Apps que solicitaram ou declararam acesso ao Shizuku™ aparecerão aqui.</string>
     <string name="dialog_adb_discovery_message_toggle_wireless_debugging">Por favor, tente desativar e reativar a \"Depuração por Wi-Fi\" se não parar de ficar procurando.</string>
-    <string name="home_adb_is_limited_description">O fabricante do seu dispositivo restringiu as permissões ADB e os apps que usam o Shizuku não funcionarão corretamente.
+    <string name="home_adb_is_limited_description">O fabricante do seu dispositivo restringiu as permissões ADB e os apps que usam o Shizuku™ não funcionarão corretamente.
 \n
 \nNormalmente, essa limitação pode ser eliminada ajustando algumas opções nas “Opções do desenvolvedor”. Por favor, leia a ajuda para obter detalhes sobre como fazer isso.
 \n
-\nPode ser necessário reiniciar o Shizuku para que a operação tenha efeito.</string>
+\nPode ser necessário reiniciar o Shizuku™ para que a operação tenha efeito.</string>
 </resources>

--- a/manager/src/main/res/values-pt/strings.xml
+++ b/manager/src/main/res/values-pt/strings.xml
@@ -2,12 +2,12 @@
 <resources>
     <string name="terminal_tutorial_1_description">Se houver arquivos com o mesmo nome na pasta selecionada, eles serão excluídos.
 \n
-\nA função de exportação usa SAF (Storage Access Framework). É relatado que o MIUI quebra as funções do SAF. Se você estiver usando o MIUI, talvez seja necessário extrair o arquivo do Shizuku em apk para download no Github.</string>
-    <string name="dialog_requesting_legacy_button_open_shizuku">Abrir Shizuku</string>
-    <string name="dialog_requesting_legacy_message">&lt;b&gt;%1$s&lt;/b&gt; tem suporte moderno para Shizuku, mas está solicitando Shizuku legado. Isso pode acontecer porque o Shizuku não está em execução. Verifique no aplicativo Shizuku.&lt;p&gt;O uso do Shizuku legado foi suspenso desde março de 2019.</string>
-    <string name="dialog_requesting_legacy_title">%1$s está solicitando Shizuku</string>
-    <string name="dialog_legacy_not_support_message">O Shizuku legado está obsoleto desde março de 2019. Além disso, o Shizuku legado não funciona em sistemas Android mais recentes.&lt;p&gt;Peça ao desenvolvedor de &lt;b&gt;%1$s&lt;/b&gt; para atualizar.</string>
-    <string name="dialog_legacy_not_support_title">%1$s não é compatível com Shizuku</string>
+\nA função de exportação usa SAF (Storage Access Framework). É relatado que o MIUI quebra as funções do SAF. Se você estiver usando o MIUI, talvez seja necessário extrair o arquivo do Shizuku™ em apk para download no Github.</string>
+    <string name="dialog_requesting_legacy_button_open_shizuku">Abrir Shizuku™</string>
+    <string name="dialog_requesting_legacy_message">&lt;b&gt;%1$s&lt;/b&gt; tem suporte moderno para Shizuku™, mas está solicitando Shizuku™ legado. Isso pode acontecer porque o Shizuku™ não está em execução. Verifique no aplicativo Shizuku™.&lt;p&gt;O uso do Shizuku™ legado foi suspenso desde março de 2019.</string>
+    <string name="dialog_requesting_legacy_title">%1$s está solicitando Shizuku™</string>
+    <string name="dialog_legacy_not_support_message">O Shizuku™ legado está obsoleto desde março de 2019. Além disso, o Shizuku™ legado não funciona em sistemas Android mais recentes.&lt;p&gt;Peça ao desenvolvedor de &lt;b&gt;%1$s&lt;/b&gt; para atualizar.</string>
+    <string name="dialog_legacy_not_support_title">%1$s não é compatível com Shizuku™</string>
     <string name="toast_copied_to_clipboard_with_text"><b>%s</b> foi copiado para a área de transferência.</string>
     <string name="toast_copied_to_clipboard">%s
 \nfoi copiado para a área de transferência.</string>
@@ -17,11 +17,11 @@
     <string name="grant_dialog_button_deny">Negar</string>
     <string name="grant_dialog_button_allow_always">Permitir o tempo todo</string>
     <string name="permission_warning_template">Permitir <b>%1$s</b> a %2$s\?</string>
-    <string name="permission_description">Permita que o aplicativo use o Shizuku.</string>
-    <string name="permission_label">Acessar Shizuku</string>
+    <string name="permission_description">Permita que o aplicativo use o Shizuku™.</string>
+    <string name="permission_label">Acessar Shizuku™</string>
     <string name="notification_adb_pairing_retry">Repetir</string>
     <string name="notification_adb_pairing_failed_title">Pareamento falhou</string>
-    <string name="notification_adb_pairing_succeed_text">Você pode iniciar o serviço Shizuku agora.</string>
+    <string name="notification_adb_pairing_succeed_text">Você pode iniciar o serviço Shizuku™ agora.</string>
     <string name="notification_adb_pairing_succeed_title">Pareamento bem sucedido</string>
     <string name="notification_adb_pairing_working_title">Emparelhamento em progresso</string>
     <string name="notification_adb_pairing_stop_searching">Parar pesquisa</string>
@@ -31,15 +31,15 @@
     <string name="notification_channel_adb_pairing">Emparelhamento de depuração sem fio</string>
     <string name="notification_working">Trabalhando…</string>
     <string name="notification_service_start_no_root">Falha ao solicitar permissão de root.</string>
-    <string name="notification_service_start_failed">Falha ao iniciar o serviço Shizuku.</string>
-    <string name="notification_service_starting">O serviço de Shizuku está começando…</string>
+    <string name="notification_service_start_failed">Falha ao iniciar o serviço Shizuku™.</string>
+    <string name="notification_service_starting">O serviço de Shizuku™ está começando…</string>
     <string name="notification_channel_service_status">Status de início do serviço</string>
-    <string name="dialog_stop_message">O serviço de Shizuku será interrompido.</string>
-    <string name="action_stop">Parar Shizuku</string>
+    <string name="dialog_stop_message">O serviço de Shizuku™ será interrompido.</string>
+    <string name="action_stop">Parar Shizuku™</string>
     <string name="about_view_source_code">Veja o código-fonte em %s</string>
     <string name="action_about">Sobre</string>
     <string name="settings_use_system_color">Use o tema do sistema</string>
-    <string name="settings_start_on_boot_summary">Para dispositivos com root, o Shizuku pode iniciar automaticamente na inicialização</string>
+    <string name="settings_start_on_boot_summary">Para dispositivos com root, o Shizuku™ pode iniciar automaticamente na inicialização</string>
     <string name="settings_start_on_boot">Iniciar na inicialização (root)</string>
     <string name="settings_translation_summary">Ajude-nos a traduzir %s para o seu idioma</string>
     <string name="settings_translation">Participe da tradução</string>
@@ -50,20 +50,20 @@
     <string name="settings_user_interface">Aparência</string>
     <string name="settings_language">Idioma</string>
     <string name="settings_title">Configurações</string>
-    <string name="rish_description">Com %1$s, em qualquer aplicativo de terminal, você pode se conectar e interagir com o shell executado pelo Shizuku. &lt;p&gt;Sobre o uso detalhado %1$s, toque para visualizar o documento.</string>
+    <string name="rish_description">Com %1$s, em qualquer aplicativo de terminal, você pode se conectar e interagir com o shell executado pelo Shizuku™. &lt;p&gt;Sobre o uso detalhado %1$s, toque para visualizar o documento.</string>
     <string name="terminal_tutorial_3_description">Algumas dicas: conceda permissão de execução para %1$s e adicione-a a %2$s, você poderá usar %1$s diretamente.</string>
-    <string name="terminal_tutorial_3">Finalmente, mova os arquivos para algum lugar onde seu aplicativo de terminal possa acessar, você poderá usar %1$s para executar comandos através do Shizuku.</string>
-    <string name="terminal_tutorial_2_description">Por exemplo, se você quiser usar Shizuku em %1$s, você deve substituir %2$s por %3$s (%4$s é o nome do pacote de %1$s).</string>
+    <string name="terminal_tutorial_3">Finalmente, mova os arquivos para algum lugar onde seu aplicativo de terminal possa acessar, você poderá usar %1$s para executar comandos através do Shizuku™.</string>
+    <string name="terminal_tutorial_2_description">Por exemplo, se você quiser usar Shizuku™ em %1$s, você deve substituir %2$s por %3$s (%4$s é o nome do pacote de %1$s).</string>
     <string name="terminal_tutorial_2">Em seguida, use qualquer editor de texto para abrir e editar %1$s.</string>
     <string name="terminal_export_files">Exportar arquivos</string>
     <string name="terminal_tutorial_1">Primeiro, exporte os arquivos para onde quiser. Você encontrará dois arquivos, %1$s e %2$s.</string>
-    <string name="home_terminal_description">Execute comandos através do Shizuku em aplicativos de terminal que você queira</string>
-    <string name="home_terminal_title">Use Shizuku em aplicativos de terminal</string>
-    <string name="app_management_item_summary_requires_root">* requer que o Shizuku seja executado com root</string>
+    <string name="home_terminal_description">Execute comandos através do Shizuku™ em aplicativos de terminal que você queira</string>
+    <string name="home_terminal_title">Use Shizuku™ em aplicativos de terminal</string>
+    <string name="app_management_item_summary_requires_root">* requer que o Shizuku™ seja executado com root</string>
     <string name="app_management_dialog_adb_is_limited_message">É altamente possível que o fabricante do seu dispositivo limite a permissão do adb.&lt;p&gt;Pode haver uma solução para o seu sistema &lt;b&gt;&lt;a href=\"%1$s\"&gt;neste documento&lt;/a&gt;&lt;/b&gt;.</string>
     <string name="app_management_dialog_adb_is_limited_title">A permissão do adb é limitada</string>
-    <string name="home_learn_more_description">Aprenda a desenvolver com Shizuku</string>
-    <string name="home_learn_more_title">Aprender sobre Shizuku</string>
+    <string name="home_learn_more_description">Aprenda a desenvolver com Shizuku™</string>
+    <string name="home_learn_more_title">Aprender sobre Shizuku™</string>
     <string name="home_app_management_view_authorized_apps">Toque para gerenciar aplicativos autorizados</string>
     <plurals name="home_app_management_authorized_apps_count">
         <item quantity="one">%d aplicativo autorizado</item>
@@ -73,20 +73,20 @@
     <string name="home_app_management_title">Gerenciamento de aplicativos</string>
     <string name="home_root_button_restart">Reiniciar</string>
     <string name="home_root_button_start">Iniciar</string>
-    <string name="home_root_description_sui">Se você estiver usando Magisk, você pode tentar %1$s. Para usuários root, ele substituirá o Shizuku. Observe que os aplicativos existentes precisam mudar um pouco para usar %2$s.</string>
-    <string name="home_root_description">Além disso, o Shizuku pode ser iniciado automaticamente na inicialização. Caso contrário, verifique se o seu sistema ou ferramentas de terceiros restringiram o Shizuku.&lt;br&gt;Você pode consultar %s.</string>
+    <string name="home_root_description_sui">Se você estiver usando Magisk, você pode tentar %1$s. Para usuários root, ele substituirá o Shizuku™. Observe que os aplicativos existentes precisam mudar um pouco para usar %2$s.</string>
+    <string name="home_root_description">Além disso, o Shizuku™ pode ser iniciado automaticamente na inicialização. Caso contrário, verifique se o seu sistema ou ferramentas de terceiros restringiram o Shizuku™.&lt;br&gt;Você pode consultar %s.</string>
     <string name="home_root_title">Iniciar (para dispositivos com root)</string>
-    <string name="adb_pairing_tutorial_content_network_limation_not_foreground">Alguns sistemas (como o MIUI) não permitem que aplicativos acessem a rede quando não estiverem visíveis, mesmo que o aplicativo use o serviço em primeiro plano como padrão. Desative os recursos de otimização de bateria para Shizuku sistemas.</string>
-    <string name="adb_pairing_tutorial_content_network">Shizuku precisa acessar a rede local. É controlado pela permissão de rede.</string>
-    <string name="adb_pairing_tutorial_content_finish">Volte ao Shizuku e inicie o Shizuku.</string>
+    <string name="adb_pairing_tutorial_content_network_limation_not_foreground">Alguns sistemas (como o MIUI) não permitem que aplicativos acessem a rede quando não estiverem visíveis, mesmo que o aplicativo use o serviço em primeiro plano como padrão. Desative os recursos de otimização de bateria para Shizuku™ sistemas.</string>
+    <string name="adb_pairing_tutorial_content_network">Shizuku™ precisa acessar a rede local. É controlado pela permissão de rede.</string>
+    <string name="adb_pairing_tutorial_content_finish">Volte ao Shizuku™ e inicie o Shizuku™.</string>
     <string name="adb_pairing_tutorial_content_left_is_clickable">Observe que a parte esquerda da opção \"Depuração sem fio\" é clicável, tocar nela abrirá uma nova página. Apenas ligar o interruptor à direita está incorreto.</string>
     <string name="adb_pairing_tutorial_content_miui_2">Caso contrário, talvez você não consiga inserir o código de pareamento da notificação.</string>
     <string name="adb_pairing_tutorial_content_miui">Os usuários do MIUI podem precisar mudar o estilo de notificação para \"Android\" de \"Notificação\" - \"Sombra de notificação\" nas configurações do sistema.</string>
-    <string name="adb_pairing_tutorial_content_notification_blocked">O processo de emparelhamento precisa que você interaja com uma notificação de Shizuku. Por favor, permita que Shizuku mostre notificações.</string>
+    <string name="adb_pairing_tutorial_content_notification_blocked">O processo de emparelhamento precisa que você interaja com uma notificação de Shizuku™. Por favor, permita que Shizuku™ mostre notificações.</string>
     <string name="adb_pairing_tutorial_content_enter_pairing_code">Digite o código na notificação para concluir o emparelhamento.</string>
     <string name="adb_pairing_tutorial_content_steps">Digite \"Opções do desenvolvedor\" - \"Depuração sem fio\". Toque em \"Emparelhar dispositivo com código de emparelhamento\", você verá um código de seis dígitos.</string>
-    <string name="adb_pairing_tutorial_content_notification">Uma notificação de Shizuku ajudará você a concluir o emparelhamento.</string>
-    <string name="adb_pairing_tutorial_title">Emparelhe Shizuku com seu dispositivo</string>
+    <string name="adb_pairing_tutorial_content_notification">Uma notificação de Shizuku™ ajudará você a concluir o emparelhamento.</string>
+    <string name="adb_pairing_tutorial_title">Emparelhe Shizuku™ com seu dispositivo</string>
     <string name="notification_settings">Opções de notificação</string>
     <string name="development_settings">Opções do desenvolvedor</string>
     <string name="adb_pair_required">Por favor, passe primeiro pela etapa de emparelhamento.</string>
@@ -109,30 +109,30 @@
     <string name="dialog_adb_port">Porta</string>
     <string name="dialog_adb_discovery_message">Ative \"Depuração sem fio\" em \"Opções do desenvolvedor\". A \"depuração sem fio\" é desabilitada automaticamente quando a rede muda.
 \n
-\nObserve que não desative \"Opções do desenvolvedor\" ou \"Depuração USB\" ou Shizuku será parado.</string>
+\nObserve que não desative \"Opções do desenvolvedor\" ou \"Depuração USB\" ou Shizuku™ será parado.</string>
     <string name="dialog_adb_discovery">Procurando serviço de depuração sem fio</string>
     <string name="home_wireless_adb_view_guide_button">Guia passo a passo</string>
     <string name="home_wireless_adb_description_pre_11">Antes do Android 11, é necessário conectar-se a um computador para ativar a depuração sem fio.</string>
-    <string name="home_wireless_adb_description">No Android 11 ou superior, você pode ativar a depuração sem fio e iniciar o Shizuku diretamente do seu dispositivo, sem conectar a um computador.&lt;p&gt;Veja o guia passo a passo primeiro.</string>
+    <string name="home_wireless_adb_description">No Android 11 ou superior, você pode ativar a depuração sem fio e iniciar o Shizuku™ diretamente do seu dispositivo, sem conectar a um computador.&lt;p&gt;Veja o guia passo a passo primeiro.</string>
     <string name="home_wireless_adb_title">Iniciar via depuração sem fio</string>
     <string name="home_adb_dialog_view_command_button_send">Mandar</string>
     <string name="home_adb_dialog_view_command_copy_button">Copiar</string>
     <string name="home_adb_dialog_view_command_message">&lt;font face=monospace&gt;%1$s&lt;/font&gt;&lt;br&gt;&lt;br&gt;* Existem algumas outras considerações, por favor confirme que você leu a ajuda primeiro.</string>
     <string name="home_adb_button_view_command">Ver o comando</string>
     <string name="home_adb_button_view_help">Leia a ajuda</string>
-    <string name="home_adb_description">Para dispositivos sem root, você precisa usar o adb para iniciar o Shizuku (requer conexão com o computador). Esse processo precisa ser repetido toda vez que o dispositivo for reiniciado. Por favor, <b><a href="%1$s">leia o Ajuda</a></b>.</string>
+    <string name="home_adb_description">Para dispositivos sem root, você precisa usar o adb para iniciar o Shizuku™ (requer conexão com o computador). Esse processo precisa ser repetido toda vez que o dispositivo for reiniciado. Por favor, <b><a href="%1$s">leia o Ajuda</a></b>.</string>
     <string name="home_adb_title">Comece conectando-se a um computador</string>
     <string name="home_status_service_version_update">Versão %2$s, %1$s&lt;br&gt;Comece novamente para atualizar para a versão %3$s</string>
     <string name="home_status_service_version">Versão %2$s, %1$s</string>
     <string name="home_status_service_not_running">%1$s não está em execução</string>
     <string name="home_status_service_is_running">%1$s está em execução</string>
     <string name="translation_contributors">Arcent</string>
-    <string name="home_adb_is_limited_description">O fabricante do dispositivo restringiu as permissões adb e os aplicativos que usam Shizuku não funcionarão corretamente.
+    <string name="home_adb_is_limited_description">O fabricante do dispositivo restringiu as permissões adb e os aplicativos que usam Shizuku™ não funcionarão corretamente.
 \n
 \nNormalmente, essa limitação pode ser contornada habilitando algumas opções em \"Opções do desenvolvedor\". Leia a ajuda para obter detalhes sobre como fazer isso.
 \n
-\nPode ser necessário reiniciar o Shizuku para que a operação entre em vigor.</string>
+\nPode ser necessário reiniciar o Shizuku™ para que a operação entre em vigor.</string>
     <string name="home_adb_is_limited_title">Você precisa dar um passo extra</string>
-    <string name="home_app_management_empty">Os aplicativos que solicitaram ou declararem Shizuku serão exibidos aqui.</string>
+    <string name="home_app_management_empty">Os aplicativos que solicitaram ou declararem Shizuku™ serão exibidos aqui.</string>
     <string name="dialog_adb_discovery_message_toggle_wireless_debugging">Por favor, tente desabilitar e habilitar \"Depuração sem fio\" se continuar procurando.</string>
 </resources>

--- a/manager/src/main/res/values-ro/strings.xml
+++ b/manager/src/main/res/values-ro/strings.xml
@@ -26,15 +26,15 @@
     <string name="adb_pair_required">Parcurge mai întâi procesul de asociere.</string>
     <string name="development_settings">Opțiuni dezvoltator</string>
     <string name="notification_settings">Opțiuni de notificare</string>
-    <string name="adb_pairing_tutorial_title">Asociază Shizuku cu acest dispozitiv</string>
-    <string name="adb_pairing_tutorial_content_notification">O notificare de la Shizuku te va ajuta să finalizezi asocierea.</string>
+    <string name="adb_pairing_tutorial_title">Asociază Shizuku™ cu acest dispozitiv</string>
+    <string name="adb_pairing_tutorial_content_notification">O notificare de la Shizuku™ te va ajuta să finalizezi asocierea.</string>
     <string name="adb_pairing_tutorial_content_miui">Este posibil ca utilizatorii MIUI să fie nevoiți să schimbe stilul de notificare la „Android” în „Notificări” - „Panou de notificare” în setările sistemului.</string>
     <string name="adb_pairing_tutorial_content_miui_2">În caz contrar, este posibil să nu poți introduce codul de asociere din notificare.</string>
-    <string name="adb_pairing_tutorial_content_finish">Înapoi la Shizuku și pornește Shizuku.</string>
-    <string name="adb_pairing_tutorial_content_network">Shizuku trebuie să acceseze rețeaua locală. Este controlat de permisiunea de rețea.</string>
+    <string name="adb_pairing_tutorial_content_finish">Înapoi la Shizuku™ și pornește Shizuku™.</string>
+    <string name="adb_pairing_tutorial_content_network">Shizuku™ trebuie să acceseze rețeaua locală. Este controlat de permisiunea de rețea.</string>
     <string name="home_root_title">Pornire (pentru dispozitive root-ate)</string>
-    <string name="home_root_description">În plus, Shizuku poate fi pornit automat la pornire. Dacă nu, verifică dacă sistemul sau instrumente terțe au restricționat Shizuku.&lt;br&gt;Poți consulta %s.</string>
-    <string name="home_root_description_sui">Dacă utilizezi Magisk, poți încerca %1$s. Pentru utilizatorii root, acesta va înlocui în cele din urmă Shizuku. Reține că aplicațiile existente trebuie să se modifice puțin pentru a fi utilizate %2$s.</string>
+    <string name="home_root_description">În plus, Shizuku™ poate fi pornit automat la pornire. Dacă nu, verifică dacă sistemul sau instrumente terțe au restricționat Shizuku™.&lt;br&gt;Poți consulta %s.</string>
+    <string name="home_root_description_sui">Dacă utilizezi Magisk, poți încerca %1$s. Pentru utilizatorii root, acesta va înlocui în cele din urmă Shizuku™. Reține că aplicațiile existente trebuie să se modifice puțin pentru a fi utilizate %2$s.</string>
     <string name="home_root_button_start">Pornire</string>
     <string name="home_root_button_restart">Repornire</string>
     <string name="home_app_management_title">Gestionare aplicație</string>
@@ -44,15 +44,15 @@
         <item quantity="other">%d aplicații autorizate</item>
     </plurals>
     <string name="home_app_management_view_authorized_apps">Atinge pentru a gestiona aplicațiile autorizate</string>
-    <string name="home_learn_more_title">Învață Shizuku</string>
+    <string name="home_learn_more_title">Învață Shizuku™</string>
     <string name="app_management_dialog_adb_is_limited_title">Permisiunea adb este limitată</string>
-    <string name="app_management_item_summary_requires_root">* necesită Shizuku să rulează cu root</string>
-    <string name="home_terminal_title">Utilizează Shizuku în aplicații terminale</string>
-    <string name="home_terminal_description">Rulează comenzi prin Shizuku în aplicațiile terminale care îți plac</string>
+    <string name="app_management_item_summary_requires_root">* necesită Shizuku™ să rulează cu root</string>
+    <string name="home_terminal_title">Utilizează Shizuku™ în aplicații terminale</string>
+    <string name="home_terminal_description">Rulează comenzi prin Shizuku™ în aplicațiile terminale care îți plac</string>
     <string name="terminal_tutorial_1">Mai întâi exportă fișierele oriunde dorești. Vei găsi două fișiere, %1$s și %2$s.</string>
     <string name="terminal_export_files">Export fișiere</string>
     <string name="terminal_tutorial_2">Apoi, utilizează orice editor de text pentru a deschide și edita %1$s.</string>
-    <string name="terminal_tutorial_2_description">De exemplu, dacă vrei să folosești Shizuku în %1$s, ar trebui să înlocuiești %2$s cu %3$s (%4$s este numele pachetului al %1$s).</string>
+    <string name="terminal_tutorial_2_description">De exemplu, dacă vrei să folosești Shizuku™ în %1$s, ar trebui să înlocuiești %2$s cu %3$s (%4$s este numele pachetului al %1$s).</string>
     <string name="settings_title">Setări</string>
     <string name="settings_language">Limba</string>
     <string name="settings_user_interface">Aspect</string>
@@ -65,11 +65,11 @@
     <string name="settings_use_system_color">Utilizează culoarea temei de sistem</string>
     <string name="action_about">Despre</string>
     <string name="about_view_source_code">Vizualizează codul sursă la %s</string>
-    <string name="action_stop">Oprire Shizuku</string>
-    <string name="dialog_stop_message">Serviciul Shizuku va fi oprit.</string>
+    <string name="action_stop">Oprire Shizuku™</string>
+    <string name="dialog_stop_message">Serviciul Shizuku™ va fi oprit.</string>
     <string name="notification_channel_service_status">Starea de pornire a serviciului</string>
-    <string name="notification_service_starting">Serviciul Shizuku pornește…</string>
-    <string name="notification_service_start_failed">Pornirea serviciului Shizuku a eșuat.</string>
+    <string name="notification_service_starting">Serviciul Shizuku™ pornește…</string>
+    <string name="notification_service_start_failed">Pornirea serviciului Shizuku™ a eșuat.</string>
     <string name="notification_service_start_no_root">Nu s-a putut solicita permisiunea root.</string>
     <string name="notification_working">Se lucrează…</string>
     <string name="notification_adb_pairing_input_paring_code">Introdu codul de asociere</string>
@@ -79,8 +79,8 @@
     <string name="notification_adb_pairing_succeed_title">Asociere reușită</string>
     <string name="notification_adb_pairing_failed_title">Asocierea eșuată</string>
     <string name="notification_adb_pairing_retry">Încearcă din nou</string>
-    <string name="permission_label">accesare Shizuku</string>
-    <string name="permission_description">Permite aplicației să folosească Shizuku.</string>
+    <string name="permission_label">accesare Shizuku™</string>
+    <string name="permission_description">Permite aplicației să folosească Shizuku™.</string>
     <string name="permission_warning_template">Permiți <b>%1$s</b> să %2$s\?</string>
     <string name="grant_dialog_button_allow_always">Permite tot timpul</string>
     <string name="grant_dialog_button_deny">Refuz</string>
@@ -89,18 +89,18 @@
     <string name="toast_copied_to_clipboard">%s
 \na fost copiat în clipboard.</string>
     <string name="toast_copied_to_clipboard_with_text"><b>%s</b> a fost copiat în clipboard.</string>
-    <string name="dialog_legacy_not_support_title">%1$s nu suportă Shizuku modern</string>
-    <string name="dialog_legacy_not_support_message">Vechea versiune Shizuku a fost retrasă din martie 2019. De asemenea, vechea versiune Shizuku nu funcționează pe sisteme Android mai noi.&lt;p&gt;Cere dezvoltatorului &lt;b&gt;%1$s&lt;/b&gt; să actualizeze.</string>
-    <string name="dialog_requesting_legacy_title">%1$s solicită Shizuku vechi</string>
-    <string name="dialog_requesting_legacy_message">&lt;b&gt;%1$s&lt;/b&gt; are suport Shizuku modern, dar solicită Shizuku vechi. Acest lucru se poate datora faptului că Shizuku nu rulează, verifică în aplicația Shizuku.&lt;p&gt;Versiunea veche a Shizuku a fost retrasă din martie 2019.</string>
-    <string name="dialog_requesting_legacy_button_open_shizuku">Deschide Shizuku</string>
+    <string name="dialog_legacy_not_support_title">%1$s nu suportă Shizuku™ modern</string>
+    <string name="dialog_legacy_not_support_message">Vechea versiune Shizuku™ a fost retrasă din martie 2019. De asemenea, vechea versiune Shizuku™ nu funcționează pe sisteme Android mai noi.&lt;p&gt;Cere dezvoltatorului &lt;b&gt;%1$s&lt;/b&gt; să actualizeze.</string>
+    <string name="dialog_requesting_legacy_title">%1$s solicită Shizuku™ vechi</string>
+    <string name="dialog_requesting_legacy_message">&lt;b&gt;%1$s&lt;/b&gt; are suport Shizuku™ modern, dar solicită Shizuku™ vechi. Acest lucru se poate datora faptului că Shizuku™ nu rulează, verifică în aplicația Shizuku™.&lt;p&gt;Versiunea veche a Shizuku™ a fost retrasă din martie 2019.</string>
+    <string name="dialog_requesting_legacy_button_open_shizuku">Deschide Shizuku™</string>
     <string name="translation_contributors">Igor</string>
     <string name="home_status_service_version">Versiune %2$s, %1$s</string>
-    <string name="home_adb_description">Pentru dispozitivele fără root, trebuie să utilizezi adb pentru a porni Shizuku (necesită conexiune la computer). Acest proces trebuie repetat de fiecare dată când dispozitivul este repornit. <b><a href="%1$s">Citește ajutorul</a></b>.</string>
-    <string name="home_wireless_adb_description">Pe Android 11 sau o versiune ulterioară, poți activa depanarea wireless și poți porni Shizuku direct de pe dispozitiv, fără a te conecta la un computer.&lt;p&gt;Mai întâi consultă ghidul pas cu pas.</string>
+    <string name="home_adb_description">Pentru dispozitivele fără root, trebuie să utilizezi adb pentru a porni Shizuku™ (necesită conexiune la computer). Acest proces trebuie repetat de fiecare dată când dispozitivul este repornit. <b><a href="%1$s">Citește ajutorul</a></b>.</string>
+    <string name="home_wireless_adb_description">Pe Android 11 sau o versiune ulterioară, poți activa depanarea wireless și poți porni Shizuku™ direct de pe dispozitiv, fără a te conecta la un computer.&lt;p&gt;Mai întâi consultă ghidul pas cu pas.</string>
     <string name="dialog_adb_discovery_message">Activează „Depanare wireless” în „Opțiuni dezvoltator”. „Depanarea wireless” se dezactivează automat când se schimbă rețeaua.
 \n
-\nReține, nu dezactiva „Opțiuni dezvoltator” sau „Depanare USB”, altfel Shizuku va fi oprit.</string>
+\nReține, nu dezactiva „Opțiuni dezvoltator” sau „Depanare USB”, altfel Shizuku™ va fi oprit.</string>
     <string name="dialog_wireless_adb_not_enabled">Depanarea wireless nu este activată.
 \nReține că înainte de Android 11, pentru a activa depanarea wireless, conexiunea la computer este o necesitate.</string>
     <string name="dialog_adb_pairing_message">Începe asocierea prin următorii pași: „Opțiuni dezvoltator” - „Depanare wireless” - „Asocierea dispozitivului folosind codul de asociere”.
@@ -110,29 +110,29 @@
     <string name="adb_pairing_requires_multi_window_reason">Sistemul necesită dialogul de asociere întotdeauna vizibil, utilizarea modului ecran divizat este singura modalitate de a lăsa această aplicație și dialogul de sistem vizibile în același timp.</string>
     <string name="adb_pairing_tutorial_content_steps">Accesează „Opțiuni dezvoltator” - „Depanare wireless”. Atinge „Asociere dispozitiv cu codul de asociere”, vei vedea un cod din șase cifre.</string>
     <string name="adb_pairing_tutorial_content_enter_pairing_code">Introdu codul în notificare pentru a finaliza asocierea.</string>
-    <string name="adb_pairing_tutorial_content_notification_blocked">Procesul de asociere necesită să interacționarea cu o notificare de la Shizuku. Permite lui Shizuku să afișeze notificări.</string>
-    <string name="adb_pairing_tutorial_content_network_limation_not_foreground">Unele sisteme (cum ar fi MIUI) nu permit aplicațiilor să acceseze rețeaua atunci când nu sunt vizibile, chiar dacă aplicația folosește serviciul din prim-plan ca standard. Dezactivarea funcțiilor de optimizare a bateriei pentru Shizuku pe astfel de sisteme este necesară.</string>
-    <string name="home_learn_more_description">Află cum să dezvolți cu Shizuku</string>
+    <string name="adb_pairing_tutorial_content_notification_blocked">Procesul de asociere necesită să interacționarea cu o notificare de la Shizuku™. Permite lui Shizuku™ să afișeze notificări.</string>
+    <string name="adb_pairing_tutorial_content_network_limation_not_foreground">Unele sisteme (cum ar fi MIUI) nu permit aplicațiilor să acceseze rețeaua atunci când nu sunt vizibile, chiar dacă aplicația folosește serviciul din prim-plan ca standard. Dezactivarea funcțiilor de optimizare a bateriei pentru Shizuku™ pe astfel de sisteme este necesară.</string>
+    <string name="home_learn_more_description">Află cum să dezvolți cu Shizuku™</string>
     <string name="app_management_dialog_adb_is_limited_message">Este foarte posibil ca producătorul dispozitivului să limiteze permisiunea adb.&lt;p&gt;Este posibil să existe o soluție pentru acest sistem în &lt;b&gt;&lt;a href=\"%1$s\"&gt;acest document&lt;/a&gt;&lt;/b&gt;.</string>
     <string name="terminal_tutorial_1_description">Dacă există fișiere cu același nume în dosarul selectat, acestea vor fi șterse.
 \n
-\nFuncția de export folosește SAF (Storage Access Framework). A fost raportat că MIUI întrerupe funcțiile SAF. Dacă utilizezi MIUI, poate fi necesar să extragi fișierul din apk-ul lui Shizuku sau să-l descarci de pe GitHub.</string>
-    <string name="terminal_tutorial_3">În cele din urmă, mută fișierele într-un loc unde aplicația de terminal le poate accesa, vei putea folosi %1$s pentru a rula comenzi prin Shizuku.</string>
+\nFuncția de export folosește SAF (Storage Access Framework). A fost raportat că MIUI întrerupe funcțiile SAF. Dacă utilizezi MIUI, poate fi necesar să extragi fișierul din apk-ul lui Shizuku™ sau să-l descarci de pe GitHub.</string>
+    <string name="terminal_tutorial_3">În cele din urmă, mută fișierele într-un loc unde aplicația de terminal le poate accesa, vei putea folosi %1$s pentru a rula comenzi prin Shizuku™.</string>
     <string name="terminal_tutorial_3_description">Câteva sfaturi: acordă permisiunea de execuție pentru %1$s și adaugă la %2$s, vei putea folosi %1$s direct.</string>
-    <string name="rish_description">Cu %1$s, în orice aplicație de terminal, vei putea conecta și interacționa cu shell-urile rulate de Shizuku. &lt;p&gt;Despre utilizarea detaliată %1$s, atinge pentru a vizualiza documentul.</string>
+    <string name="rish_description">Cu %1$s, în orice aplicație de terminal, vei putea conecta și interacționa cu shell-urile rulate de Shizuku™. &lt;p&gt;Despre utilizarea detaliată %1$s, atinge pentru a vizualiza documentul.</string>
     <string name="settings_translation_contributors">Colaboratori de traduceri</string>
-    <string name="settings_start_on_boot_summary">Pentru dispozitivele root-ate, Shizuku poate porni automat la pornire</string>
+    <string name="settings_start_on_boot_summary">Pentru dispozitivele root-ate, Shizuku™ poate porni automat la pornire</string>
     <string name="notification_channel_adb_pairing">Asociere prin depanare fără fir</string>
     <string name="notification_adb_pairing_stop_searching">Oprire căutare</string>
-    <string name="notification_adb_pairing_succeed_text">Poți porni serviciul Shizuku acum.</string>
+    <string name="notification_adb_pairing_succeed_text">Poți porni serviciul Shizuku™ acum.</string>
     <string name="start_with_root_failed">Nu se poate porni serviciul deoarece permisiunea root nu este acordată sau acest dispozitiv nu este root-at.</string>
     <string name="adb_pairing_tutorial_content_left_is_clickable">Reține că partea din stânga a opțiunii \"Depanare fără fir\" este click-abilă, apăsarea acesteia va deschide o pagina nouă. Este incorect să pornești doar comutatorul din dreapta.</string>
-    <string name="home_app_management_empty">Aplicațiile care au solicitat sau au declarat Shizuku se vor afișa aici.</string>
-    <string name="home_adb_is_limited_description">Producătorul dispozitivului are permisiuni adb limitate, iar aplicațiile care folosesc Shizuku nu vor funcționa corect. 
+    <string name="home_app_management_empty">Aplicațiile care au solicitat sau au declarat Shizuku™ se vor afișa aici.</string>
+    <string name="home_adb_is_limited_description">Producătorul dispozitivului are permisiuni adb limitate, iar aplicațiile care folosesc Shizuku™ nu vor funcționa corect. 
 \n
 \nDe obicei, această limitare poate fi ridicată prin ajustarea unor opțiuni din „Opțiuni pentru dezvoltatori”. Citește ajutorul pentru detalii despre cum să faci acest lucru.
 \n
-\nPoate fi necesar să repornești Shizuku pentru ca operațiunea să intre în vigoare.</string>
+\nPoate fi necesar să repornești Shizuku™ pentru ca operațiunea să intre în vigoare.</string>
     <string name="home_adb_is_limited_title">Trebuie să faci un pas suplimentar</string>
     <string name="dialog_adb_discovery_message_toggle_wireless_debugging">Încearcă să dezactivezi și să activezi „Depanare fără fir” dacă caută în continuare.</string>
 </resources>

--- a/manager/src/main/res/values-ru/strings.xml
+++ b/manager/src/main/res/values-ru/strings.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="dialog_requesting_legacy_button_open_shizuku">Открыть Shizuku</string>
-    <string name="dialog_requesting_legacy_message">&lt;b&gt;%1$s&lt;/b&gt; имеет поддержку актуального Shizuku, но запрашивает его устаревшую версию. Возможно это происходит оттого, что Shizuku не запущен, пожалуйста, перепроверьте в приложении Shizuku.&lt;p&gt;Изначальная версия Shizuku признана устаревшей ещё в марте 2019 года.</string>
-    <string name="dialog_requesting_legacy_title">%1$s запрашивает устаревшую версию Shizuku</string>
-    <string name="dialog_legacy_not_support_message">Изначальная версия Shizuku устарела с марта 2019 года. Кроме того, она не работает на новых системах Android.&lt;p&gt;Пожалуйста, попросите разработчика &lt;b&gt;%1$s&lt;/b&gt; внести поправки.</string>
-    <string name="dialog_legacy_not_support_title">%1$s не поддерживает актуальную версию Shizuku</string>
+    <string name="dialog_requesting_legacy_button_open_shizuku">Открыть Shizuku™</string>
+    <string name="dialog_requesting_legacy_message">&lt;b&gt;%1$s&lt;/b&gt; имеет поддержку актуального Shizuku™, но запрашивает его устаревшую версию. Возможно это происходит оттого, что Shizuku™ не запущен, пожалуйста, перепроверьте в приложении Shizuku™.&lt;p&gt;Изначальная версия Shizuku™ признана устаревшей ещё в марте 2019 года.</string>
+    <string name="dialog_requesting_legacy_title">%1$s запрашивает устаревшую версию Shizuku™</string>
+    <string name="dialog_legacy_not_support_message">Изначальная версия Shizuku™ устарела с марта 2019 года. Кроме того, она не работает на новых системах Android.&lt;p&gt;Пожалуйста, попросите разработчика &lt;b&gt;%1$s&lt;/b&gt; внести поправки.</string>
+    <string name="dialog_legacy_not_support_title">%1$s не поддерживает актуальную версию Shizuku™</string>
     <string name="toast_copied_to_clipboard_with_text">&lt;b&gt;%s&lt;/b&gt; было скопировано в буфер обмена.</string>
     <string name="toast_copied_to_clipboard">%s
 \nбыло скопировано в буфер обмена.</string>
     <string name="dialog_cannot_open_browser_title">Не удается запустить браузер</string>
     <string name="start_with_root_failed">Не удалось запустить службу. Root права не выданы или они недоступны на устройстве.</string>
     <string name="starter">Запуск</string>
-    <string name="permission_label">доступ Shizuku</string>
+    <string name="permission_label">доступ Shizuku™</string>
     <string name="notification_working">Работает…</string>
     <string name="notification_service_start_no_root">Не удалось запросить root права.</string>
-    <string name="notification_service_start_failed">Не удалось запустить службу Shizuku.</string>
-    <string name="notification_service_starting">Служба Shizuku запускается…</string>
+    <string name="notification_service_start_failed">Не удалось запустить службу Shizuku™.</string>
+    <string name="notification_service_starting">Служба Shizuku™ запускается…</string>
     <string name="notification_channel_service_status">Состояние работы службы</string>
-    <string name="dialog_stop_message">Служба Shizuku будет остановлена.</string>
-    <string name="action_stop">Остановить Shizuku</string>
+    <string name="dialog_stop_message">Служба Shizuku™ будет остановлена.</string>
+    <string name="action_stop">Остановить Shizuku™</string>
     <string name="about_view_source_code">Исходный код доступен на %s</string>
     <string name="action_about">О приложении</string>
     <string name="settings_translation_summary">Помогите перевести %s на ваш язык</string>
@@ -30,11 +30,11 @@
     <string name="settings_user_interface">Внешний вид</string>
     <string name="settings_language">Язык</string>
     <string name="settings_title">Настройки</string>
-    <string name="app_management_item_summary_requires_root">* требуется Shizuku, запущенный с root правами</string>
+    <string name="app_management_item_summary_requires_root">* требуется Shizuku™, запущенный с root правами</string>
     <string name="app_management_dialog_adb_is_limited_message">Возможно, что производитель вашего устройства ограничивает доступ к adb.&lt;p&gt;Решение для вашей системы может быть описано &lt;b&gt;&lt;a href=\"%1$s\"&gt;здесь&lt;/a&gt;&lt;/b&gt;.</string>
     <string name="app_management_dialog_adb_is_limited_title">Доступ к adb ограничен</string>
-    <string name="home_learn_more_description">Узнайте, как начать разрабатывать с Shizuku</string>
-    <string name="home_learn_more_title">Узнать больше о Shizuku</string>
+    <string name="home_learn_more_description">Узнайте, как начать разрабатывать с Shizuku™</string>
+    <string name="home_learn_more_title">Узнать больше о Shizuku™</string>
     <string name="home_app_management_view_authorized_apps">Нажмите для управления списком допущенных приложений</string>
     <plurals name="home_app_management_authorized_apps_count">
         <item quantity="one">Доступно для %d приложения</item>
@@ -45,7 +45,7 @@
     <string name="home_app_management_title">Управление приложениями</string>
     <string name="home_root_button_restart">Перезапустить</string>
     <string name="home_root_button_start">Запустить</string>
-    <string name="home_root_description">В дополнение, Shizuku может запускаться сразу после загрузки системы. Если этого не происходит, проверьте, нет ли ограничений со стороны вашей системы или сторонних инструментов.&lt;br&gt;Вы можете обратиться в %s.</string>
+    <string name="home_root_description">В дополнение, Shizuku™ может запускаться сразу после загрузки системы. Если этого не происходит, проверьте, нет ли ограничений со стороны вашей системы или сторонних инструментов.&lt;br&gt;Вы можете обратиться в %s.</string>
     <string name="home_root_title">Запуск (для устройств с root правами)</string>
     <string name="development_settings">Параметры разработчика</string>
     <string name="adb_pair_required">Пожалуйста, сперва пройдите процедуру сопряжения.</string>
@@ -68,7 +68,7 @@
     <string name="dialog_adb_port">Порт</string>
     <string name="dialog_adb_discovery_message">Пожалуйста, включите пункт «Отладка по Wi-Fi» в меню «Для разработчиков». «Отладка по Wi-Fi» автоматически отключается при изменении сети.
 \n
-\nВнимание: не отключайте пункт «Для разработчиков» или «Отладка по USB», иначе Shizuku остановит работу.</string>
+\nВнимание: не отключайте пункт «Для разработчиков» или «Отладка по USB», иначе Shizuku™ остановит работу.</string>
     <string name="dialog_adb_discovery">Ожидание службы отладки по Wi-Fi</string>
     <string name="home_wireless_adb_title">Запуск через отладку по Wi-Fi</string>
     <string name="home_adb_dialog_view_command_button_send">Отправить</string>
@@ -76,64 +76,64 @@
     <string name="home_adb_dialog_view_command_message">&lt;font face=monospace&gt;%1$s&lt;/font&gt;&lt;br&gt;&lt;br&gt;* Есть и другие способы; сначала убедитесь, что сперва прочли справку.</string>
     <string name="home_adb_button_view_command">Просмотр команды</string>
     <string name="home_adb_button_view_help">Читать справку</string>
-    <string name="home_adb_description">Для устройств без root прав потребуется обращаться к adb для запуска Shizuku (не обойтись без соединения с компьютером). Этот процесс нужно повторять каждый раз, когда устройство перезагружается. Пожалуйста, <b><a href="%1$s">прочтите справку</a></b>.</string>
+    <string name="home_adb_description">Для устройств без root прав потребуется обращаться к adb для запуска Shizuku™ (не обойтись без соединения с компьютером). Этот процесс нужно повторять каждый раз, когда устройство перезагружается. Пожалуйста, <b><a href="%1$s">прочтите справку</a></b>.</string>
     <string name="home_adb_title">Запуск через соединение с ПК</string>
     <string name="home_status_service_version_update">Версия %2$s, %1$s&lt;br&gt;Запустите снова что бы обновиться до версии %3$s</string>
     <string name="home_status_service_version">Версия %2$s, %1$s</string>
     <string name="home_status_service_not_running">%1$s не запущен</string>
     <string name="home_status_service_is_running">%1$s запущен</string>
     <string name="translation_contributors">sermart1234, ruvlad</string>
-    <string name="settings_start_on_boot_summary">На устройствах с root правами Shizuku может автоматически запускаться после загрузки системы</string>
+    <string name="settings_start_on_boot_summary">На устройствах с root правами Shizuku™ может автоматически запускаться после загрузки системы</string>
     <string name="settings_start_on_boot">Автозапуск (с root правами)</string>
     <string name="grant_dialog_button_allow_always">Разрешить всегда</string>
     <string name="grant_dialog_button_deny">Запретить</string>
     <string name="permission_warning_template">Разрешить <b>%1$s</b> следующее: %2$s\?</string>
-    <string name="home_root_description_sui">Если вы пользуетесь Magisk, можете попробовать %1$s. Для пользователей с root правами он в конечном итоге заменит Shizuku. Обратите внимание, что в уже вышедшие приложения должны внести небольшие изменения, чтобы они заработали с %2$s.</string>
-    <string name="permission_description">Разрешить приложению использовать Shizuku.</string>
+    <string name="home_root_description_sui">Если вы пользуетесь Magisk, можете попробовать %1$s. Для пользователей с root правами он в конечном итоге заменит Shizuku™. Обратите внимание, что в уже вышедшие приложения должны внести небольшие изменения, чтобы они заработали с %2$s.</string>
+    <string name="permission_description">Разрешить приложению использовать Shizuku™.</string>
     <string name="terminal_tutorial_3_description">Небольшой совет: выдайте %1$s права на выполнение и пропишите в %2$s, чтобы обращаться к %1$s напрямую.</string>
-    <string name="terminal_tutorial_3">И последнее: переместите файлы туда, куда сможет обращаться ваше приложение-терминал, и отныне станет возможным запускать команды через Shizuku посредством %1$s.</string>
-    <string name="terminal_tutorial_2_description">К примеру: если вы захотите использовать Shizuku внутри %1$s, нужно заменить %2$s на %3$s (%4$s – это имя пакета эмулятора терминала %1$s).</string>
+    <string name="terminal_tutorial_3">И последнее: переместите файлы туда, куда сможет обращаться ваше приложение-терминал, и отныне станет возможным запускать команды через Shizuku™ посредством %1$s.</string>
+    <string name="terminal_tutorial_2_description">К примеру: если вы захотите использовать Shizuku™ внутри %1$s, нужно заменить %2$s на %3$s (%4$s – это имя пакета эмулятора терминала %1$s).</string>
     <string name="terminal_tutorial_2">Затем откройте и отредактируйте %1$s любым текстовым редактором.</string>
     <string name="terminal_export_files">Экспорт файлов</string>
     <string name="terminal_tutorial_1_description">Если в выбранной папке уже есть файлы с такими же именами, они будут удалены.
 \n
-\nДля работы функции экспорта используется SAF (Storage Access Framework). Сообщается, что на MIUI сломаны механизмы SAF, поэтому там может понадобиться вручную извлечь файл из .apk Shizuku или скачать его с GitHub.</string>
+\nДля работы функции экспорта используется SAF (Storage Access Framework). Сообщается, что на MIUI сломаны механизмы SAF, поэтому там может понадобиться вручную извлечь файл из .apk Shizuku™ или скачать его с GitHub.</string>
     <string name="terminal_tutorial_1">Сначала экспортируйте файлы в любое место на свое усмотрение. Там появятся два файла: %1$s и %2$s.</string>
-    <string name="home_terminal_description">Запуск команд через Shizuku прямиком из любимых приложений-терминалов</string>
-    <string name="home_terminal_title">Применение Shizuku в эмуляторах терминала</string>
+    <string name="home_terminal_description">Запуск команд через Shizuku™ прямиком из любимых приложений-терминалов</string>
+    <string name="home_terminal_title">Применение Shizuku™ в эмуляторах терминала</string>
     <string name="home_wireless_adb_description">На Android 11 или выше Вы можете включить отладку по Wi-Fi без дополнительного ПО, без подключения к компьютеру. Пожалуйста, сперва просмотрите инструкцию</string>
     <string name="adb_pairing_tutorial_content_miui">На оболочке MIUI может потребоваться сменить параметр в пункте системных настроек «Уведомления» – «Стиль уведомлений» на «Android».</string>
     <string name="adb_pairing_tutorial_content_steps">Перейдите в «Параметры разработчика» – «Отладка по Wi-Fi». Нажмите на «Сопряжение устройства с помощью кода сопряжения» и увидите шестизначный код.</string>
     <string name="adb_pairing_tutorial_content_enter_pairing_code">Введите код в уведомление для завершения процедуры сопряжения.</string>
-    <string name="adb_pairing_tutorial_content_notification">Уведомление от Shizuku поможет завершить процедуру сопряжения.</string>
-    <string name="rish_description">Посредством %1$s из любого приложения-терминала можно подключаться и взаимодействовать с shell, запущенной Shizuku. &lt;p&gt;Нажмите здесь для просмотра инструкции по работе с %1$s.</string>
+    <string name="adb_pairing_tutorial_content_notification">Уведомление от Shizuku™ поможет завершить процедуру сопряжения.</string>
+    <string name="rish_description">Посредством %1$s из любого приложения-терминала можно подключаться и взаимодействовать с shell, запущенной Shizuku™. &lt;p&gt;Нажмите здесь для просмотра инструкции по работе с %1$s.</string>
     <string name="notification_adb_pairing_working_title">Выполняется сопряжение</string>
     <string name="notification_adb_pairing_succeed_title">Сопряжение выполнено</string>
-    <string name="notification_adb_pairing_succeed_text">Теперь можете запустить службу Shizuku.</string>
+    <string name="notification_adb_pairing_succeed_text">Теперь можете запустить службу Shizuku™.</string>
     <string name="notification_adb_pairing_failed_title">Не удалось выполнить сопряжение</string>
     <string name="notification_adb_pairing_retry">Повторить попытку</string>
-    <string name="adb_pairing_tutorial_title">Сопряжение Shizuku с вашим устройством</string>
+    <string name="adb_pairing_tutorial_title">Сопряжение Shizuku™ с вашим устройством</string>
     <string name="home_wireless_adb_description_pre_11">"Для отладки по Wi-Fi в Android до 11 версии  потребуется соединения с компьютером."</string>
     <string name="home_wireless_adb_view_guide_button">Пошаговая инструкция</string>
     <string name="notification_settings">Настройки уведомлений</string>
-    <string name="adb_pairing_tutorial_content_notification_blocked">Процедура сопряжения подразумевает взаимодействие с уведомлением от Shizuku. Для продолжения выдайте Shizuku разрешение на показ уведомлений.</string>
-    <string name="adb_pairing_tutorial_content_finish">Вернитесь в приложение Shizuku и запустите его.</string>
+    <string name="adb_pairing_tutorial_content_notification_blocked">Процедура сопряжения подразумевает взаимодействие с уведомлением от Shizuku™. Для продолжения выдайте Shizuku™ разрешение на показ уведомлений.</string>
+    <string name="adb_pairing_tutorial_content_finish">Вернитесь в приложение Shizuku™ и запустите его.</string>
     <string name="notification_channel_adb_pairing">Сопряжение с отладкой по Wi-Fi</string>
     <string name="notification_adb_pairing_input_paring_code">Введите код подключения</string>
     <string name="notification_adb_pairing_searching_for_service_title">Ожидание службы сопряжения</string>
     <string name="notification_adb_pairing_service_found_title">Служба найдена</string>
     <string name="notification_adb_pairing_stop_searching">Прекратить поиск</string>
     <string name="adb_pairing_tutorial_content_miui_2">Иначе вы, вероятнее всего, не сможете ввести код сопряжения из уведомления.</string>
-    <string name="adb_pairing_tutorial_content_network">Shizuku требуется доступ к локальной сети. Он управляется сетевым разрешением.</string>
-    <string name="adb_pairing_tutorial_content_network_limation_not_foreground">Некоторые системы (та же MIUI) не разрешают приложениям доступ к сети, когда они не на экране, даже если те в основе задействуют службу переднего плана. Пожалуйста, добавьте Shizuku в исключения алгоритмов оптимизации заряда батареи на таких системах.</string>
+    <string name="adb_pairing_tutorial_content_network">Shizuku™ требуется доступ к локальной сети. Он управляется сетевым разрешением.</string>
+    <string name="adb_pairing_tutorial_content_network_limation_not_foreground">Некоторые системы (та же MIUI) не разрешают приложениям доступ к сети, когда они не на экране, даже если те в основе задействуют службу переднего плана. Пожалуйста, добавьте Shizuku™ в исключения алгоритмов оптимизации заряда батареи на таких системах.</string>
     <string name="settings_use_system_color">Палитра цветов из системы</string>
     <string name="adb_pairing_tutorial_content_left_is_clickable">Обратите внимание, что левая часть опции \"Беспроводная отладка\" является кликабельной, нажатие на нее открывает новую страницу. Нажатие только на переключатель (справа) является неправильным.</string>
     <string name="dialog_adb_discovery_message_toggle_wireless_debugging">Попробуй выключить и снова включить \"Отладка по Wi-Fi\", если поиск продолжается.</string>
-    <string name="home_app_management_empty">Приложения, которые запросили или задекларировали использование Shizuku будут отображаться здесь.</string>
-    <string name="home_adb_is_limited_description">Производитель вашего устройства ограничил права ADB, приложения использующие Shizuku будут работать не корректно.
+    <string name="home_app_management_empty">Приложения, которые запросили или задекларировали использование Shizuku™ будут отображаться здесь.</string>
+    <string name="home_adb_is_limited_description">Производитель вашего устройства ограничил права ADB, приложения использующие Shizuku™ будут работать не корректно.
 \n
 \nОбычно эти ограничения можно снять в настройках для разработчиков. Пожалуйста, прочитай раздел помощи, чтобы узнать как это сделать.
 \n
-\nВозможно Вам понадобится перезапустить Shizuku для применения изменений.</string>
+\nВозможно Вам понадобится перезапустить Shizuku™ для применения изменений.</string>
     <string name="home_adb_is_limited_title">Нужен дополнительный шаг</string>
 </resources>

--- a/manager/src/main/res/values-sl/strings.xml
+++ b/manager/src/main/res/values-sl/strings.xml
@@ -9,15 +9,15 @@
     <string name="notification_channel_adb_pairing">Seznanjanje brezžičnega razhroščevanja</string>
     <string name="notification_working">V teku…</string>
     <string name="notification_service_start_no_root">Neuspešna zahteva za root dovoljenje.</string>
-    <string name="notification_service_start_failed">Zagon storitve Shizuku ni uspel.</string>
-    <string name="notification_service_starting">Storitev Shizuku se zaganja…</string>
+    <string name="notification_service_start_failed">Zagon storitve Shizuku™ ni uspel.</string>
+    <string name="notification_service_starting">Storitev Shizuku™ se zaganja…</string>
     <string name="notification_channel_service_status">Status zagona storitve</string>
-    <string name="dialog_stop_message">Storitev Shizuku bo bila ustavljena.</string>
-    <string name="action_stop">Ustavi Shizuku</string>
+    <string name="dialog_stop_message">Storitev Shizuku™ bo bila ustavljena.</string>
+    <string name="action_stop">Ustavi Shizuku™</string>
     <string name="about_view_source_code">Poglej izvorno kodo na %s</string>
     <string name="action_about">O</string>
     <string name="settings_use_system_color">Uporabi sistemsko barvo teme</string>
-    <string name="settings_start_on_boot_summary">Za naprave z rootom, se lahko Shizuku zažene avtomatsko na zagonu</string>
+    <string name="settings_start_on_boot_summary">Za naprave z rootom, se lahko Shizuku™ zažene avtomatsko na zagonu</string>
     <string name="settings_start_on_boot">Zaženi na zagonu (root)</string>
     <string name="settings_translation_summary">Pomagajte nam prevajati %s v vaš jezik</string>
     <string name="dialog_adb_pairing_message">Prosimo, začnite z seznanitvijo po teh korakih: \"Nastavitve za razvijalce\" - \"Seznanjanje naprave z seznantitveno kodo\".
@@ -32,15 +32,15 @@
     <string name="dialog_adb_pairing_title">Seznani z napravo</string>
     <string name="adb_pairing">Seznanjanje</string>
     <string name="dialog_adb_invalid_port">Vrata so število v obsegu od 1 do 65535.</string>
-    <string name="home_adb_description">Za naprave brez root-a, potrebujete adb, da zaženete Shizuku (potrebna je računalniška povezava). Ta proces je potrebno ponoviti vsakič, ko se naprava ponovno zažene. Prosimo <b><a href="%1$s">preberite pomoč</a></b>.</string>
+    <string name="home_adb_description">Za naprave brez root-a, potrebujete adb, da zaženete Shizuku™ (potrebna je računalniška povezava). Ta proces je potrebno ponoviti vsakič, ko se naprava ponovno zažene. Prosimo <b><a href="%1$s">preberite pomoč</a></b>.</string>
     <string name="dialog_adb_port">Vrata</string>
     <string name="dialog_adb_discovery_message">Prosimo omogočite \"Brezžično razhroščevanje\" v \"Nastavitvah za razvijalce\". \"Brezžično razhroščevanje\" je avtomatsko onemogočeno, ko se spremeni omrežje.
 \n
-\nPozor! Ne onemogočajte \"Nastavitev za razvijalce\" ali \"USB razhroščevanja\", drugače bo Shizuku ustavljen.</string>
+\nPozor! Ne onemogočajte \"Nastavitev za razvijalce\" ali \"USB razhroščevanja\", drugače bo Shizuku™ ustavljen.</string>
     <string name="dialog_adb_discovery">Iskanje storitve za Brezžično razhroščevanje</string>
     <string name="home_wireless_adb_view_guide_button">Vodnik po korakih</string>
     <string name="home_wireless_adb_description_pre_11">Pred Androidom 11, je povezava z računalnikom potrebna, da omogočite Brezžično razhroščevanje.</string>
-    <string name="home_wireless_adb_description">Na Androidu 11 ali več, lahko vklopite Brezžično razhroščevanje in začnete Shizuku direktno iz vaše naprave, brez povezovanja na računalnik.&lt;p&gt;Prosimo, najprej poglejte vodnik po korakih.</string>
+    <string name="home_wireless_adb_description">Na Androidu 11 ali več, lahko vklopite Brezžično razhroščevanje in začnete Shizuku™ direktno iz vaše naprave, brez povezovanja na računalnik.&lt;p&gt;Prosimo, najprej poglejte vodnik po korakih.</string>
     <string name="home_wireless_adb_title">Začni preko Brezžičnega razhroščevanja</string>
     <string name="home_adb_dialog_view_command_button_send">Pošlji</string>
     <string name="home_adb_dialog_view_command_copy_button">Kopiraj</string>

--- a/manager/src/main/res/values-sr/strings.xml
+++ b/manager/src/main/res/values-sr/strings.xml
@@ -3,17 +3,17 @@
     <string name="dialog_adb_port">Port</string>
     <string name="dialog_adb_discovery_message">"Molimo Vas omogućite rad režima \"Bežično otklanjanje  grešaka\" u sekciji \"Opcije programera\". Režim  \"Bežično otklanjanje grešaka\" se automatski onemogućava pri svakoj promeni mrežne konekcije..
 \n
-\nPrimetićete, onemogućavanjem sekcije \"Opcije programera\" ili režima \"USB otklanjanje grešaka\", proces rada aplikacije Shizuku se prekida."</string>
+\nPrimetićete, onemogućavanjem sekcije \"Opcije programera\" ili režima \"USB otklanjanje grešaka\", proces rada aplikacije Shizuku™ se prekida."</string>
     <string name="dialog_adb_discovery">Traženje servisa Bežično otklanjanje grešaka</string>
     <string name="home_wireless_adb_view_guide_button">Vodič Korak-po-korak</string>
     <string name="home_wireless_adb_description_pre_11">"Pre Android verzije softvera 11, konekcija sa računarom bila je neophodna  u cilju omogućavanja rada režima Bežično otklanjanja grešaka."</string>
-    <string name="home_wireless_adb_description">"Za Android verziju softvera 11 i više, možete omogućavanjem rada režima Bežičnog otklanjanja grešaka pokrenuti Shizuku aplikaciju direktno sa Vašeg  telefona, zaobilazeći konekciju sa računarom.&lt;p&gt; Molimo Vas, najpre pogledajte vodič Korak-po-korak."</string>
+    <string name="home_wireless_adb_description">"Za Android verziju softvera 11 i više, možete omogućavanjem rada režima Bežičnog otklanjanja grešaka pokrenuti Shizuku™ aplikaciju direktno sa Vašeg  telefona, zaobilazeći konekciju sa računarom.&lt;p&gt; Molimo Vas, najpre pogledajte vodič Korak-po-korak."</string>
     <string name="home_wireless_adb_title">Pokreni preko Bežičnog otklanjanja grešaka</string>
     <string name="home_adb_dialog_view_command_button_send">Pošalji</string>
     <string name="home_adb_dialog_view_command_copy_button">Kopiraj</string>
     <string name="home_adb_button_view_command">Pregled komande</string>
     <string name="home_adb_button_view_help">Pročitajte pomoć</string>
-    <string name="home_adb_description">Za uređaje koji nisu root-ovani, potrebno je izvršiti adb komandu radi pokretanja Shizuku aplikacije (zahteva konekciju sa računarom). Ovaj proces je neophodno svaki put ponoviti nakon restarta uređaja. Molim Vas <b><a href="%1$s">pročitajte pomoć </a></b>.</string>
+    <string name="home_adb_description">Za uređaje koji nisu root-ovani, potrebno je izvršiti adb komandu radi pokretanja Shizuku™ aplikacije (zahteva konekciju sa računarom). Ovaj proces je neophodno svaki put ponoviti nakon restarta uređaja. Molim Vas <b><a href="%1$s">pročitajte pomoć </a></b>.</string>
     <string name="home_adb_title">Pokreni uz pomoć konekcije preko računara</string>
     <string name="home_status_service_version_update">Verzija %2$s, %1$s&lt;br&gt;Počni ispočetka zbog ažuriranja na verziju%3$s</string>
     <string name="home_status_service_version">Verzija %2$s, %1$s</string>
@@ -35,7 +35,7 @@
     <string name="adb_pair_required">Molim Vas, najpre prođite kroz korake za uparivanje uređaja.</string>
     <string name="development_settings">Razvojne opcije programera</string>
     <string name="notification_settings">Opcije obaveštenja</string>
-    <string name="adb_pairing_tutorial_title">Uparite Shizuku sa Vašim uređajem</string>
-    <string name="adb_pairing_tutorial_content_notification">Notifikacija iz Shizuku aplikacije će Vam pomoći da dovršite uparivanje.</string>
+    <string name="adb_pairing_tutorial_title">Uparite Shizuku™ sa Vašim uređajem</string>
+    <string name="adb_pairing_tutorial_content_notification">Notifikacija iz Shizuku™ aplikacije će Vam pomoći da dovršite uparivanje.</string>
     <string name="adb_pairing_tutorial_content_steps">Otvorite sekciju \"Razvojne opcije programera\" - \"Bežično otklanjanje grešaka\". Dodirnite \"Uparivanje uređaja pomoću kóda za uparivanje\" i pojaviće Vam se 6-cifreni kód.</string>
 </resources>

--- a/manager/src/main/res/values-ta/strings.xml
+++ b/manager/src/main/res/values-ta/strings.xml
@@ -2,7 +2,7 @@
 <resources>
     <string name="home_adb_button_view_command">கட்டளையைக் காட்டு</string>
     <string name="home_adb_button_view_help">உதவி பக்கத்தை திற</string>
-    <string name="home_adb_description">Root அணுகல் இல்லாத பட்சத்தில், adb பயன்படுத்தி Shizuku வை தொடங்க வேண்டும் (கணினி இணைப்பு தேவை). ஒவ்வொரு முறை திறன்பேசி மறுதொடக்கம் ஆகும்போதும் இச்செயலை செய்ய வேண்டும். <b><a href="%1$s">உதவி பக்கத்தை படிக்கவும்</a></b></string>
+    <string name="home_adb_description">Root அணுகல் இல்லாத பட்சத்தில், adb பயன்படுத்தி Shizuku™ வை தொடங்க வேண்டும் (கணினி இணைப்பு தேவை). ஒவ்வொரு முறை திறன்பேசி மறுதொடக்கம் ஆகும்போதும் இச்செயலை செய்ய வேண்டும். <b><a href="%1$s">உதவி பக்கத்தை படிக்கவும்</a></b></string>
     <string name="home_adb_title">முதலில், திறன்பேசியை கணினியுடன் இணைக்கவும்</string>
     <string name="home_status_service_version_update">பதிப்பு %2$s, %1$s&lt;br&gt;%3$s பதிப்புக்கு மேம்படுத்த செயலியை மறுதொடக்கம் செய்யவும்</string>
     <string name="home_status_service_version">பதிப்பு %2$s, %1$s</string>

--- a/manager/src/main/res/values-th/strings.xml
+++ b/manager/src/main/res/values-th/strings.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="dialog_requesting_legacy_title">%1$s กำลังขอร้อง Shizuku รุ่นเก่า</string>
-    <string name="dialog_requesting_legacy_button_open_shizuku">เปิด Shizuku</string>
-    <string name="dialog_requesting_legacy_message">&lt;b&gt;%1$s&lt;/b&gt; รองรับ Shizuku รุ่นใหม่ แต่กำลังขอร้อง Shizuku รุ่นเก่า นี่อาจเป็นเพราะ Shizuku ไม่ทำงาน โปรดตรวจสอบในแอป Shizuku &lt;p&gt;Shizuku รุ่นเก่าได้ถูกเลิกใช้ไปแล้วตั้งแต่เดือนมีนาคมปี 2019</string>
-    <string name="dialog_legacy_not_support_message">Shizuku รุ่นเก่าได้ถูกเลิกใช้ไปแล้วตั้งแต่เดือนมีนาคม 2019 นอกจากนี้ Shizuku รุ่นเก่ายังใช้งานไม่ได้กับระบบ Android ที่ใหม่กว่า &lt;p&gt;โปรดติดต่อผู้พัฒนาของ &lt;b&gt;%1$s&lt;/b&gt; เพื่ออัปเดตเป็นเวอร์ชันใหม่</string>
-    <string name="dialog_legacy_not_support_title">%1$s ไม่รองรับ Shizuku รุ่นใหม่</string>
+    <string name="dialog_requesting_legacy_title">%1$s กำลังขอร้อง Shizuku™ รุ่นเก่า</string>
+    <string name="dialog_requesting_legacy_button_open_shizuku">เปิด Shizuku™</string>
+    <string name="dialog_requesting_legacy_message">&lt;b&gt;%1$s&lt;/b&gt; รองรับ Shizuku™ รุ่นใหม่ แต่กำลังขอร้อง Shizuku™ รุ่นเก่า นี่อาจเป็นเพราะ Shizuku™ ไม่ทำงาน โปรดตรวจสอบในแอป Shizuku™ &lt;p&gt;Shizuku™ รุ่นเก่าได้ถูกเลิกใช้ไปแล้วตั้งแต่เดือนมีนาคมปี 2019</string>
+    <string name="dialog_legacy_not_support_message">Shizuku™ รุ่นเก่าได้ถูกเลิกใช้ไปแล้วตั้งแต่เดือนมีนาคม 2019 นอกจากนี้ Shizuku™ รุ่นเก่ายังใช้งานไม่ได้กับระบบ Android ที่ใหม่กว่า &lt;p&gt;โปรดติดต่อผู้พัฒนาของ &lt;b&gt;%1$s&lt;/b&gt; เพื่ออัปเดตเป็นเวอร์ชันใหม่</string>
+    <string name="dialog_legacy_not_support_title">%1$s ไม่รองรับ Shizuku™ รุ่นใหม่</string>
     <string name="toast_copied_to_clipboard">%s
 \nได้ถูกคัดลอกไปยังคลิปบอร์ด</string>
     <string name="toast_copied_to_clipboard_with_text"><b>%s</b> ได้ถูกคัดลอกไปยังคลิปบอร์ด</string>
@@ -14,11 +14,11 @@
     <string name="grant_dialog_button_deny">ปฏิเสธ</string>
     <string name="grant_dialog_button_allow_always">อนุญาตเสมอ</string>
     <string name="permission_warning_template">อนุญาต <b>%1$s</b> ให้ %2$s ไหม\?</string>
-    <string name="permission_description">อนุญาตให้แอปใช้งาน Shizuku</string>
-    <string name="permission_label">เข้าถึง Shizuku</string>
+    <string name="permission_description">อนุญาตให้แอปใช้งาน Shizuku™</string>
+    <string name="permission_label">เข้าถึง Shizuku™</string>
     <string name="notification_adb_pairing_retry">ลองใหม่</string>
     <string name="notification_adb_pairing_failed_title">การจับคู่ล้มเหลว</string>
-    <string name="notification_adb_pairing_succeed_text">สามารถเริ่มบริการ Shizuku ได้ทันที</string>
+    <string name="notification_adb_pairing_succeed_text">สามารถเริ่มบริการ Shizuku™ ได้ทันที</string>
     <string name="notification_adb_pairing_succeed_title">การจับคู่สำเร็จ</string>
     <string name="notification_adb_pairing_working_title">กำลังจับคู่</string>
     <string name="notification_adb_pairing_stop_searching">หยุดค้นหา</string>
@@ -28,15 +28,15 @@
     <string name="notification_channel_adb_pairing">การจับคู่การแก้ไขข้อบกพร่องผ่าน Wi-Fi</string>
     <string name="notification_working">กำลังทำงาน…</string>
     <string name="notification_service_start_no_root">ล้มเหลวในการขอการอนุญาตรูท</string>
-    <string name="notification_service_start_failed">ล้มเหลวในการเริ่มบริการ Shizuku</string>
-    <string name="notification_service_starting">บริการ Shizuku กำลังเริ่มต้น…</string>
+    <string name="notification_service_start_failed">ล้มเหลวในการเริ่มบริการ Shizuku™</string>
+    <string name="notification_service_starting">บริการ Shizuku™ กำลังเริ่มต้น…</string>
     <string name="notification_channel_service_status">สถานะการเริ่มบริการ</string>
-    <string name="action_stop">หยุดทำงาน Shizuku</string>
-    <string name="dialog_stop_message">บริการ Shizuku จะถูกหยุดทำงาน</string>
+    <string name="action_stop">หยุดทำงาน Shizuku™</string>
+    <string name="dialog_stop_message">บริการ Shizuku™ จะถูกหยุดทำงาน</string>
     <string name="about_view_source_code">ดูซอร์สโค้ดใน %s</string>
     <string name="action_about">เกี่ยวกับ</string>
     <string name="settings_use_system_color">ใช้สีของธีมระบบ</string>
-    <string name="settings_start_on_boot_summary">สำหรับอุปกรณ์ที่รูทแล้ว Shizuku จะสามารถเริ่มได้โดยอัตโนมัติเมื่อเปิดเครื่อง</string>
+    <string name="settings_start_on_boot_summary">สำหรับอุปกรณ์ที่รูทแล้ว Shizuku™ จะสามารถเริ่มได้โดยอัตโนมัติเมื่อเปิดเครื่อง</string>
     <string name="settings_start_on_boot">เริ่มเมื่อเปิดเครื่อง (รูท)</string>
     <string name="settings_translation_summary">ช่วยเราแปล %s เป็นภาษาของคุณ</string>
     <string name="settings_translation">มีส่วนร่วมในการแปล</string>
@@ -47,23 +47,23 @@
     <string name="settings_user_interface">ลักษณะ</string>
     <string name="settings_language">ภาษา</string>
     <string name="settings_title">การตั้งค่า</string>
-    <string name="rish_description">ด้วย %1$s ในแอปเทอร์มินอลใด ๆ คุณจะสามารถเชื่อมต่อและดำเนินการกับ shell ที่รันโดย Shizuku &lt;p&gt;รายละเอียดอื่น ๆ ในการใช้ %1$s แตะเพื่อดูเอกสาร</string>
+    <string name="rish_description">ด้วย %1$s ในแอปเทอร์มินอลใด ๆ คุณจะสามารถเชื่อมต่อและดำเนินการกับ shell ที่รันโดย Shizuku™ &lt;p&gt;รายละเอียดอื่น ๆ ในการใช้ %1$s แตะเพื่อดูเอกสาร</string>
     <string name="terminal_tutorial_3_description">แนะนำนิดหน่อย: ให้การอนุญาตดำเนิดการแก่ %1$s และเพิ่มเข้าไปใน %2$s ก็จะสามารถใช้ %1$s ได้โดยตรง</string>
-    <string name="terminal_tutorial_3">สุดท้าย ย้ายไฟล์ไปสักที่ที่แอปเทอร์มินอลของคุณสามารถเข้าถึงได้ ทีนี้คุณก็จะสามารถใช้ %1$s เพื่อสั่งคำสั่งผ่าน Shizuku</string>
-    <string name="terminal_tutorial_2_description">ยกตัวอย่างเช่น ถ้าคุณต้องการใช้ Shizuku ใน %1$s คุณจะต้องแทนที่ %2$s ด้วย %3$s (%4$s คือชื่อแพ็กเกจของ %1$s)</string>
+    <string name="terminal_tutorial_3">สุดท้าย ย้ายไฟล์ไปสักที่ที่แอปเทอร์มินอลของคุณสามารถเข้าถึงได้ ทีนี้คุณก็จะสามารถใช้ %1$s เพื่อสั่งคำสั่งผ่าน Shizuku™</string>
+    <string name="terminal_tutorial_2_description">ยกตัวอย่างเช่น ถ้าคุณต้องการใช้ Shizuku™ ใน %1$s คุณจะต้องแทนที่ %2$s ด้วย %3$s (%4$s คือชื่อแพ็กเกจของ %1$s)</string>
     <string name="terminal_tutorial_2">จากนั้น ใช้ตัวแก้ไขไฟล์เปิดและแก้ไข %1$s</string>
     <string name="terminal_export_files">ส่งออกไฟล์</string>
     <string name="terminal_tutorial_1_description">หากมีไฟล์ที่มีชื่อเดียวกันในโฟลเดอร์ที่เลือก ไฟล์เหล่านั้นจะถูกลบออก
 \n
-\nใช้ฟังก์ชันการส่งออก SAF (Storage Access Framework) มีรายงานว่า MIUI ทำลายฟังก์ชันของ SAF หากคุณใช้ MIUI คุณอาจจะต้องแตกไฟล์จาก apk ของ Shizuku หรือดาวน์โหลดจาก GitHub</string>
+\nใช้ฟังก์ชันการส่งออก SAF (Storage Access Framework) มีรายงานว่า MIUI ทำลายฟังก์ชันของ SAF หากคุณใช้ MIUI คุณอาจจะต้องแตกไฟล์จาก apk ของ Shizuku™ หรือดาวน์โหลดจาก GitHub</string>
     <string name="terminal_tutorial_1">ก่อนอื่น ส่งออกไฟล์ไปยังที่ใดก็ได้ จะมีอยู่สองไฟล์ %1$s และ %2$s</string>
-    <string name="home_terminal_description">สั่งคำสั่งผ่าน Shizuku ในแอปเทอร์มินอลที่คุณเลือก</string>
-    <string name="home_terminal_title">ใช้ Shizuku ในแอปเทอร์มินอล</string>
-    <string name="app_management_item_summary_requires_root">* จำเป็นต้องให้ Shizuku ทำงานผ่านรูท</string>
+    <string name="home_terminal_description">สั่งคำสั่งผ่าน Shizuku™ ในแอปเทอร์มินอลที่คุณเลือก</string>
+    <string name="home_terminal_title">ใช้ Shizuku™ ในแอปเทอร์มินอล</string>
+    <string name="app_management_item_summary_requires_root">* จำเป็นต้องให้ Shizuku™ ทำงานผ่านรูท</string>
     <string name="app_management_dialog_adb_is_limited_message">เป็นไปได้สูงที่ผู้ผลิตอุปกรณ์ของคุณจะจำกัดการอนุญาตของ adb &lt;p&gt;อาจมีวิธีแก้ไขสำหรับอุปกรณ์ของคุณใน&lt;b&gt;&lt;a href=\"%1$s\"&gt;เอกสารนี้&lt;/a&gt;&lt;/b&gt;</string>
     <string name="app_management_dialog_adb_is_limited_title">การอนุญาตของ adb นั้นจำกัด</string>
-    <string name="home_learn_more_description">เรียนรู้การพัฒนาเพื่อใช้ร่วมกันกับ Shizuku</string>
-    <string name="home_learn_more_title">เรียนรู้ Shizuku</string>
+    <string name="home_learn_more_description">เรียนรู้การพัฒนาเพื่อใช้ร่วมกันกับ Shizuku™</string>
+    <string name="home_learn_more_title">เรียนรู้ Shizuku™</string>
     <string name="home_app_management_view_authorized_apps">แตะเพื่อจัดการแอปที่ได้รับอนุญาต</string>
     <plurals name="home_app_management_authorized_apps_count">
         <item quantity="other">อนุญาตแล้ว %d แอปพลิเคชัน</item>
@@ -71,20 +71,20 @@
     <string name="home_app_management_title">การจัดการแอปพลิเคชัน</string>
     <string name="home_root_button_restart">เริ่มใหม่</string>
     <string name="home_root_button_start">เริ่ม</string>
-    <string name="home_root_description_sui">หากคุณกำลังใช้ Magisk สามารถลองใช้ %1$s สำหรับผู้ใช้งานรูท จะเป็นตัวที่ใช้แทนที่ Shizuku แต่โปรดทราบว่า แอปพลิเคชันที่มีอยู่จำเป็นต้องเปลี่ยนเล็กน้อยให้ไปใช้ %2$s</string>
-    <string name="home_root_description">นอกจากนี้ Shizuku ยังสามารถเริ่มอัตโนมัติเมื่ออุปกรณ์ถูกเปิด หากไม่ โปรดตรวจสอบอุปกรณ์หรือเครื่องมือภายนอกที่จำกัดการเข้าถึงของ Shizuku&lt;br&gt;หรือดูตาม %s</string>
+    <string name="home_root_description_sui">หากคุณกำลังใช้ Magisk สามารถลองใช้ %1$s สำหรับผู้ใช้งานรูท จะเป็นตัวที่ใช้แทนที่ Shizuku™ แต่โปรดทราบว่า แอปพลิเคชันที่มีอยู่จำเป็นต้องเปลี่ยนเล็กน้อยให้ไปใช้ %2$s</string>
+    <string name="home_root_description">นอกจากนี้ Shizuku™ ยังสามารถเริ่มอัตโนมัติเมื่ออุปกรณ์ถูกเปิด หากไม่ โปรดตรวจสอบอุปกรณ์หรือเครื่องมือภายนอกที่จำกัดการเข้าถึงของ Shizuku™&lt;br&gt;หรือดูตาม %s</string>
     <string name="home_root_title">เริ่ม (สำหรับอุปกรณ์ที่รูทแล้ว)</string>
-    <string name="adb_pairing_tutorial_content_network_limation_not_foreground">บางระบบ (เช่น MIUI) จะไม่อนุญาตให้แอปเข้าถึงเครือข่ายเมื่อไม่แสดง แม้แอปจะใช้บริการเบื้องหน้าตามปกติ โปรดเปิดใช้งานการเพิ่มประสิทธิภาพแบตเตอรี่ของ Shizuku บนระบบที่เป็นเช่นนั้น</string>
-    <string name="adb_pairing_tutorial_content_network">Shizuku จำเป็นต้องเข้าถึงเครือข่ายท้องถิ่น ซึ่งกำลังควบคุมอยู่โดยการอนุญาตเครือข่าย</string>
-    <string name="adb_pairing_tutorial_content_finish">กลับไปที่ Shizuku เพื่อเริ่ม Shizuku</string>
+    <string name="adb_pairing_tutorial_content_network_limation_not_foreground">บางระบบ (เช่น MIUI) จะไม่อนุญาตให้แอปเข้าถึงเครือข่ายเมื่อไม่แสดง แม้แอปจะใช้บริการเบื้องหน้าตามปกติ โปรดเปิดใช้งานการเพิ่มประสิทธิภาพแบตเตอรี่ของ Shizuku™ บนระบบที่เป็นเช่นนั้น</string>
+    <string name="adb_pairing_tutorial_content_network">Shizuku™ จำเป็นต้องเข้าถึงเครือข่ายท้องถิ่น ซึ่งกำลังควบคุมอยู่โดยการอนุญาตเครือข่าย</string>
+    <string name="adb_pairing_tutorial_content_finish">กลับไปที่ Shizuku™ เพื่อเริ่ม Shizuku™</string>
     <string name="adb_pairing_tutorial_content_left_is_clickable">โปรดให้ทราบว่า ส่วนด้านซ้ายของตัวเลือก \"การแก้ไขข้อบกพร่องผ่าน Wi-Fi\" สามารถกดได้ เมื่อแตะแล้วจะเปิดหน้าใหม่ขึ้นมา การแค่เปิดสวิตช์ที่ด้านขวาอย่างเดียวนั้นไม่ถูกต้อง</string>
     <string name="adb_pairing_tutorial_content_miui_2">ไม่เช่นนั้นจะไม่สามารถป้อนรหัสการจับคู่ลงในการแจ้งเตือน</string>
     <string name="adb_pairing_tutorial_content_miui">ผู้ใช้ MIUI อาจจำเป็นต้องเปลี่ยนสไตล์การแจ้งเตือนเป็น \"Android\" ใน \"การแจ้งเตือน\" -\"เฉดการแจ้งเตือน\" ในการตั้งค่าของระบบ</string>
-    <string name="adb_pairing_tutorial_content_notification_blocked">กระบวนการจับคู่จำเป็นต้องมีการป้อนข้อมูลลงในการแจ้งเตือนของ Shizuku โปรดอนุญาตให้ Shizuku ส่งการแจ้งเตือน</string>
+    <string name="adb_pairing_tutorial_content_notification_blocked">กระบวนการจับคู่จำเป็นต้องมีการป้อนข้อมูลลงในการแจ้งเตือนของ Shizuku™ โปรดอนุญาตให้ Shizuku™ ส่งการแจ้งเตือน</string>
     <string name="adb_pairing_tutorial_content_enter_pairing_code">ป้อนรหัสลงไปในการแจ้งเตือนเพื่อเสร็จสิ้นการจับคู่</string>
     <string name="adb_pairing_tutorial_content_steps">เข้าไปยัง \"ตัวเลือกสำหรับนักพัฒนาแอป\" - \"การแก้ไขข้อบกพร่องผ่าน Wi-Fi\" แตะ \"จับคู่อุปกรณ์ผ่านรหัสการจับคู่\" ก็จะพบกับรหัสหกตัว</string>
-    <string name="adb_pairing_tutorial_content_notification">การแจ้งเตือนจาก Shizuku จะช่วยให้เสร็จสิ้นกระบวนการจับคู่</string>
-    <string name="adb_pairing_tutorial_title">จับคู่ Shizuku กับอุปกรณ์</string>
+    <string name="adb_pairing_tutorial_content_notification">การแจ้งเตือนจาก Shizuku™ จะช่วยให้เสร็จสิ้นกระบวนการจับคู่</string>
+    <string name="adb_pairing_tutorial_title">จับคู่ Shizuku™ กับอุปกรณ์</string>
     <string name="notification_settings">ตัวเลือกการแจ้งเตือน</string>
     <string name="development_settings">ตัวเลือกสำหรับนักพัฒนาแอป</string>
     <string name="adb_pair_required">โปรดทำขั้นตอนการจับคู่ก่อน</string>
@@ -108,8 +108,8 @@
     <string name="dialog_adb_port">พอร์ต</string>
     <string name="dialog_adb_discovery_message">โปรดเปิดใช้งาน \"การแก้ไขข้อบกพร่องผ่าน Wi-Fi\" ใน \"ตัวเลือกสำหรับนักพัฒนาแอป\" \"การแก้ไขข้อบกพร่องผ่าน Wi-Fi\" จะถูกปิดโดยอัตโนมัติเมื่อเปลี่ยนเครือข่าย
 \n
-\nหมายเหตุ ห้ามปิดใช้งาน \"ตัวเลือกสำหรับนักพัฒนาแอป\" หรือ \"การแก้ไขข้อบกพร่อง USB\" ไม่เช่นนั้น Shizuku จะหยุดการทำงาน</string>
-    <string name="home_wireless_adb_description">ตั้งแต่ Android 11 ขึ้นไป สามารถเปิดใช้งานการแก้ไขข้อบกพร่องผ่าน Wi-Fi เพื่อเริ่ม Shizuku ได้โดยตรงผ่านอุปกรณ์ โดยไม่ต้องเชื่อมต่อกับคอมพิวเตอร์ &lt;p&gt;โปรดอ่านคำแนะนำทีละขั้นตอนก่อน</string>
+\nหมายเหตุ ห้ามปิดใช้งาน \"ตัวเลือกสำหรับนักพัฒนาแอป\" หรือ \"การแก้ไขข้อบกพร่อง USB\" ไม่เช่นนั้น Shizuku™ จะหยุดการทำงาน</string>
+    <string name="home_wireless_adb_description">ตั้งแต่ Android 11 ขึ้นไป สามารถเปิดใช้งานการแก้ไขข้อบกพร่องผ่าน Wi-Fi เพื่อเริ่ม Shizuku™ ได้โดยตรงผ่านอุปกรณ์ โดยไม่ต้องเชื่อมต่อกับคอมพิวเตอร์ &lt;p&gt;โปรดอ่านคำแนะนำทีละขั้นตอนก่อน</string>
     <string name="home_wireless_adb_title">เริ่มผ่านการแก้ไขข้อบกพร่องผ่าน Wi-Fi</string>
     <string name="dialog_adb_discovery">กำลังค้นหาบริการการแก้ไขข้อบกพร่อง</string>
     <string name="home_wireless_adb_view_guide_button">คำแนะนำทีละขั้นตอน</string>
@@ -120,17 +120,17 @@
     <string name="home_adb_button_view_help">อ่านการช่วยเหลือ</string>
     <string name="home_adb_title">เริ่มโดยเชื่อมต่อกับคอมพิวเตอร์</string>
     <string name="home_status_service_is_running">%1$s กำลังทำงาน</string>
-    <string name="home_adb_description">สำหรับอุปกรณ์ที่ไม่ได้ติดตั้งรูท จะต้องใช้ adb เพื่อเริ่ม Shizuku (จำเป็นต้องเชื่อมต่อกับคอมพิวเตอร์) กระบวนการนี้จะต้องทำทุกครั้งที่อุปกรณ์ปิดและเปิดใหม่ กรุณา<b><a href="%1$s">อ่านการช่วยเหลือ</a></b></string>
+    <string name="home_adb_description">สำหรับอุปกรณ์ที่ไม่ได้ติดตั้งรูท จะต้องใช้ adb เพื่อเริ่ม Shizuku™ (จำเป็นต้องเชื่อมต่อกับคอมพิวเตอร์) กระบวนการนี้จะต้องทำทุกครั้งที่อุปกรณ์ปิดและเปิดใหม่ กรุณา<b><a href="%1$s">อ่านการช่วยเหลือ</a></b></string>
     <string name="home_status_service_version_update">เวอร์ชัน %2$s, %1$s&lt;br&gt;เริ่มใหม่อีกครั้งเพื่ออัปเดตเป็นเวอร์ชัน %3$s</string>
     <string name="home_status_service_version">เวอร์ชัน %2$s ผ่าน %1$s</string>
     <string name="home_status_service_not_running">%1$s ไม่ได้กำลังทำงาน</string>
     <string name="translation_contributors">altinat</string>
-    <string name="home_adb_is_limited_description">ผู้ผลิตอุปกรณ์ของคุณ จำกัดการอนุญาต adb ทำให้แอปที่ใช้ Shizuku จะไม่ทำงานอย่างถูกต้อง
+    <string name="home_adb_is_limited_description">ผู้ผลิตอุปกรณ์ของคุณ จำกัดการอนุญาต adb ทำให้แอปที่ใช้ Shizuku™ จะไม่ทำงานอย่างถูกต้อง
 \n
 \nโดยปกติ ข้อจำกัดนี้สามารถจัดการได้โดยการปรับตัวเลือกใน \"ตัวเลือกสำหรับนักพัฒนาซอฟต์แวร์\" โปรดอ่าน การช่วยเหลือสำหรับรายละเอียดวิธีการแก้ไข
 \n
-\nคุณอาจต้องรีสตาร์ท Shizuku เพื่อให้การดำเนินการมีผล</string>
+\nคุณอาจต้องรีสตาร์ท Shizuku™ เพื่อให้การดำเนินการมีผล</string>
     <string name="home_adb_is_limited_title">คุณต้องทำขั้นตอนเพิ่มเติม</string>
-    <string name="home_app_management_empty">แอปที่ขอร้องหรือขอใช้ Shizuku จะแสดงที่นี่</string>
+    <string name="home_app_management_empty">แอปที่ขอร้องหรือขอใช้ Shizuku™ จะแสดงที่นี่</string>
     <string name="dialog_adb_discovery_message_toggle_wireless_debugging">โปรดลองปิดและเปิดใช้งาน \"การแก้ไขข้อบกพร่องผ่าน Wi-Fi\" ใหม่ หากระบบยังคงค้นหาอยู่</string>
 </resources>

--- a/manager/src/main/res/values-tr/strings.xml
+++ b/manager/src/main/res/values-tr/strings.xml
@@ -12,7 +12,7 @@
     <string name="dialog_adb_port">Port</string>
     <string name="dialog_adb_discovery_message">Lütfen \"Geliştirici seçenekleri\"nde \"Kablosuz hata ayıklama\"yı etkinleştirin. Ağ değiştiğinde \"kablosuz hata ayıklama\" otomatik olarak devre dışı bırakılır.
 \n
-\nNot, \"Geliştirici seçenekleri\" veya \"USB hata ayıklama\" devre dışı bırakmayın, Shizuku durdurulur.</string>
+\nNot, \"Geliştirici seçenekleri\" veya \"USB hata ayıklama\" devre dışı bırakmayın, Shizuku™ durdurulur.</string>
     <string name="dialog_adb_discovery">Kablosuz hata ayıklama hizmeti aranıyor</string>
     <string name="home_wireless_adb_title">Kablosuz hata ayıklama ile başlat</string>
     <string name="home_adb_dialog_view_command_button_send">Gönder</string>
@@ -20,7 +20,7 @@
     <string name="home_adb_dialog_view_command_message">&lt;font face=monospace&gt;%1$s&lt;/font&gt;&lt;br&gt;&lt;br&gt;* Başka hususlar da var, lütfen önce yardımı okuduğunuzu onaylayın.</string>
     <string name="home_adb_button_view_command">Komutu görüntüle</string>
     <string name="home_adb_button_view_help">Yardımı oku</string>
-    <string name="home_adb_description">Rootsuz cihazlar için Shizuku’yu başlatmak için adb kullanmanız gerekir (bilgisayar bağlantısı gerektirir). Bu işlemin cihaz her yeniden başlatıldığında tekrarlanması gerekir. Lütfen <b><a href="%1$s">yardımı okuyun</a></b>.</string>
+    <string name="home_adb_description">Rootsuz cihazlar için Shizuku™’yu başlatmak için adb kullanmanız gerekir (bilgisayar bağlantısı gerektirir). Bu işlemin cihaz her yeniden başlatıldığında tekrarlanması gerekir. Lütfen <b><a href="%1$s">yardımı okuyun</a></b>.</string>
     <string name="home_adb_title">Bilgisayara bağlanarak başlatın</string>
     <string name="home_status_service_version_update">Sürüm %2$s, %1$s&lt;br&gt;Sürüm %3$s, güncelleştirmek için yeniden başlatın</string>
     <string name="home_status_service_version">Sürüm %2$s, %1$s</string>
@@ -33,7 +33,7 @@
     <string name="home_app_management_title">Uygulama yönetimi</string>
     <string name="home_root_button_restart">Yeniden başlat</string>
     <string name="home_root_button_start">Başlat</string>
-    <string name="home_root_description">Buna ek olarak, Shizuku otomatik olarak açılışta başlatılabilir. Aksi durumda ise, lütfen sisteminizin veya üçüncü taraf araçlarınızın Shizuku\'yu kısıtlayıp kısıtlamadığını kontrol edin. &lt;br&gt;%s \'ye başvurabilirsiniz.</string>
+    <string name="home_root_description">Buna ek olarak, Shizuku™ otomatik olarak açılışta başlatılabilir. Aksi durumda ise, lütfen sisteminizin veya üçüncü taraf araçlarınızın Shizuku™\'yu kısıtlayıp kısıtlamadığını kontrol edin. &lt;br&gt;%s \'ye başvurabilirsiniz.</string>
     <string name="home_root_title">Başlat (rootlu cihazlar için)</string>
     <string name="development_settings">Geliştirici seçenekleri</string>
     <string name="adb_pair_required">Lütfen önce eşleştirme adımını uygulayın.</string>
@@ -47,25 +47,25 @@
     <string name="translation_contributors">İlker Binzet (ilker.binzet@gmail.com)
 \nUmut Songur (umutsongur19@gmail.com)
 \ncroxz900 (croxz.900@gmail.com)</string>
-    <string name="dialog_requesting_legacy_button_open_shizuku">Shizuku’yu aç</string>
-    <string name="dialog_requesting_legacy_message">&lt;b&gt;%1$s&lt;/b&gt; yeni Shizuku desteğine sahip ama eski Shizuku talep ediyor. Bu Shizuku çalışmadığı zaman meydana gelir, lütfen Shizuku uygulamasını kontrol edin.&lt;p&gt;Eski Shizuku uygulaması Mart 2019’da kullanımdan kaldırılmıştır.</string>
-    <string name="dialog_requesting_legacy_title">%1$s, mevcut Shizuku gerektiriyor</string>
-    <string name="dialog_legacy_not_support_message">Eski Shizuku, Mart 2019’dan beri kullanımdan kaldırılmıştır. Ayrıca, eski Shizuku yeni Android sistemlerinde çalışmaz. &lt;p&gt;Lütfen&lt;b&gt;%1$s&lt;/b&gt; geliştiricisinden güncelleme yapmasını isteyin.</string>
-    <string name="dialog_legacy_not_support_title">%1$s, yeni Shizuku’yu desteklemiyor</string>
+    <string name="dialog_requesting_legacy_button_open_shizuku">Shizuku™’yu aç</string>
+    <string name="dialog_requesting_legacy_message">&lt;b&gt;%1$s&lt;/b&gt; yeni Shizuku™ desteğine sahip ama eski Shizuku™ talep ediyor. Bu Shizuku™ çalışmadığı zaman meydana gelir, lütfen Shizuku™ uygulamasını kontrol edin.&lt;p&gt;Eski Shizuku™ uygulaması Mart 2019’da kullanımdan kaldırılmıştır.</string>
+    <string name="dialog_requesting_legacy_title">%1$s, mevcut Shizuku™ gerektiriyor</string>
+    <string name="dialog_legacy_not_support_message">Eski Shizuku™, Mart 2019’dan beri kullanımdan kaldırılmıştır. Ayrıca, eski Shizuku™ yeni Android sistemlerinde çalışmaz. &lt;p&gt;Lütfen&lt;b&gt;%1$s&lt;/b&gt; geliştiricisinden güncelleme yapmasını isteyin.</string>
+    <string name="dialog_legacy_not_support_title">%1$s, yeni Shizuku™’yu desteklemiyor</string>
     <string name="toast_copied_to_clipboard_with_text"><b>%s</b> panoya kopyalandı.</string>
     <string name="toast_copied_to_clipboard">%s
 \npanoya kopyalanmıştır.</string>
     <string name="dialog_cannot_open_browser_title">Tarayıcı başlatılamıyor</string>
     <string name="start_with_root_failed">Root izni verilmediği veya bu aygıtın rootlu olmadığı için hizmet başlatılamıyor.</string>
     <string name="starter">Başlatıcı</string>
-    <string name="permission_label">Shizuku’ya erişim</string>
+    <string name="permission_label">Shizuku™’ya erişim</string>
     <string name="notification_working">Çalışıyor…</string>
     <string name="notification_service_start_no_root">Kök izni sağlanamadı.</string>
-    <string name="notification_service_start_failed">Shizuku hizmeti başlatılamadı.</string>
-    <string name="notification_service_starting">Shizuku hizmeti başlıyor…</string>
+    <string name="notification_service_start_failed">Shizuku™ hizmeti başlatılamadı.</string>
+    <string name="notification_service_starting">Shizuku™ hizmeti başlıyor…</string>
     <string name="notification_channel_service_status">Hizmet başlangıç durumu</string>
-    <string name="dialog_stop_message">Shizuku hizmeti durdurulacak.</string>
-    <string name="action_stop">Shizuku’yu durdur</string>
+    <string name="dialog_stop_message">Shizuku™ hizmeti durdurulacak.</string>
+    <string name="action_stop">Shizuku™’yu durdur</string>
     <string name="about_view_source_code">%s ’da kaynak kodunu görüntüle</string>
     <string name="action_about">Hakkında</string>
     <string name="settings_translation_summary">%s , dilinize çevirmemize yardımcı olun</string>
@@ -77,41 +77,41 @@
     <string name="settings_user_interface">Görünüm</string>
     <string name="settings_language">Dil</string>
     <string name="settings_title">Ayarlar</string>
-    <string name="app_management_item_summary_requires_root">* Shizuku’nun root ile çalıştırılması gerekli</string>
+    <string name="app_management_item_summary_requires_root">* Shizuku™’nun root ile çalıştırılması gerekli</string>
     <string name="app_management_dialog_adb_is_limited_message">Cihaz üreticinizin adb iznini sınırlaması son derece olasıdır. &lt;p&gt;Bu belgede&lt;b&gt;&lt;a href=\"%1$s\"&gt;sisteminiz için bir çözüm olabilir&lt;/a&gt;&lt;/b&gt;.</string>
     <string name="app_management_dialog_adb_is_limited_title">ADB’nin izni sınırlıdır</string>
-    <string name="home_learn_more_description">Shizuku ile nasıl uygulama geliştireceğinizi öğrenin</string>
+    <string name="home_learn_more_description">Shizuku™ ile nasıl uygulama geliştireceğinizi öğrenin</string>
     <string name="home_learn_more_title">Daha fazlasını öğren</string>
     <string name="home_app_management_view_authorized_apps">Yetkilendirilmiş uygulamaları yönetmek için dokunun</string>
-    <string name="settings_start_on_boot_summary">Rootlu cihazlar için, Shizuku sistem açılışı sırasında otomatik olarak başlayabilir</string>
+    <string name="settings_start_on_boot_summary">Rootlu cihazlar için, Shizuku™ sistem açılışı sırasında otomatik olarak başlayabilir</string>
     <string name="settings_start_on_boot">Sistem açılışında başlat (root)</string>
     <string name="grant_dialog_button_allow_always">Her zaman izin ver</string>
     <string name="grant_dialog_button_deny">Reddet</string>
     <string name="permission_warning_template"><b>%1$s</b> uygulamasına %2$s için izin verilsin mi\?</string>
     <string name="terminal_tutorial_3_description">Bazı ipuçları: %1$s’e yürütme izni verin ve %2$s’a ekleyin, %1$s’i doğrudan kullanabileceksiniz.</string>
-    <string name="home_wireless_adb_description">Android 11 ve üzeri sürümlerde, Kablosuz hata ayıklama ve Shizuku\'yu cihazınızdan bir bilgisayara bağlanmadan direkt aktif edebilirsiniz.&lt;p&gt;Lütfen öncelikle adım adım kılavuz\'u inceleyin.</string>
+    <string name="home_wireless_adb_description">Android 11 ve üzeri sürümlerde, Kablosuz hata ayıklama ve Shizuku™\'yu cihazınızdan bir bilgisayara bağlanmadan direkt aktif edebilirsiniz.&lt;p&gt;Lütfen öncelikle adım adım kılavuz\'u inceleyin.</string>
     <string name="adb_pairing_tutorial_content_miui">MIUI kullanıcılarının sistem ayarlarında \"Bildirim\" - \"Bildirim gölgesi\"nden bildirim stilini \"Android\" olarak değiştirmeleri gerekebilir.</string>
-    <string name="home_terminal_title">Shizuku’yu terminal uygulamalarında kullanın</string>
-    <string name="home_terminal_description">Sevdiğiniz terminal uygulamalarında Shizuku aracılığıyla komutları çalıştırın</string>
+    <string name="home_terminal_title">Shizuku™’yu terminal uygulamalarında kullanın</string>
+    <string name="home_terminal_description">Sevdiğiniz terminal uygulamalarında Shizuku™ aracılığıyla komutları çalıştırın</string>
     <string name="terminal_tutorial_1">İlk olarak, dosyaları istediğiniz yere dışa aktarın. İki dosya bulacaksınız, %1$s ve %2$s.</string>
     <string name="terminal_tutorial_1_description">Seçilen klasörde aynı ada sahip dosyalar varsa bunlar silinecektir.
 \n
-\nDışa aktarma işlevi SAF’yi (Depolama Erişim Çerçevesi) kullanır. MIUI’ın SAF işlevlerini bozduğu bildirildi. MIUI kullanıyorsanız, dosyayı Shizuku’nun apk’sinden çıkarmanız veya GitHub’dan indirmeniz gerekebilir.</string>
+\nDışa aktarma işlevi SAF’yi (Depolama Erişim Çerçevesi) kullanır. MIUI’ın SAF işlevlerini bozduğu bildirildi. MIUI kullanıyorsanız, dosyayı Shizuku™’nun apk’sinden çıkarmanız veya GitHub’dan indirmeniz gerekebilir.</string>
     <string name="terminal_export_files">Dosyaları dışa aktar</string>
-    <string name="adb_pairing_tutorial_content_notification">Shizuku’dan bir bildirim eşleştirmeyi tamamlamanıza yardım edecek.</string>
+    <string name="adb_pairing_tutorial_content_notification">Shizuku™’dan bir bildirim eşleştirmeyi tamamlamanıza yardım edecek.</string>
     <string name="adb_pairing_tutorial_content_steps">\"Geliştirici Seçenekleri\" - \"Kablosuz hata ayıklama\" girin. \"Cihazı eşleştirme kodu ile eşleştir\"e dokunun, altı haneli bir kod göreceksiniz.</string>
     <string name="adb_pairing_tutorial_content_enter_pairing_code">Eşleştirmeyi tamamlamak için kodu bildirime girin.</string>
-    <string name="rish_description">%1$s ile herhangi bir terminal uygulamasında Shizuku\'nun shell run\'larına bağlanabilir ve bunlarla etkileşim kurabilirsiniz. &lt;p&gt;%1$s ayrıntılı kullanımı hakkında, belgeyi görüntülemek için dokunun.</string>
-    <string name="adb_pairing_tutorial_title">Shizuku’yu cihazınızla eşleştirin</string>
-    <string name="home_root_description_sui">Magisk kullanıyorsanız, %1$s’yi deneyebilirsiniz. Kök kullanıcıları için sonunda Shizuku’nun yerini alacak. %2$s’yi kullanmak için mevcut uygulamaların biraz değişmesi gerektiğini unutmayın.</string>
+    <string name="rish_description">%1$s ile herhangi bir terminal uygulamasında Shizuku™\'nun shell run\'larına bağlanabilir ve bunlarla etkileşim kurabilirsiniz. &lt;p&gt;%1$s ayrıntılı kullanımı hakkında, belgeyi görüntülemek için dokunun.</string>
+    <string name="adb_pairing_tutorial_title">Shizuku™’yu cihazınızla eşleştirin</string>
+    <string name="home_root_description_sui">Magisk kullanıyorsanız, %1$s’yi deneyebilirsiniz. Kök kullanıcıları için sonunda Shizuku™’nun yerini alacak. %2$s’yi kullanmak için mevcut uygulamaların biraz değişmesi gerektiğini unutmayın.</string>
     <string name="notification_settings">Bildirim seçenekleri</string>
-    <string name="adb_pairing_tutorial_content_notification_blocked">Eşleştirme işlemi, Shizuku\'dan gelen bir bildirimle etkileşim kurmanızı gerektirir. Lütfen Shizuku\'nun bildirim göndermesine izin verin.</string>
+    <string name="adb_pairing_tutorial_content_notification_blocked">Eşleştirme işlemi, Shizuku™\'dan gelen bir bildirimle etkileşim kurmanızı gerektirir. Lütfen Shizuku™\'nun bildirim göndermesine izin verin.</string>
     <string name="terminal_tutorial_2">Ardından, %1$s’i açıp düzenlemek için herhangi bir metin düzenleyiciyi kullanın.</string>
-    <string name="terminal_tutorial_2_description">Örneğin, Shizuku\'yu %1$s içinde kullanmak istiyorsanız, %2$s\'yi %3$s ile değiştirmelisiniz (%4$s, %1$s paketinin adıdır).</string>
-    <string name="terminal_tutorial_3">Son olarak, dosyaları terminal uygulamanızın erişebileceği bir yere taşıyın, Shizuku aracılığıyla komutları çalıştırmak için %1$s kullanabileceksiniz.</string>
+    <string name="terminal_tutorial_2_description">Örneğin, Shizuku™\'yu %1$s içinde kullanmak istiyorsanız, %2$s\'yi %3$s ile değiştirmelisiniz (%4$s, %1$s paketinin adıdır).</string>
+    <string name="terminal_tutorial_3">Son olarak, dosyaları terminal uygulamanızın erişebileceği bir yere taşıyın, Shizuku™ aracılığıyla komutları çalıştırmak için %1$s kullanabileceksiniz.</string>
     <string name="home_wireless_adb_description_pre_11">Android 11 ve önceki sürümlerde, Kablosuz hata ayıklama’yı aktif etmek için bir bilgisayara bağlanmak gereklidir.</string>
     <string name="home_wireless_adb_view_guide_button">Adım adım kılavuz</string>
-    <string name="adb_pairing_tutorial_content_finish">Shizuku\'ya geri dönün ve Shizuku\'yu başlatın.</string>
+    <string name="adb_pairing_tutorial_content_finish">Shizuku™\'ya geri dönün ve Shizuku™\'yu başlatın.</string>
     <string name="notification_channel_adb_pairing">Kablosuz hata ayıklama eşleştirmesi</string>
     <string name="notification_adb_pairing_input_paring_code">Eşleştirme kodunu girin</string>
     <string name="notification_adb_pairing_searching_for_service_title">Eşleştirme hizmeti aranıyor</string>
@@ -119,21 +119,21 @@
     <string name="notification_adb_pairing_stop_searching">Aramayı durdur</string>
     <string name="notification_adb_pairing_working_title">Eşleştirme devam ediyor</string>
     <string name="notification_adb_pairing_succeed_title">Eşleştirme başarılı</string>
-    <string name="notification_adb_pairing_succeed_text">Shizuku hizmetini şimdi başlatabilirsiniz.</string>
+    <string name="notification_adb_pairing_succeed_text">Shizuku™ hizmetini şimdi başlatabilirsiniz.</string>
     <string name="notification_adb_pairing_failed_title">Eşleştirme başarısız</string>
     <string name="notification_adb_pairing_retry">Yeniden dene</string>
-    <string name="permission_description">Uygulamanın Shizuku’yu kullanmasına izin verin.</string>
+    <string name="permission_description">Uygulamanın Shizuku™’yu kullanmasına izin verin.</string>
     <string name="adb_pairing_tutorial_content_miui_2">Aksi takdirde, bildirimden eşleştirme kodunu giremeyebilirsiniz.</string>
-    <string name="adb_pairing_tutorial_content_network">Shizuku’nun yerel ağa erişmesi gerekiyor. Ağ izni tarafından kontrol edilir.</string>
+    <string name="adb_pairing_tutorial_content_network">Shizuku™’nun yerel ağa erişmesi gerekiyor. Ağ izni tarafından kontrol edilir.</string>
     <string name="adb_pairing_tutorial_content_left_is_clickable">Lütfen, \"Kablosuz hata ayıklama\" seçeneğinin sol kısmının tıklanabilir olduğunu, dokunulduğunda yeni bir sayfa açılacağını unutmayın. Yalnızca sağdaki düğmeyi açmak yanlıştır.</string>
-    <string name="adb_pairing_tutorial_content_network_limation_not_foreground">Bazı sistemler (MIUI gibi), uygulama standart olarak ön plan hizmetini kullansa bile, arka planda çalıştıklarında ağa erişmesine izin vermez. Lütfen bu tür sistemlerde Shizuku için pil optimizasyon özelliklerini devre dışı bırakın.</string>
+    <string name="adb_pairing_tutorial_content_network_limation_not_foreground">Bazı sistemler (MIUI gibi), uygulama standart olarak ön plan hizmetini kullansa bile, arka planda çalıştıklarında ağa erişmesine izin vermez. Lütfen bu tür sistemlerde Shizuku™ için pil optimizasyon özelliklerini devre dışı bırakın.</string>
     <string name="settings_use_system_color">Sistem tema rengini kullan</string>
     <string name="home_adb_is_limited_title">Fazladan bi adım daha yapmanız gerekiyor</string>
     <string name="dialog_adb_discovery_message_toggle_wireless_debugging">Eğer sürekli arıyorsa lütfen \"Wireless Debugging\" ayarını kapatıp açmayı deneyin.</string>
-    <string name="home_app_management_empty">Shizuku iznine ihtiyaç duyan uygulamalar burada gösterilir.</string>
-    <string name="home_adb_is_limited_description">Cihaz üreticiniz adb izinlerini kısıtladığı için Shizuku kullanan uygulamalar düzgün çalışmayacaktır. 
+    <string name="home_app_management_empty">Shizuku™ iznine ihtiyaç duyan uygulamalar burada gösterilir.</string>
+    <string name="home_adb_is_limited_description">Cihaz üreticiniz adb izinlerini kısıtladığı için Shizuku™ kullanan uygulamalar düzgün çalışmayacaktır. 
 \n 
 \nGenellikle, bu kısıtlama \"Geliştirici seçenekleri\"ndeki bazı ayarlar değiştirilerek kaldırılabilir. Bunun nasıl yapılacağına ilişkin ayrıntılar için lütfen yardımı okuyun. 
 \n 
-\nİşlemin etkili olabilmesi için Shizuku yeniden başlatılmalı.</string>
+\nİşlemin etkili olabilmesi için Shizuku™ yeniden başlatılmalı.</string>
 </resources>

--- a/manager/src/main/res/values-uk/strings.xml
+++ b/manager/src/main/res/values-uk/strings.xml
@@ -11,13 +11,13 @@
     <string name="notification_channel_service_status">Статус запуску серав</string>
     <string name="home_adb_dialog_view_command_copy_button">Копіювати</string>
     <string name="dialog_cannot_open_browser_title">Не вдається запустити браузер</string>
-    <string name="home_learn_more_title">Вивчіть Shizuku</string>
-    <string name="home_learn_more_description">Дізнайтеся, як розробляти з Shizuku</string>
-    <string name="notification_service_start_failed">Помилка запуску служби Shizuku.</string>
+    <string name="home_learn_more_title">Вивчіть Shizuku™</string>
+    <string name="home_learn_more_description">Дізнайтеся, як розробляти з Shizuku™</string>
+    <string name="notification_service_start_failed">Помилка запуску служби Shizuku™.</string>
     <string name="notification_service_start_no_root">Помилка запиту на root доступ.</string>
-    <string name="notification_service_starting">Сервіс Shizuku запущено…</string>
+    <string name="notification_service_starting">Сервіс Shizuku™ запущено…</string>
     <string name="notification_working">Працює…</string>
-    <string name="dialog_requesting_legacy_button_open_shizuku">Відкрити Shizuku</string>
+    <string name="dialog_requesting_legacy_button_open_shizuku">Відкрити Shizuku™</string>
     <string name="home_root_button_restart">Перезапуск</string>
     <string name="home_status_service_is_running">%1$s працює</string>
     <string name="home_adb_dialog_view_command_button_send">Відправити</string>
@@ -27,12 +27,12 @@
     <string name="settings_user_interface">Зовнішній вигляд</string>
     <string name="settings_startup">Стартап</string>
     <string name="home_status_service_version_update">версія %2$s, %1$s&lt;br&gt;почніть оновлюватися до версії %3$s</string>
-    <string name="permission_label">доступ до Shizuku</string>
-    <string name="app_management_item_summary_requires_root">* потрібен root, щоб запускався Shizuku</string>
+    <string name="permission_label">доступ до Shizuku™</string>
+    <string name="app_management_item_summary_requires_root">* потрібен root, щоб запускався Shizuku™</string>
     <string name="home_status_service_not_running">%1$s не працює</string>
     <string name="about_view_source_code"><![CDATA[Переглянути вихідний код на %s]]></string>
     <string name="app_management_dialog_adb_is_limited_message">Можливо, ваш виробник пристрою лімітує дозвіл adb.&lt;p&gt;Можливо, є рішення для вашої системи у &lt;b&gt;&lt;a href=\"%1$s\"&gt;цьому документі&lt;/a&gt;&lt;/b&gt;.</string>
-    <string name="home_adb_description">Для пристроїв без root потрібно використовувати ADB для запуску Shizuku (потрібне підключення до комп’ютера). Цей процес потрібно повторювати кожного разу, коли пристрій перезавантажується. Будь ласка, <b><a href="%1$s">прочитайте довідку</a></b>.</string>
+    <string name="home_adb_description">Для пристроїв без root потрібно використовувати ADB для запуску Shizuku™ (потрібне підключення до комп’ютера). Цей процес потрібно повторювати кожного разу, коли пристрій перезавантажується. Будь ласка, <b><a href="%1$s">прочитайте довідку</a></b>.</string>
     <string name="home_adb_title">Почніть з підключення до ПК</string>
     <string name="home_root_title"><![CDATA[Запустіть службу з root доступом]]></string>
     <string name="toast_copied_to_clipboard_with_text"><b>%s</b> скопійовано в буфер обміну.</string>
@@ -45,17 +45,17 @@
     <string name="grant_dialog_button_deny">Заборонити</string>
     <string name="permission_warning_template">Дозволити додатку <b>%1$s</b> таке: %2$s\?</string>
     <string name="home_wireless_adb_title">Запуск за допомогою налагоджування через Wi-Fi</string>
-    <string name="adb_pairing_tutorial_content_notification">Повідомлення від Shizuku допоможе вам закінчити парування.</string>
+    <string name="adb_pairing_tutorial_content_notification">Повідомлення від Shizuku™ допоможе вам закінчити парування.</string>
     <string name="adb_pairing_tutorial_content_enter_pairing_code">Введіть код в повідомленні щоб завершити парування.</string>
-    <string name="adb_pairing_tutorial_title">Парувати Shizuku з вашим пристроєм</string>
+    <string name="adb_pairing_tutorial_title">Парувати Shizuku™ з вашим пристроєм</string>
     <string name="notification_settings">Налаштування повідомлень</string>
-    <string name="adb_pairing_tutorial_content_notification_blocked">Процес парування потребує, щоб ви взаємодіяли із сповіщенням від Shizuku. Будь ласка, дозвольте Shizuku публікувати сповіщення.</string>
-    <string name="home_wireless_adb_description">Починаючи з Android 11 та вище, ви можете ввімкнути налагодження через WiFi та запустити Shizuku прямо з вашого пристрою, не під\'єднуючись до комп\'ютеру.&lt;p&gt;Будь ласка, спочатку перегляньте інструкцію.</string>
+    <string name="adb_pairing_tutorial_content_notification_blocked">Процес парування потребує, щоб ви взаємодіяли із сповіщенням від Shizuku™. Будь ласка, дозвольте Shizuku™ публікувати сповіщення.</string>
+    <string name="home_wireless_adb_description">Починаючи з Android 11 та вище, ви можете ввімкнути налагодження через WiFi та запустити Shizuku™ прямо з вашого пристрою, не під\'єднуючись до комп\'ютеру.&lt;p&gt;Будь ласка, спочатку перегляньте інструкцію.</string>
     <string name="home_wireless_adb_view_guide_button">Покрокова інструкція</string>
     <string name="dialog_adb_discovery">Пошук сервісу бездротового налагодження</string>
     <string name="dialog_adb_discovery_message">Будь ласка, увімкніть \"Налагодження через Wi-Fi\" в \"Параметрах розробника\". \"Налагодження через Wi-Fi\" автоматично вимикається при зміні мереж.
 \n
-\nЗверніть увагу, не вимикайте \"Параметри розробника\" чи \"Налагодження USB\", інакше Shizuku буде зупинено.</string>
+\nЗверніть увагу, не вимикайте \"Параметри розробника\" чи \"Налагодження USB\", інакше Shizuku™ буде зупинено.</string>
     <string name="dialog_adb_port">Порт</string>
     <string name="dialog_adb_invalid_port">Порт – це ціле число від 1 до 65535.</string>
     <string name="adb_pairing">Парування</string>
@@ -81,30 +81,30 @@
     <string name="adb_pairing_tutorial_content_miui">Користувачам MIUI, иожливо, доведеться змінити стіль сповіщень на \"Android\" із \"Сповіщення\" - \"Панель сповіщень\" в системних налаштуваннях.</string>
     <string name="settings_title">Налаштування</string>
     <string name="adb_pairing_tutorial_content_miui_2">В іншому випадку, ви, можливо, не зможете увести код парування з повідомлення.</string>
-    <string name="home_terminal_title">Використовувати Shizuku в програмах терміналу</string>
-    <string name="home_terminal_description">Виконуйте команди через Shizuku у програмах терміналу, які вам подобаються</string>
+    <string name="home_terminal_title">Використовувати Shizuku™ в програмах терміналу</string>
+    <string name="home_terminal_description">Виконуйте команди через Shizuku™ у програмах терміналу, які вам подобаються</string>
     <string name="terminal_tutorial_2">Тоді, використайте будь-який текстовий редактор та редагуйте %1$s.</string>
-    <string name="terminal_tutorial_3">Нарешті, перемістіть файли туди, де програма терміналу матиме доступ до них, ви зможете використовувати %1$s для запуску команд через Shizuku.</string>
+    <string name="terminal_tutorial_3">Нарешті, перемістіть файли туди, де програма терміналу матиме доступ до них, ви зможете використовувати %1$s для запуску команд через Shizuku™.</string>
     <string name="settings_translation">Беріть участь у перекладі</string>
     <string name="settings_translation_summary">Допоможіть нам перекласти %s на вашу мову</string>
     <string name="notification_adb_pairing_succeed_title">Парування успішне</string>
     <string name="terminal_tutorial_1_description">Файли з такою ж назвою у вибраній папці буде видалено.
 \n
-\nФункція експорту використовує SAF (Storage Access Framework). Були скарги на те, що MIUI ламає функції SAF. Якщо ви користуєтесь MIUI, вам потрібно розпакувати файл з apk-файлу Shizuku або завантажити його з GitHub.</string>
+\nФункція експорту використовує SAF (Storage Access Framework). Були скарги на те, що MIUI ламає функції SAF. Якщо ви користуєтесь MIUI, вам потрібно розпакувати файл з apk-файлу Shizuku™ або завантажити його з GitHub.</string>
     <string name="notification_adb_pairing_retry">Спробувати ще раз</string>
     <string name="notification_adb_pairing_failed_title">Парування невдале</string>
-    <string name="action_stop">Зупинити Shizuku</string>
-    <string name="dialog_stop_message">Сервіс Shizuku буде зупинено.</string>
-    <string name="adb_pairing_tutorial_content_network">Shizuku потрібен доступ до локальної мережі. Це контролюється дозволом мережі.</string>
-    <string name="adb_pairing_tutorial_content_network_limation_not_foreground">Деякі системи (наприклад, MIUI) забороняють програмам доступ до мережі коли їх не видно, навіть якщо програма використовує фоновий сервіс за замовчуванням. Будь ласка, вимкніть оптимізацію батареї для Shizuku на таких системах.</string>
-    <string name="settings_start_on_boot_summary">Для рутованих пристроїв, Shizuku має можливість автоматично запускатися при завантаженні системи</string>
+    <string name="action_stop">Зупинити Shizuku™</string>
+    <string name="dialog_stop_message">Сервіс Shizuku™ буде зупинено.</string>
+    <string name="adb_pairing_tutorial_content_network">Shizuku™ потрібен доступ до локальної мережі. Це контролюється дозволом мережі.</string>
+    <string name="adb_pairing_tutorial_content_network_limation_not_foreground">Деякі системи (наприклад, MIUI) забороняють програмам доступ до мережі коли їх не видно, навіть якщо програма використовує фоновий сервіс за замовчуванням. Будь ласка, вимкніть оптимізацію батареї для Shizuku™ на таких системах.</string>
+    <string name="settings_start_on_boot_summary">Для рутованих пристроїв, Shizuku™ має можливість автоматично запускатися при завантаженні системи</string>
     <string name="home_wireless_adb_description_pre_11">До Android 11, потрібно під\'єднатися до комп\'ютеру щоб ввімкнути налагодження через Wi-FI.</string>
-    <string name="adb_pairing_tutorial_content_finish">Поверніться до Shizuku та запустіть Shizuku.</string>
-    <string name="home_root_description">В додаток, Shizuku можна автоматично запустити при завантаженні. Якщо цього не трапляється, будь ласка, перевірте чи ваша не обмежили Shizuku система чи сторонні інструменти.&lt;br&gt;Ви можете переглянути більше на %s.</string>
-    <string name="home_root_description_sui">Якщо ви користуєтесь Magisk, ви можете спробувати %1$s. Для користувачів root, він колись замінить Shizuku. Увага, існуючі програми мають трохи змінитися щоб можна було користуватися %2$s.</string>
-    <string name="dialog_legacy_not_support_title">%1$s не підтримує сучасну версію Shizuku</string>
-    <string name="dialog_requesting_legacy_title">%1$s просить стару версію Shizuku</string>
-    <string name="dialog_requesting_legacy_message">&lt;b&gt;%1$s&lt;/b&gt; має підтримку нової версії Shizuku, але просить стару версію Shizuku. Це може трапитися тому, що Shizuku не запущено, будь ласка, перевірте у програмі Shizuku.&lt;p&gt;Підтримка старої версії Shizuku завершилася у березні 2019 року.</string>
+    <string name="adb_pairing_tutorial_content_finish">Поверніться до Shizuku™ та запустіть Shizuku™.</string>
+    <string name="home_root_description">В додаток, Shizuku™ можна автоматично запустити при завантаженні. Якщо цього не трапляється, будь ласка, перевірте чи ваша не обмежили Shizuku™ система чи сторонні інструменти.&lt;br&gt;Ви можете переглянути більше на %s.</string>
+    <string name="home_root_description_sui">Якщо ви користуєтесь Magisk, ви можете спробувати %1$s. Для користувачів root, він колись замінить Shizuku™. Увага, існуючі програми мають трохи змінитися щоб можна було користуватися %2$s.</string>
+    <string name="dialog_legacy_not_support_title">%1$s не підтримує сучасну версію Shizuku™</string>
+    <string name="dialog_requesting_legacy_title">%1$s просить стару версію Shizuku™</string>
+    <string name="dialog_requesting_legacy_message">&lt;b&gt;%1$s&lt;/b&gt; має підтримку нової версії Shizuku™, але просить стару версію Shizuku™. Це може трапитися тому, що Shizuku™ не запущено, будь ласка, перевірте у програмі Shizuku™.&lt;p&gt;Підтримка старої версії Shizuku™ завершилася у березні 2019 року.</string>
     <string name="settings_use_system_color">Використовувати системний колір</string>
     <string name="notification_channel_adb_pairing">Парування для налагодження по Wi-Fi</string>
     <string name="notification_adb_pairing_input_paring_code">Уведіть код парування</string>
@@ -112,8 +112,8 @@
     <string name="notification_adb_pairing_service_found_title">Сервіс парування знайдено</string>
     <string name="notification_adb_pairing_stop_searching">Зупинити пошук</string>
     <string name="notification_adb_pairing_working_title">Виконується створення пари</string>
-    <string name="notification_adb_pairing_succeed_text">Тепер ви можете запустити сервіс Shizuku.</string>
-    <string name="permission_description">Дозволити програмі використовувати Shizuku.</string>
+    <string name="notification_adb_pairing_succeed_text">Тепер ви можете запустити сервіс Shizuku™.</string>
+    <string name="permission_description">Дозволити програмі використовувати Shizuku™.</string>
     <string name="adb_pairing_tutorial_content_left_is_clickable">Зверніть увагу, на ліву частину \"Налагодження по Wi-Fi\" можна натиснути, при натисканні відкриється нова сторіна. Лише вмикати перемикач справа неправильно.</string>
     <plurals name="home_app_management_authorized_apps_count">
         <item quantity="one">Авторизовано %d програму</item>
@@ -122,18 +122,18 @@
         <item quantity="other">Авторизовано %d програм</item>
     </plurals>
     <string name="terminal_tutorial_1">Спочатку, експортуйте файли де вам потрібно. Ви побачите два файли, %1$s та %2$s.</string>
-    <string name="terminal_tutorial_2_description">Наприклад, якщо ви хочете використати Shizuku в %1$s, вам потрібно замінити %2$s на %3$s (%4$s це назва пакету %1$s).</string>
+    <string name="terminal_tutorial_2_description">Наприклад, якщо ви хочете використати Shizuku™ в %1$s, вам потрібно замінити %2$s на %3$s (%4$s це назва пакету %1$s).</string>
     <string name="terminal_tutorial_3_description">Деякі поради: надайте %1$s дозвіл на виконання та додайте його в %2$s, ви зможете використовувати %1$s відразу.</string>
-    <string name="rish_description">З %1$s, в будь-якій програмі терміналу, ви зможете під\'\'єднатися та взаємодіяти з Shizuku. &lt;p&gt;Ви можете дізнатися більше про використання %1$s, натисніть тут щоб перегляньте документацію.</string>
+    <string name="rish_description">З %1$s, в будь-якій програмі терміналу, ви зможете під\'\'єднатися та взаємодіяти з Shizuku™. &lt;p&gt;Ви можете дізнатися більше про використання %1$s, натисніть тут щоб перегляньте документацію.</string>
     <string name="settings_translation_contributors">Співробітники перекладу</string>
     <string name="settings_start_on_boot">Запуск при завантаженні системи (root)</string>
-    <string name="dialog_legacy_not_support_message">Підтримка старої версії Shizuku завершилася у березні 2019 року. Також, стара версія Shizuku не працює на нових версіях Android.&lt;p&gt;Будь ласка, попросіть оновитися у розробника &lt;b&gt;%1$s&lt;/b&gt;.</string>
-    <string name="home_app_management_empty">Додатки, що запросили або декларували використання Shizuku будуть відображені тут.</string>
-    <string name="home_adb_is_limited_description">Виробник вашого пристрою обмежив права ADB, додатки що використовую Shizuku будуть працювати некорректно.
+    <string name="dialog_legacy_not_support_message">Підтримка старої версії Shizuku™ завершилася у березні 2019 року. Також, стара версія Shizuku™ не працює на нових версіях Android.&lt;p&gt;Будь ласка, попросіть оновитися у розробника &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="home_app_management_empty">Додатки, що запросили або декларували використання Shizuku™ будуть відображені тут.</string>
+    <string name="home_adb_is_limited_description">Виробник вашого пристрою обмежив права ADB, додатки що використовую Shizuku™ будуть працювати некорректно.
 \n
 \nЗазвичай ці обмеження можна зняти змінивши налаштування в параметрах розробника. Будь ласка, прочитайте як це зробити в розділі \"Допомога\".
 \n
-\nМожливо потрібно буде перезапустити Shizuku.</string>
+\nМожливо потрібно буде перезапустити Shizuku™.</string>
     <string name="home_adb_is_limited_title">Потрібен ще один крок</string>
     <string name="dialog_adb_discovery_message_toggle_wireless_debugging">Будь ласка, спробуйте вимкнути та увімкнути \"Налагодження через Wi-Fi\", якщо пошук продовжується.</string>
 </resources>

--- a/manager/src/main/res/values-vi/strings.xml
+++ b/manager/src/main/res/values-vi/strings.xml
@@ -12,7 +12,7 @@
     <string name="dialog_adb_discovery">Tìm kiếm dịch vụ gỡ lỗi không dây</string>
     <string name="dialog_adb_discovery_message">Vui lòng bật \"Gỡ lỗi không dây\" trong \"Tùy chọn nhà phát triển\". \"Gỡ lỗi không dây\" tự động bị tắt khi mạng thay đổi.
 \n
-\nLưu ý, không vô hiệu hóa \"Tùy chọn nhà phát triển\" hoặc \"Gỡ lỗi USB\", nếu không Shizuku sẽ bị dừng.</string>
+\nLưu ý, không vô hiệu hóa \"Tùy chọn nhà phát triển\" hoặc \"Gỡ lỗi USB\", nếu không Shizuku™ sẽ bị dừng.</string>
     <string name="dialog_adb_port">Cổng</string>
     <string name="dialog_adb_invalid_port">Cổng là một số nguyên nằm trong khoảng từ 1 đến 65535.</string>
     <string name="dialog_adb_pairing_title">Ghép nối với thiết bị</string>
@@ -28,18 +28,18 @@
         <item quantity="other">Đã ủy quyền %d ứng dụng</item>
     </plurals>
     <string name="home_app_management_view_authorized_apps">Nhấn để quản lý các ứng dụng được ủy quyền</string>
-    <string name="home_root_description_sui">Nếu bạn đang sử dụng Magisk, bạn có thể thử %1$s. Đối với người dùng root, nó cuối cùng sẽ thay thế Shizuku. Lưu ý, các ứng dụng hiện có cần thay đổi một chút để sử dụng %2$s.</string>
+    <string name="home_root_description_sui">Nếu bạn đang sử dụng Magisk, bạn có thể thử %1$s. Đối với người dùng root, nó cuối cùng sẽ thay thế Shizuku™. Lưu ý, các ứng dụng hiện có cần thay đổi một chút để sử dụng %2$s.</string>
     <string name="adb_error_key_store">Không thể tạo khóa để gỡ lỗi không dây.
 \nĐiều này có thể do cơ chế KeyStore của thiết bị này bị hỏng.</string>
     <string name="adb_pair_required">Vui lòng thực hiện bước ghép nối trước.</string>
     <string name="development_settings">Tùy chọn nhà phát triển</string>
     <string name="home_app_management_title">Quản lí ứng dụng</string>
-    <string name="home_learn_more_title">Tìm hiểu Shizuku</string>
-    <string name="home_learn_more_description">Tìm hiểu cách phát triển với Shizuku hoặc tải ứng dụng bằng Shizuku</string>
+    <string name="home_learn_more_title">Tìm hiểu Shizuku™</string>
+    <string name="home_learn_more_description">Tìm hiểu cách phát triển với Shizuku™ hoặc tải ứng dụng bằng Shizuku™</string>
     <string name="app_management_dialog_adb_is_limited_title">Quyền của adb bị hạn chế</string>
-    <string name="app_management_item_summary_requires_root">* yêu cầu Shizuku chạy với root</string>
-    <string name="home_terminal_title">Sử dụng Shizuku trong các ứng dụng đầu cuối</string>
-    <string name="home_terminal_description">Chạy lệnh thông qua Shizuku trong các ứng dụng đầu cuối bạn thích</string>
+    <string name="app_management_item_summary_requires_root">* yêu cầu Shizuku™ chạy với root</string>
+    <string name="home_terminal_title">Sử dụng Shizuku™ trong các ứng dụng đầu cuối</string>
+    <string name="home_terminal_description">Chạy lệnh thông qua Shizuku™ trong các ứng dụng đầu cuối bạn thích</string>
     <string name="terminal_tutorial_1">Đầu tiên, Xuất tệp sang bất kỳ nơi nào bạn muốn. Bạn sẽ tìm thấy hai tệp, %1$s và %2$s.</string>
     <string name="terminal_export_files">Xuất tệp</string>
     <string name="terminal_tutorial_2">Sau đó, sử dụng bất kỳ trình soạn thảo văn bản nào để mở và chỉnh sửa %1$s.</string>
@@ -47,15 +47,15 @@
     <string name="settings_black_night_theme">Chủ đề đen</string>
     <string name="settings_black_night_theme_summary">Sử dụng chủ đề đen tuyền nếu chế độ ban đêm được bật</string>
     <string name="settings_user_interface">Hiển thị</string>
-    <string name="terminal_tutorial_3">Cuối cùng, di chuyển các tệp đến một nơi nào đó mà ứng dụng đầu cuối của bạn có thể truy cập, bạn sẽ có thể sử dụng %1$s để chạy các lệnh thông qua Shizuku.</string>
-    <string name="rish_description">Với %1$s, trong bất kỳ ứng dụng đầu cuối nào, bạn có thể kết nối và tương tác với shell do Shizuku điều hành. &lt;p&gt;Về cách sử dụng chi tiết %1$s, nhấn để xem tài liệu.</string>
+    <string name="terminal_tutorial_3">Cuối cùng, di chuyển các tệp đến một nơi nào đó mà ứng dụng đầu cuối của bạn có thể truy cập, bạn sẽ có thể sử dụng %1$s để chạy các lệnh thông qua Shizuku™.</string>
+    <string name="rish_description">Với %1$s, trong bất kỳ ứng dụng đầu cuối nào, bạn có thể kết nối và tương tác với shell do Shizuku™ điều hành. &lt;p&gt;Về cách sử dụng chi tiết %1$s, nhấn để xem tài liệu.</string>
     <string name="settings_title">Cài đặt</string>
     <string name="settings_startup">Khởi động</string>
     <string name="settings_start_on_boot">Tự khởi động (root)</string>
-    <string name="settings_start_on_boot_summary">Đối với các thiết bị đã root, Shizuku có thể tự khởi động khi thiết bị khởi động</string>
+    <string name="settings_start_on_boot_summary">Đối với các thiết bị đã root, Shizuku™ có thể tự khởi động khi thiết bị khởi động</string>
     <string name="notification_channel_service_status">Trạng thái khởi động dịch vụ</string>
-    <string name="notification_service_starting">Dịch vụ Shizuku đang khởi động…</string>
-    <string name="notification_service_start_failed">Khởi động dịch vụ Shizuku thất bại.</string>
+    <string name="notification_service_starting">Dịch vụ Shizuku™ đang khởi động…</string>
+    <string name="notification_service_start_failed">Khởi động dịch vụ Shizuku™ thất bại.</string>
     <string name="notification_service_start_no_root">Yêu cầu quyền root thất bại.</string>
     <string name="starter">Trình khởi động</string>
     <string name="start_with_root_failed">Không thể bắt đầu dịch vụ vì quyền root chưa được cấp hoặc thiết bị này chưa được root.</string>
@@ -64,26 +64,26 @@
     <string name="settings_translation">Tham gia phiên dịch</string>
     <string name="settings_translation_contributors">Người đóng góp bản dịch</string>
     <string name="action_about">Giới thiệu</string>
-    <string name="dialog_stop_message">Dịch vụ Shizuku sẽ ngừng hoạt động.</string>
+    <string name="dialog_stop_message">Dịch vụ Shizuku™ sẽ ngừng hoạt động.</string>
     <string name="about_view_source_code">Xem mã nguồn tại %s</string>
-    <string name="action_stop">Dừng Shizuku</string>
+    <string name="action_stop">Dừng Shizuku™</string>
     <string name="notification_working">Đang làm việc…</string>
-    <string name="permission_label">truy cập Shizuku</string>
-    <string name="permission_description">Cho phép ứng dụng sử dụng Shizuku.</string>
+    <string name="permission_label">truy cập Shizuku™</string>
+    <string name="permission_description">Cho phép ứng dụng sử dụng Shizuku™.</string>
     <string name="permission_warning_template">Cho phép <b>%1$s</b> thành %2$s\?</string>
     <string name="grant_dialog_button_allow_always">Cho phép mọi lúc</string>
     <string name="grant_dialog_button_deny">Từ chối</string>
     <string name="toast_copied_to_clipboard">%s
 \nđã được sao chép vào khay nhớ tạm.</string>
     <string name="toast_copied_to_clipboard_with_text"><b>%s</b> đã được sao chép vào khay nhớ tạm.</string>
-    <string name="dialog_legacy_not_support_title">%1$s không hỗ trợ Shizuku hiện đại</string>
-    <string name="dialog_legacy_not_support_message">Shizuku cũ không được dùng nữa kể từ tháng 3 năm 2019. Ngoài ra, Shizuku cũ không hoạt động trên các hệ thống Android mới hơn.&lt;p&gt;Vui lòng yêu cầu nhà phát triển của &lt;b&gt;%1$s&lt;/b&gt; cập nhật.</string>
-    <string name="dialog_requesting_legacy_title">%1$s đang yêu cầu Shizuku cũ</string>
-    <string name="dialog_requesting_legacy_message">&lt;b&gt;%1$s&lt;/b&gt; có hỗ trợ Shizuku hiện đại, nhưng nó yêu cầu Shizuku cũ. Điều này có thể do Shizuku đang không chạy, vui lòng kiểm tra ứng dụng Shizuku.&lt;p&gt;Shizuku cũ không được dùng nữa kể từ tháng 3 năm 2019.</string>
-    <string name="dialog_requesting_legacy_button_open_shizuku">Mở Shizuku</string>
+    <string name="dialog_legacy_not_support_title">%1$s không hỗ trợ Shizuku™ hiện đại</string>
+    <string name="dialog_legacy_not_support_message">Shizuku™ cũ không được dùng nữa kể từ tháng 3 năm 2019. Ngoài ra, Shizuku™ cũ không hoạt động trên các hệ thống Android mới hơn.&lt;p&gt;Vui lòng yêu cầu nhà phát triển của &lt;b&gt;%1$s&lt;/b&gt; cập nhật.</string>
+    <string name="dialog_requesting_legacy_title">%1$s đang yêu cầu Shizuku™ cũ</string>
+    <string name="dialog_requesting_legacy_message">&lt;b&gt;%1$s&lt;/b&gt; có hỗ trợ Shizuku™ hiện đại, nhưng nó yêu cầu Shizuku™ cũ. Điều này có thể do Shizuku™ đang không chạy, vui lòng kiểm tra ứng dụng Shizuku™.&lt;p&gt;Shizuku™ cũ không được dùng nữa kể từ tháng 3 năm 2019.</string>
+    <string name="dialog_requesting_legacy_button_open_shizuku">Mở Shizuku™</string>
     <string name="translation_contributors">The Primal Pea, ngatngay</string>
     <string name="home_status_service_version_update">Phiên bản %2$s, %1$s&lt;br&gt;Bắt đầu lại để cập nhật lên phiên bản %3$s</string>
-    <string name="home_adb_description">Đối với thiết bị không có root, bạn cần sử dụng adb để khởi động Shizuku (yêu cầu kết nối máy tính). Quá trình này cần được lặp lại mỗi khi thiết bị được khởi động lại. Vui lòng <b><a href="%1$s">đọc phần trợ giúp</a></b>.</string>
+    <string name="home_adb_description">Đối với thiết bị không có root, bạn cần sử dụng adb để khởi động Shizuku™ (yêu cầu kết nối máy tính). Quá trình này cần được lặp lại mỗi khi thiết bị được khởi động lại. Vui lòng <b><a href="%1$s">đọc phần trợ giúp</a></b>.</string>
     <string name="home_adb_dialog_view_command_message">&lt;font face=monospace&gt;%1$s&lt;/font&gt;&lt;br&gt;&lt;br&gt;* Có một số cân nhắc khác, vui lòng xác nhận rằng bạn đã đọc phần trợ giúp trước.</string>
     <string name="paring_code_is_wrong">Mã ghép nối sai.</string>
     <string name="cannot_connect_port">Không thể kết nối với dịch vụ gỡ lỗi không dây.</string>
@@ -92,39 +92,39 @@
     <string name="dialog_adb_pairing_message">Vui lòng bắt đầu ghép nối theo các bước sau: \"Tùy chọn nhà phát triển\" - \"Gỡ lỗi không dây\" - \"Ghép nối thiết bị bằng mã ghép nối\".
 \n
 \nSau khi quá trình ghép nối bắt đầu, bạn sẽ có thể nhập mã ghép nối.</string>
-    <string name="home_root_description">Ngoài ra, Shizuku có thể được khởi động tự động khi khởi động. Nếu không, vui lòng kiểm tra xem hệ thống của bạn hoặc các công cụ của bên thứ ba có hạn chế Shizuku hay không.&lt;br&gt;Bạn có thể tham khảo %s.</string>
+    <string name="home_root_description">Ngoài ra, Shizuku™ có thể được khởi động tự động khi khởi động. Nếu không, vui lòng kiểm tra xem hệ thống của bạn hoặc các công cụ của bên thứ ba có hạn chế Shizuku™ hay không.&lt;br&gt;Bạn có thể tham khảo %s.</string>
     <string name="terminal_tutorial_1_description">Nếu có các tệp trùng tên trong thư mục đã chọn, chúng sẽ bị xóa.
 \n
-\nChức năng xuất sử dụng SAF (Khung Truy cập Bộ nhớ). Có báo cáo rằng MIUI phá vỡ các chức năng của SAF. Nếu bạn đang sử dụng MIUI, bạn có thể phải giải nén tệp từ apk của Shizuku hoặc tải xuống từ GitHub.</string>
+\nChức năng xuất sử dụng SAF (Khung Truy cập Bộ nhớ). Có báo cáo rằng MIUI phá vỡ các chức năng của SAF. Nếu bạn đang sử dụng MIUI, bạn có thể phải giải nén tệp từ apk của Shizuku™ hoặc tải xuống từ GitHub.</string>
     <string name="app_management_dialog_adb_is_limited_message">Rất có thể nhà sản xuất thiết bị của bạn giới hạn quyền của adb.&lt;p&gt;Có thể có giải pháp cho hệ thống của bạn trong &lt;b&gt;&lt;a href=\"%1$s\"&gt;tài liệu này&lt;/a&gt;&lt;/b&gt;.</string>
-    <string name="terminal_tutorial_2_description">Ví dụ, nếu bạn muốn sử dụng Shizuku trong %1$s, bạn nên thay thế %2$s bằng %3$s (%4$s là tên gói của %1$s).</string>
+    <string name="terminal_tutorial_2_description">Ví dụ, nếu bạn muốn sử dụng Shizuku™ trong %1$s, bạn nên thay thế %2$s bằng %3$s (%4$s là tên gói của %1$s).</string>
     <string name="terminal_tutorial_3_description">Một số mẹo: cấp quyền thực thi cho %1$s và thêm quyền đó vào %2$s, bạn sẽ có thể sử dụng %1$s trực tiếp.</string>
     <string name="home_wireless_adb_description_pre_11">Trước Android 11, kết nối với máy tính là yêu cầu bắt buộc để bật Gỡ lỗi không dây.</string>
     <string name="notification_adb_pairing_stop_searching">Dừng tìm kiếm</string>
     <string name="adb_pairing_tutorial_content_miui">Người dùng MIUI có thể cần chuyển kiểu thông báo sang \"Android\" từ \"Thông báo\" - \"Bóng thông báo\" trong cài đặt hệ thống.</string>
-    <string name="notification_adb_pairing_succeed_text">Bạn có thể khởi động dịch vụ Shizuku ngay bây giờ.</string>
+    <string name="notification_adb_pairing_succeed_text">Bạn có thể khởi động dịch vụ Shizuku™ ngay bây giờ.</string>
     <string name="notification_adb_pairing_failed_title">Ghép nối thất bại</string>
     <string name="notification_adb_pairing_retry">Thử lại</string>
     <string name="adb_pairing_tutorial_content_enter_pairing_code">Nhập mã vào thông báo để hoàn tất quá trình ghép nối.</string>
-    <string name="adb_pairing_tutorial_content_notification">Một thông báo từ Shizuku sẽ giúp bạn hoàn thành việc ghép nối.</string>
+    <string name="adb_pairing_tutorial_content_notification">Một thông báo từ Shizuku™ sẽ giúp bạn hoàn thành việc ghép nối.</string>
     <string name="adb_pairing_tutorial_content_steps">Nhập \"Tùy chọn nhà phát triển\" - \"Gỡ lỗi qua Wi-Fi\". Nhấn vào \"Ghép nối thiết bị bằng mã ghép nối\", bạn sẽ thấy một mã gồm sáu chữ số.</string>
-    <string name="adb_pairing_tutorial_title">Ghép nối Shizuku với thiết bị của bạn</string>
+    <string name="adb_pairing_tutorial_title">Ghép nối Shizuku™ với thiết bị của bạn</string>
     <string name="notification_settings">Tùy chọn thông báo</string>
-    <string name="adb_pairing_tutorial_content_notification_blocked">Quá trình ghép nối cần bạn tương tác với thông báo từ Shizuku. Vui lòng cho phép Shizuku đăng thông báo.</string>
+    <string name="adb_pairing_tutorial_content_notification_blocked">Quá trình ghép nối cần bạn tương tác với thông báo từ Shizuku™. Vui lòng cho phép Shizuku™ đăng thông báo.</string>
     <string name="notification_channel_adb_pairing">Ghép nối gỡ lỗi qua Wi-Fi</string>
     <string name="notification_adb_pairing_input_paring_code">Nhập mã ghép nối</string>
     <string name="home_wireless_adb_view_guide_button">Hướng dẫn từng bước</string>
-    <string name="adb_pairing_tutorial_content_finish">Quay lại với Shizuku và khởi động Shizuku.</string>
+    <string name="adb_pairing_tutorial_content_finish">Quay lại với Shizuku™ và khởi động Shizuku™.</string>
     <string name="notification_adb_pairing_searching_for_service_title">Đang tìm kiếm dịch vụ ghép nối</string>
     <string name="notification_adb_pairing_service_found_title">Đã tìm thấy dịch vụ ghép nối</string>
     <string name="notification_adb_pairing_working_title">Đang trong quá trình ghép nối</string>
     <string name="notification_adb_pairing_succeed_title">Ghép nối thành công</string>
-    <string name="home_wireless_adb_description">Trên Android 11 trở lên, bạn có thể bật tính năng Gỡ lỗi không dây và khởi động Shizuku trực tiếp từ thiết bị của mình mà không cần kết nối với máy tính.&lt;p&gt;Vui lòng xem hướng dẫn từng bước trước.</string>
+    <string name="home_wireless_adb_description">Trên Android 11 trở lên, bạn có thể bật tính năng Gỡ lỗi không dây và khởi động Shizuku™ trực tiếp từ thiết bị của mình mà không cần kết nối với máy tính.&lt;p&gt;Vui lòng xem hướng dẫn từng bước trước.</string>
     <string name="adb_pairing_tutorial_content_miui_2">Nếu không, bạn có thể không nhập được mã ghép nối từ thông báo.</string>
     <string name="adb_pairing_tutorial_content_left_is_clickable">Xin lưu ý, phần bên trái của tùy chọn \"Gỡ lỗi không dây\" có thể nhấn được, nhấn vào nó sẽ mở ra một trang mới. Chỉ điều chỉnh công tắc ở bên phải là không chính xác.</string>
-    <string name="adb_pairing_tutorial_content_network">Shizuku cần truy cập mạng cục bộ. Nó được kiểm soát bởi sự cho phép của mạng.</string>
-    <string name="adb_pairing_tutorial_content_network_limation_not_foreground">Một số hệ thống (chẳng hạn như MIUI) không cho phép ứng dụng truy cập mạng khi chúng không hiển thị, ngay cả khi ứng dụng sử dụng dịch vụ nền trước làm tiêu chuẩn. Vui lòng tắt các tính năng tối ưu hóa pin cho Shizuku trên các hệ thống như vậy.</string>
+    <string name="adb_pairing_tutorial_content_network">Shizuku™ cần truy cập mạng cục bộ. Nó được kiểm soát bởi sự cho phép của mạng.</string>
+    <string name="adb_pairing_tutorial_content_network_limation_not_foreground">Một số hệ thống (chẳng hạn như MIUI) không cho phép ứng dụng truy cập mạng khi chúng không hiển thị, ngay cả khi ứng dụng sử dụng dịch vụ nền trước làm tiêu chuẩn. Vui lòng tắt các tính năng tối ưu hóa pin cho Shizuku™ trên các hệ thống như vậy.</string>
     <string name="settings_use_system_color">Sử dụng màu chủ đề hệ thống</string>
-    <string name="home_app_management_empty">Các ứng dụng đã yêu cầu hoặc khai báo Shizuku sẽ hiển thị ở đây.</string>
+    <string name="home_app_management_empty">Các ứng dụng đã yêu cầu hoặc khai báo Shizuku™ sẽ hiển thị ở đây.</string>
     <string name="dialog_adb_discovery_message_toggle_wireless_debugging">Vui lòng thử tắt và bật \"Gỡ lỗi không dây\" nếu nó tiếp tục tìm kiếm.</string>
 </resources>

--- a/manager/src/main/res/values-zh-rCN/strings.xml
+++ b/manager/src/main/res/values-zh-rCN/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="permission_label">使用 Shizuku</string>
-    <string name="permission_description">允许应用使用 Shizuku。</string>
+    <string name="permission_label">使用 Shizuku™</string>
+    <string name="permission_description">允许应用使用 Shizuku™。</string>
     <string name="home_status_service_is_running">%1$s 正在运行</string>
     <string name="home_status_service_version">版本 %2$s，%1$s</string>
     <string name="home_status_service_version_update"><![CDATA[版本 %2$s，%1$s<br>再次启动来升级到版本 %3$s]]></string>
@@ -10,30 +10,30 @@
     <string name="home_root_button_restart">重新启动</string>
     <string name="home_root_title"><![CDATA[启动（针对已 root 设备）]]></string>
     <string name="home_adb_title"><![CDATA[通过连接电脑启动（使用 adb）]]></string>
-    <string name="home_adb_description"><![CDATA[对于没有 root 的设备需要借助 adb 来启动 Shizuku（需要连接电脑）。这个过程每次设备重新启动后需要重新进行。请<b><a href=\"%1$s\">阅读帮助</a></b>。]]></string>
-    <string name="home_root_description"><![CDATA[另外，Shizuku 可以在开机时自动启动。如果没有，请检查您的系统或是第三方工具是否限制了 Shizuku。<br>你可以参考 %s。]]></string>
+    <string name="home_adb_description"><![CDATA[对于没有 root 的设备需要借助 adb 来启动 Shizuku™（需要连接电脑）。这个过程每次设备重新启动后需要重新进行。请<b><a href=\"%1$s\">阅读帮助</a></b>。]]></string>
+    <string name="home_root_description"><![CDATA[另外，Shizuku™ 可以在开机时自动启动。如果没有，请检查您的系统或是第三方工具是否限制了 Shizuku™。<br>你可以参考 %s。]]></string>
     <string name="home_adb_dialog_view_command_copy_button">复制</string>
     <string name="home_adb_dialog_view_command_button_send">发送</string>
     <string name="home_adb_button_view_command">查看指令</string>
     <string name="home_adb_dialog_view_command_message"><![CDATA[<font face="monospace">%1$s</font><br><br>* 还有一些其他注意事项，请确认你已阅读帮助。]]></string>
-    <string name="dialog_legacy_not_support_title">%1$s 不支持现代 Shizuku</string>
-    <string name="dialog_legacy_not_support_message"><![CDATA[旧式 Shizuku 已于 2019 年 3 月被弃用。此外，旧式 Shizuku 无法在较新版本的 Android 系统上工作。<p>请要求 <b>%1$s</b> 的开发者进行更新。]]></string>
-    <string name="dialog_requesting_legacy_title">%1$s 正在请求旧式 Shizuku</string>
-    <string name="dialog_requesting_legacy_message"><![CDATA[<b>%1$s</b> 支持现代 Shizuku，但它正在请求旧式 Shizuku。这可能是因为 Shizuku 没有运行，请在 Shizuku 应用内检查。<p>旧式 Shizuku 已于 2019 年 3 月被弃用。]]></string>
+    <string name="dialog_legacy_not_support_title">%1$s 不支持现代 Shizuku™</string>
+    <string name="dialog_legacy_not_support_message"><![CDATA[旧式 Shizuku™ 已于 2019 年 3 月被弃用。此外，旧式 Shizuku™ 无法在较新版本的 Android 系统上工作。<p>请要求 <b>%1$s</b> 的开发者进行更新。]]></string>
+    <string name="dialog_requesting_legacy_title">%1$s 正在请求旧式 Shizuku™</string>
+    <string name="dialog_requesting_legacy_message"><![CDATA[<b>%1$s</b> 支持现代 Shizuku™，但它正在请求旧式 Shizuku™。这可能是因为 Shizuku™ 没有运行，请在 Shizuku™ 应用内检查。<p>旧式 Shizuku™ 已于 2019 年 3 月被弃用。]]></string>
     <string name="home_app_management_title">应用管理</string>
     <plurals name="home_app_management_authorized_apps_count">
         <item quantity="other"><![CDATA[已授权 %d 个应用]]></item>
     </plurals>
     <string name="home_app_management_view_authorized_apps">点按以管理授权的应用</string>
     <string name="toast_copied_to_clipboard">%s\n已被复制到剪贴板。</string>
-    <string name="dialog_requesting_legacy_button_open_shizuku">打开 Shizuku</string>
+    <string name="dialog_requesting_legacy_button_open_shizuku">打开 Shizuku™</string>
     <string name="action_about">关于</string>
     <string name="about_view_source_code"><![CDATA[在 %s 查看源码]]></string>
     <string name="settings_title">设置</string>
     <string name="start_with_root_failed">未授予 root 权限或是该设备没有 root，因此无法启动服务。</string>
     <string name="notification_channel_service_status">服务启动状态</string>
-    <string name="notification_service_starting">Shizuku 服务正在启动…</string>
-    <string name="notification_service_start_failed">启动 Shizuku 服务失败。</string>
+    <string name="notification_service_starting">Shizuku™ 服务正在启动…</string>
+    <string name="notification_service_start_failed">启动 Shizuku™ 服务失败。</string>
     <string name="notification_service_start_no_root">请求 root 权限失败。</string>
     <string name="notification_working">工作中…</string>
     <string name="settings_language">语言</string>
@@ -46,9 +46,9 @@
     <string name="home_adb_button_view_help">阅读帮助</string>
     <string name="dialog_cannot_open_browser_title">无法启动浏览器</string>
     <string name="toast_copied_to_clipboard_with_text"><![CDATA[<b>%s</b> 已被复制到剪贴板。]]></string>
-    <string name="home_learn_more_title">了解 Shizuku</string>
-    <string name="home_learn_more_description">了解如何使用 Shizuku 开发</string>
-    <string name="app_management_item_summary_requires_root">* 需要以 root 执行的 Shizuku</string>
+    <string name="home_learn_more_title">了解 Shizuku™</string>
+    <string name="home_learn_more_description">了解如何使用 Shizuku™ 开发</string>
+    <string name="app_management_item_summary_requires_root">* 需要以 root 执行的 Shizuku™</string>
     <string name="settings_translation_contributors">翻译贡献者</string>
     <string name="translation_contributors"/>
     <string name="settings_translation">参与翻译</string>
@@ -60,9 +60,9 @@
     <string name="starter">启动程序</string>
     <string name="dialog_adb_invalid_port">端口号是一个 1 至 65535 的整数。</string>
     <string name="home_wireless_adb_title"><![CDATA[通过无线调试启动]]></string>
-    <string name="home_wireless_adb_description"><![CDATA[在 Android 11 或更高版本上，您可以直接从您的设备启用无线调试并启动 Shizuku，无需连接到计算机。<p>请先查看分步骤指南。]]></string>
-    <string name="action_stop">停止 Shizuku</string>
-    <string name="dialog_stop_message">Shizuku 服务将被停止。</string>
+    <string name="home_wireless_adb_description"><![CDATA[在 Android 11 或更高版本上，您可以直接从您的设备启用无线调试并启动 Shizuku™，无需连接到计算机。<p>请先查看分步骤指南。]]></string>
+    <string name="action_stop">停止 Shizuku™</string>
+    <string name="dialog_stop_message">Shizuku™ 服务将被停止。</string>
     <string name="paring_code_is_wrong">配对码错误。</string>
     <string name="cannot_connect_port">无法连接至无线调试服务。</string>
     <string name="adb_pairing_requires_multi_window">请先进入分屏（多窗口）模式。</string>
@@ -72,7 +72,7 @@
     <string name="dialog_adb_discovery">正在搜索无线调试服务</string>
     <string name="dialog_adb_discovery_message">请在“开发者选项”中启用“无线调试”功能。当网络变化时“无线调试”会被自动禁用。
 \n
-\n注意：请不要禁用“开发者选项”或“USB 调试”，否则 Shizuku 会被停止。</string>
+\n注意：请不要禁用“开发者选项”或“USB 调试”，否则 Shizuku™ 会被停止。</string>
     <string name="dialog_adb_discovery_message_toggle_wireless_debugging">如果一直搜索，请尝试禁用并启用“无线调试”。</string>
     <string name="dialog_adb_pairing_discovery">正在搜索配对服务</string>
     <string name="dialog_wireless_adb_not_enabled">无线调试未启用。
@@ -81,29 +81,29 @@
 \n
 \n配对过程开始后，您将能够输入配对码。</string>
     <string name="development_settings">开发者选项</string>
-    <string name="home_root_description_sui"><![CDATA[如果您正在使用 Magisk，可以尝试 %1$s。对于 root 用户，它将最终取代 Shizuku。注意，已有的应用需要一点点修改来使用 %2$s。]]></string>
-    <string name="settings_start_on_boot_summary">对于已 root 设备，Shizuku 可以开机启动</string>
+    <string name="home_root_description_sui"><![CDATA[如果您正在使用 Magisk，可以尝试 %1$s。对于 root 用户，它将最终取代 Shizuku™。注意，已有的应用需要一点点修改来使用 %2$s。]]></string>
+    <string name="settings_start_on_boot_summary">对于已 root 设备，Shizuku™ 可以开机启动</string>
     <string name="settings_start_on_boot">开机启动（root）</string>
     <string name="permission_warning_template"><![CDATA[要允许<b>%1$s</b>%2$s吗？]]></string>
     <string name="grant_dialog_button_allow_always">始终允许</string>
     <string name="grant_dialog_button_deny">拒绝</string>
-    <string name="home_terminal_title">在终端应用中使用 Shizuku</string>
-    <string name="home_terminal_description">在您喜欢的终端应用中通过 Shizuku 运行命令</string>
+    <string name="home_terminal_title">在终端应用中使用 Shizuku™</string>
+    <string name="home_terminal_description">在您喜欢的终端应用中通过 Shizuku™ 运行命令</string>
     <string name="terminal_tutorial_1">首先，将文件导出到任何您想要的位置。您将找到两个文件，%1$s 和 %2$s。</string>
-    <string name="terminal_tutorial_1_description">若选择的文件夹中已有同名文件，它们会被删除。\n\n导出功能使用 SAF（Storage Access Framework）。有报告称 MIUI 破坏了 SAF 的功能，如果您使用 MIUI，您可能需要从 Shizuku 的 apk 中提取文件，或是从 GitHub 下载文件。</string>
+    <string name="terminal_tutorial_1_description">若选择的文件夹中已有同名文件，它们会被删除。\n\n导出功能使用 SAF（Storage Access Framework）。有报告称 MIUI 破坏了 SAF 的功能，如果您使用 MIUI，您可能需要从 Shizuku™ 的 apk 中提取文件，或是从 GitHub 下载文件。</string>
     <string name="terminal_export_files">导出文件</string>
     <string name="terminal_tutorial_2">然后，使用任意文本编辑器打开并编辑 %1$s。</string>
-    <string name="terminal_tutorial_2_description">例如，如果要在 %1$s 中使用 Shizuku，则应将 %2$s 替换为 %3$s（%4$s 是 %1$s 的软件包名称）。</string>
-    <string name="terminal_tutorial_3">最后，将文件移动到终端应用可以访问的位置，您便可使用 %1$s 来通过 Shizuku 运行命令。</string>
+    <string name="terminal_tutorial_2_description">例如，如果要在 %1$s 中使用 Shizuku™，则应将 %2$s 替换为 %3$s（%4$s 是 %1$s 的软件包名称）。</string>
+    <string name="terminal_tutorial_3">最后，将文件移动到终端应用可以访问的位置，您便可使用 %1$s 来通过 Shizuku™ 运行命令。</string>
     <string name="terminal_tutorial_3_description">一些技巧：将执行权限授予 %1$s 并将其添加到 %2$s，您将可以直接使用 %1$s。</string>
     <string name="rish_description"><![CDATA[
-通过 %1$s，您可以在任何终端应用中连接到由 Shizuku 运行的 shell 并与之交互。
+通过 %1$s，您可以在任何终端应用中连接到由 Shizuku™ 运行的 shell 并与之交互。
 <p>有关 %1$s 的具体使用方式，点按以阅读文档。
 ]]></string>
-    <string name="adb_pairing_tutorial_title">将 Shizuku 与您的设备配对</string>
+    <string name="adb_pairing_tutorial_title">将 Shizuku™ 与您的设备配对</string>
     <string name="adb_pairing_tutorial_content_steps">进入“开发者选项”-“无线调试”。点按“使用配对码配对设备”，您将看到一个六位数字代码。</string>
     <string name="adb_pairing_tutorial_content_enter_pairing_code">在通知中输入代码来完成配对。</string>
-    <string name="adb_pairing_tutorial_content_finish">返回到 Shizuku 并启动 Shizuku。</string>
+    <string name="adb_pairing_tutorial_content_finish">返回到 Shizuku™ 并启动 Shizuku™。</string>
     <string name="notification_channel_adb_pairing">无线调试配对</string>
     <string name="notification_adb_pairing_input_paring_code">输入配对码</string>
     <string name="notification_adb_pairing_searching_for_service_title">正在搜索配对服务</string>
@@ -111,21 +111,21 @@
     <string name="notification_adb_pairing_stop_searching">停止搜索</string>
     <string name="notification_adb_pairing_working_title">正在进行配对</string>
     <string name="notification_adb_pairing_succeed_title">配对成功</string>
-    <string name="notification_adb_pairing_succeed_text">您现在可以启动 Shizuku 服务了。</string>
+    <string name="notification_adb_pairing_succeed_text">您现在可以启动 Shizuku™ 服务了。</string>
     <string name="notification_adb_pairing_failed_title">配对失败</string>
     <string name="notification_adb_pairing_retry">重试</string>
-    <string name="adb_pairing_tutorial_content_notification_blocked">配对过程需要您与 Shizuku 的通知交互。请允许 Shizuku 发布通知。</string>
+    <string name="adb_pairing_tutorial_content_notification_blocked">配对过程需要您与 Shizuku™ 的通知交互。请允许 Shizuku™ 发布通知。</string>
     <string name="notification_settings">通知设置</string>
     <string name="adb_pairing_tutorial_content_miui">MIUI 用户可能需要在系统设置中从“通知管理”-“通知显示设置”将通知样式切换为“原生样式”。</string>
     <string name="adb_pairing_tutorial_content_miui_2">否则，您可能会无法从通知输入配对码。</string>
-    <string name="adb_pairing_tutorial_content_notification">一条来自 Shizuku 的通知将帮助您完成配对。</string>
+    <string name="adb_pairing_tutorial_content_notification">一条来自 Shizuku™ 的通知将帮助您完成配对。</string>
     <string name="adb_pairing_tutorial_content_left_is_clickable">请注意，“无线调试”选项的左侧是可点击的，点按它将打开一个新的页面。仅打开右侧的开关是错误的。</string>
     <string name="home_wireless_adb_description_pre_11"><![CDATA[在 Android 11 之前，需要连接到计算机才能启用无线调试。]]></string>
     <string name="home_wireless_adb_view_guide_button">分步骤指南</string>
-    <string name="adb_pairing_tutorial_content_network">Shizuku 需要访问本地网络。它由网络权限控制。</string>
-    <string name="adb_pairing_tutorial_content_network_limation_not_foreground">某些系统（例如 MIUI）不允许应用在不可见时访问网络，即使应用已按标准使用前台服务。请在此类系统上为 Shizuku 禁用电池优化功能。</string>
+    <string name="adb_pairing_tutorial_content_network">Shizuku™ 需要访问本地网络。它由网络权限控制。</string>
+    <string name="adb_pairing_tutorial_content_network_limation_not_foreground">某些系统（例如 MIUI）不允许应用在不可见时访问网络，即使应用已按标准使用前台服务。请在此类系统上为 Shizuku™ 禁用电池优化功能。</string>
     <string name="settings_use_system_color">使用系统主题颜色</string>
-    <string name="home_app_management_empty">已请求或声明 Shizuku 的应用程序将显示在此处。</string>
+    <string name="home_app_management_empty">已请求或声明 Shizuku™ 的应用程序将显示在此处。</string>
     <string name="home_adb_is_limited_title">您需要进行额外的步骤</string>
-    <string name="home_adb_is_limited_description">您的设备制造商限制了 adb 的权限，使用 Shizuku 的应用无法正常工作。\n\n通常，在“开发者选项”中调整一些选项即可解除此限制。请阅读帮助来了解具体的操作方式。\n\n您可能需要重新启动 Shizuku 以使操作生效。</string>
+    <string name="home_adb_is_limited_description">您的设备制造商限制了 adb 的权限，使用 Shizuku™ 的应用无法正常工作。\n\n通常，在“开发者选项”中调整一些选项即可解除此限制。请阅读帮助来了解具体的操作方式。\n\n您可能需要重新启动 Shizuku™ 以使操作生效。</string>
 </resources>

--- a/manager/src/main/res/values-zh-rTW/strings.xml
+++ b/manager/src/main/res/values-zh-rTW/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="permission_label">使用 Shizuku</string>
-    <string name="permission_description">允許應用程式使用 Shizuku。</string>
+    <string name="permission_label">使用 Shizuku™</string>
+    <string name="permission_description">允許應用程式使用 Shizuku™。</string>
     <string name="home_status_service_is_running">%1$s 正在執行</string>
     <string name="home_status_service_version">版本 %2$s，%1$s</string>
     <string name="home_status_service_version_update">版本 %2$s，%1$s&lt;br&gt;再次啟動來升級到版本 %3$s</string>
@@ -10,16 +10,16 @@
     <string name="home_root_button_restart">重新啟動</string>
     <string name="home_root_title">啟動 (針對已 Root 裝置)</string>
     <string name="home_adb_title">透過與電腦連線來啟動 (使用 ADB)</string>
-    <string name="home_adb_description">沒有 Root 的裝置需藉助 ADB 來啟動 Shizuku (須與電腦連線)。在裝置每次重新啟動後，這項作業皆須重新進行。請<b><a href="%1$s">閱讀說明</a></b>。</string>
-    <string name="home_root_description">另外，Shizuku 可以在開機時自動啟動。如果沒有啟動，請檢查 Shizuku 是否被您的系統或是第三方工具限制。&lt;br&gt;你可以參考 %s。</string>
+    <string name="home_adb_description">沒有 Root 的裝置需藉助 ADB 來啟動 Shizuku™ (須與電腦連線)。在裝置每次重新啟動後，這項作業皆須重新進行。請<b><a href="%1$s">閱讀說明</a></b>。</string>
+    <string name="home_root_description">另外，Shizuku™ 可以在開機時自動啟動。如果沒有啟動，請檢查 Shizuku™ 是否被您的系統或是第三方工具限制。&lt;br&gt;你可以參考 %s。</string>
     <string name="home_adb_dialog_view_command_copy_button">複製</string>
     <string name="home_adb_dialog_view_command_button_send">傳送</string>
     <string name="home_adb_button_view_command">檢視命令</string>
     <string name="home_adb_dialog_view_command_message">&lt;font face=monospace&gt;%1$s&lt;/font&gt;&lt;br&gt;&lt;br&gt;* 還有一些其他注意事項，請確認你已閱讀說明。</string>
-    <string name="dialog_legacy_not_support_title">%1$s 不支援現代 Shizuku</string>
-    <string name="dialog_legacy_not_support_message">舊式 Shizuku 已於 2019 年 3 月被棄用。此外，舊式 Shizuku 無法在較新版本的 Android 系統上工作。&lt;p&gt;請要求 &lt;b&gt;%1$s&lt;/b&gt; 的開發人員進行更新。</string>
-    <string name="dialog_requesting_legacy_title">%1$s 正在要求舊版 Shizuku</string>
-    <string name="dialog_requesting_legacy_message">&lt;b&gt;%1$s&lt;/b&gt; 支援現代 Shizuku，但它正在要求舊版 Shizuku。這可能是因為 Shizuku 未在執行，請在 Shizuku 應用程式內檢查。&lt;p&gt;舊版 Shizuku 已於 2019 年 3 月被棄用。</string>
+    <string name="dialog_legacy_not_support_title">%1$s 不支援現代 Shizuku™</string>
+    <string name="dialog_legacy_not_support_message">舊式 Shizuku™ 已於 2019 年 3 月被棄用。此外，舊式 Shizuku™ 無法在較新版本的 Android 系統上工作。&lt;p&gt;請要求 &lt;b&gt;%1$s&lt;/b&gt; 的開發人員進行更新。</string>
+    <string name="dialog_requesting_legacy_title">%1$s 正在要求舊版 Shizuku™</string>
+    <string name="dialog_requesting_legacy_message">&lt;b&gt;%1$s&lt;/b&gt; 支援現代 Shizuku™，但它正在要求舊版 Shizuku™。這可能是因為 Shizuku™ 未在執行，請在 Shizuku™ 應用程式內檢查。&lt;p&gt;舊版 Shizuku™ 已於 2019 年 3 月被棄用。</string>
     <string name="home_app_management_title">應用程式管理</string>
     <plurals name="home_app_management_authorized_apps_count">
         <item quantity="other">已授權 %d 個應用程式</item>
@@ -27,14 +27,14 @@
     <string name="home_app_management_view_authorized_apps">輕觸以管理已授權的應用程式</string>
     <string name="toast_copied_to_clipboard">%s
 \n已複製到剪貼簿。</string>
-    <string name="dialog_requesting_legacy_button_open_shizuku">開啟 Shizuku</string>
+    <string name="dialog_requesting_legacy_button_open_shizuku">開啟 Shizuku™</string>
     <string name="action_about">關於</string>
     <string name="about_view_source_code">在 %s 檢視原始碼</string>
     <string name="settings_title">設定</string>
     <string name="start_with_root_failed">未授予 Root 權限或是此裝置沒有 Root，因此無法啟動服務。</string>
     <string name="notification_channel_service_status">服務啟動狀態</string>
-    <string name="notification_service_starting">Shizuku 服務正在啟動…</string>
-    <string name="notification_service_start_failed">啟動 Shizuku 服務時失敗。</string>
+    <string name="notification_service_starting">Shizuku™ 服務正在啟動…</string>
+    <string name="notification_service_start_failed">啟動 Shizuku™ 服務時失敗。</string>
     <string name="notification_service_start_no_root">無法要求 Root 權限。</string>
     <string name="notification_working">正在處理…</string>
     <string name="settings_language">語言</string>
@@ -47,19 +47,19 @@
     <string name="home_adb_button_view_help">閱讀說明</string>
     <string name="dialog_cannot_open_browser_title">無法啟動瀏覽器</string>
     <string name="toast_copied_to_clipboard_with_text"><b>%s</b> 已複製到剪貼簿。</string>
-    <string name="home_learn_more_title">瞭解 Shizuku</string>
-    <string name="home_learn_more_description">瞭解如何使用 Shizuku 開發</string>
-    <string name="app_management_item_summary_requires_root">* 需要以 Root 執行的 Shizuku</string>
+    <string name="home_learn_more_title">瞭解 Shizuku™</string>
+    <string name="home_learn_more_description">瞭解如何使用 Shizuku™ 開發</string>
+    <string name="app_management_item_summary_requires_root">* 需要以 Root 執行的 Shizuku™</string>
     <string name="settings_translation_contributors">翻譯貢獻者</string>
     <string name="translation_contributors"/>
     <string name="settings_translation">參與翻譯</string>
     <string name="settings_translation_summary">協助我們將 %s 翻譯至您的語言</string>
-    <string name="dialog_stop_message">Shizuku 服務將被停止。</string>
+    <string name="dialog_stop_message">Shizuku™ 服務將被停止。</string>
     <string name="dialog_adb_port">通訊埠</string>
     <string name="dialog_adb_invalid_port">通訊埠是一個 1 至 65535 的整數。</string>
     <string name="dialog_adb_pairing_paring_code">配對碼</string>
     <string name="home_wireless_adb_title">透過無線偵錯啟動</string>
-    <string name="home_wireless_adb_description">在 Android 11 或更高版本上，您可以直接從您的裝置啟用無線偵錯並啟動 Shizuku，無須與電腦連線。&lt;p&gt;請先檢視分步驟指南。</string>
+    <string name="home_wireless_adb_description">在 Android 11 或更高版本上，您可以直接從您的裝置啟用無線偵錯並啟動 Shizuku™，無須與電腦連線。&lt;p&gt;請先檢視分步驟指南。</string>
     <string name="dialog_adb_pairing_title">與裝置配對</string>
     <string name="paring_code_is_wrong">配對碼錯誤。</string>
     <string name="cannot_connect_port">無法連線至無線偵錯服務。</string>
@@ -67,14 +67,14 @@
     <string name="adb_error_key_store">無法為無線偵錯產生金鑰。
 \n這可能是因為此裝置上的 KeyStore 機制已損壞。</string>
     <string name="adb_pair_required">請先進行配對步驟。</string>
-    <string name="action_stop">停止 Shizuku</string>
+    <string name="action_stop">停止 Shizuku™</string>
     <string name="adb_pairing">配對</string>
     <string name="starter">啟動器</string>
     <string name="dialog_adb_discovery">正在尋找無線偵錯服務</string>
     <string name="dialog_adb_pairing_discovery">正在尋找配對服務</string>
     <string name="dialog_adb_discovery_message">請在「開發人員選項」中啟用「無線偵錯」功能。在切換網路時，「無線偵錯」會自動停用。
 \n
-\n注意：請不要停用「開發人員選項」或「USB 偵錯」，否則 Shizuku 會被停止。</string>
+\n注意：請不要停用「開發人員選項」或「USB 偵錯」，否則 Shizuku™ 會被停止。</string>
     <string name="dialog_adb_discovery_message_toggle_wireless_debugging">如果一直搜尋，請嘗試停用並啟用「無線偵錯」。</string>
     <string name="dialog_wireless_adb_not_enabled">無線偵錯未啟用。
 \n請注意，在 Android 11 之前，要啟用無線偵錯必須先與電腦連線。</string>
@@ -83,25 +83,25 @@
 \n配對過程開始後，您將能夠輸入配對碼。</string>
     <string name="adb_pairing_requires_multi_window_reason">系統要求配對對話方塊始終可見，使用「分割畫面」模式是使此應用程式和系統對話方塊同時可見的唯一方法。</string>
     <string name="development_settings">開發人員選項</string>
-    <string name="home_root_description_sui">如果您正在使用 Magisk，可以嘗試 %1$s。對於 Root 使用者，它將最終取代 Shizuku。注意，已有的應用程式需要一點點修改來使用 %2$s。</string>
-    <string name="settings_start_on_boot_summary">對於已 Root 裝置，Shizuku 可以在開機時自動啟動</string>
+    <string name="home_root_description_sui">如果您正在使用 Magisk，可以嘗試 %1$s。對於 Root 使用者，它將最終取代 Shizuku™。注意，已有的應用程式需要一點點修改來使用 %2$s。</string>
+    <string name="settings_start_on_boot_summary">對於已 Root 裝置，Shizuku™ 可以在開機時自動啟動</string>
     <string name="settings_start_on_boot">在開機時啟動 (Root)</string>
     <string name="grant_dialog_button_allow_always">一律允許</string>
     <string name="grant_dialog_button_deny">拒絕</string>
     <string name="permission_warning_template">要允許「%1$s」%2$s 嗎？</string>
-    <string name="home_terminal_title">在終端機應用程式中使用 Shizuku</string>
-    <string name="home_terminal_description">在您喜愛的終端機應用程式中透過 Shizuku 執行命令</string>
+    <string name="home_terminal_title">在終端機應用程式中使用 Shizuku™</string>
+    <string name="home_terminal_description">在您喜愛的終端機應用程式中透過 Shizuku™ 執行命令</string>
     <string name="terminal_tutorial_1">首先，將檔案匯出到任何您想要的位置。您將找到兩個檔案，%1$s 和 %2$s。</string>
     <string name="terminal_tutorial_1_description">若選擇的資料夾中已有同名檔案，它們會被刪除。
 \n
-\n匯出功能使用 SAF (Storage Access Framework)。有報告稱 MIUI 破壞了 SAF 的功能，如果您使用 MIUI，您可能需要從 Shizuku 的 apk 中提取檔案，或是從 GitHub 下載檔案。</string>
+\n匯出功能使用 SAF (Storage Access Framework)。有報告稱 MIUI 破壞了 SAF 的功能，如果您使用 MIUI，您可能需要從 Shizuku™ 的 apk 中提取檔案，或是從 GitHub 下載檔案。</string>
     <string name="terminal_export_files">匯出檔案</string>
     <string name="terminal_tutorial_2">然後，使用任意文字編輯器開啟並編輯 %1$s。</string>
-    <string name="terminal_tutorial_2_description">例如，如果要在 %1$s 中使用 Shizuku，則應將 %2$s 取代為 %3$s (%4$s 是 %1$s 的套件名稱)。</string>
-    <string name="terminal_tutorial_3">最後，將檔案移至終端機應用程式可以存取的位置，您便可使用 %1$s 來透過 Shizuku 執行命令。</string>
+    <string name="terminal_tutorial_2_description">例如，如果要在 %1$s 中使用 Shizuku™，則應將 %2$s 取代為 %3$s (%4$s 是 %1$s 的套件名稱)。</string>
+    <string name="terminal_tutorial_3">最後，將檔案移至終端機應用程式可以存取的位置，您便可使用 %1$s 來透過 Shizuku™ 執行命令。</string>
     <string name="terminal_tutorial_3_description">一些技巧：將執行權限授予 %1$s 並將其新增到 %2$s，您就能直接使用 %1$s。</string>
-    <string name="rish_description">透過 %1$s，您可以在任何終端機應用程式中連線到由 Shizuku 執行的 shell 並與之互動。 &lt;p&gt;有關 %1$s 的具體使用方式，請輕觸以檢視文件。</string>
-    <string name="adb_pairing_tutorial_title">將 Shizuku 與您的裝置配對</string>
+    <string name="rish_description">透過 %1$s，您可以在任何終端機應用程式中連線到由 Shizuku™ 執行的 shell 並與之互動。 &lt;p&gt;有關 %1$s 的具體使用方式，請輕觸以檢視文件。</string>
+    <string name="adb_pairing_tutorial_title">將 Shizuku™ 與您的裝置配對</string>
     <string name="adb_pairing_tutorial_content_steps">進入「開發人員選項」-「無線偵錯」。輕觸「使用配對碼配對裝置」，您將看到一個六位數字代碼。</string>
     <string name="adb_pairing_tutorial_content_enter_pairing_code">在通知中輸入代碼來完成配對。</string>
     <string name="notification_channel_adb_pairing">無線偵錯配對</string>
@@ -111,26 +111,26 @@
     <string name="notification_adb_pairing_stop_searching">停止尋找</string>
     <string name="notification_adb_pairing_working_title">正在進行配對</string>
     <string name="notification_adb_pairing_succeed_title">配對成功</string>
-    <string name="notification_adb_pairing_succeed_text">您現在可以啟動 Shizuku 服務了。</string>
+    <string name="notification_adb_pairing_succeed_text">您現在可以啟動 Shizuku™ 服務了。</string>
     <string name="notification_adb_pairing_failed_title">配對失敗</string>
     <string name="notification_adb_pairing_retry">重試</string>
-    <string name="adb_pairing_tutorial_content_notification_blocked">配對過程需要您與 Shizuku 的通知互動。請允許 Shizuku 發布通知。</string>
+    <string name="adb_pairing_tutorial_content_notification_blocked">配對過程需要您與 Shizuku™ 的通知互動。請允許 Shizuku™ 發布通知。</string>
     <string name="notification_settings">通知設定</string>
     <string name="adb_pairing_tutorial_content_miui">MIUI 使用者可能需要在系統設定中從「通知管理」-「通知顯示設定」將通知樣式切換為「原生樣式」。</string>
     <string name="adb_pairing_tutorial_content_miui_2">否則，您可能會無法從通知輸入配對碼。</string>
-    <string name="adb_pairing_tutorial_content_notification">一則來自 Shizuku 的通知將協助您完成配對。</string>
+    <string name="adb_pairing_tutorial_content_notification">一則來自 Shizuku™ 的通知將協助您完成配對。</string>
     <string name="adb_pairing_tutorial_content_left_is_clickable">請注意，「無線偵錯」選項的左側是可點選的，輕觸它將開啟一個新的頁面。僅開啟右側的開關是錯誤的。</string>
     <string name="home_wireless_adb_description_pre_11">在 Android 11 之前，必須與電腦連線才能啟用無線偵錯。</string>
     <string name="home_wireless_adb_view_guide_button">分步驟指南</string>
-    <string name="adb_pairing_tutorial_content_network">Shizuku 需要存取本機網路。它由網路權限控制。</string>
-    <string name="adb_pairing_tutorial_content_network_limation_not_foreground">某些系統 (例如 MIUI) 不允許應用程式在不可見時存取網路，即使應用程式已按標準使用前景服務。請在此類系統上為 Shizuku 停用電池效能最佳化功能。</string>
+    <string name="adb_pairing_tutorial_content_network">Shizuku™ 需要存取本機網路。它由網路權限控制。</string>
+    <string name="adb_pairing_tutorial_content_network_limation_not_foreground">某些系統 (例如 MIUI) 不允許應用程式在不可見時存取網路，即使應用程式已按標準使用前景服務。請在此類系統上為 Shizuku™ 停用電池效能最佳化功能。</string>
     <string name="settings_use_system_color">使用系統主題色彩</string>
-    <string name="adb_pairing_tutorial_content_finish">回到 Shizuku 並啟動 Shizuku。</string>
-    <string name="home_app_management_empty">已要求或宣告 Shizuku 的應用程式將顯示在此處。</string>
+    <string name="adb_pairing_tutorial_content_finish">回到 Shizuku™ 並啟動 Shizuku™。</string>
+    <string name="home_app_management_empty">已要求或宣告 Shizuku™ 的應用程式將顯示在此處。</string>
     <string name="home_adb_is_limited_title">您需要進行額外的步驟</string>
-    <string name="home_adb_is_limited_description">您的裝置製造商限制了 ADB 的權限，使用 Shizuku 的應用程式無法正常運作。
+    <string name="home_adb_is_limited_description">您的裝置製造商限制了 ADB 的權限，使用 Shizuku™ 的應用程式無法正常運作。
 \n
 \n通常，在「開發人員選項」中調整一些選項即可解除此限制。請閱讀說明來瞭解具體的作業方式。
 \n
-\n您可能需要重新啟動 Shizuku 以使作業生效。</string>
+\n您可能需要重新啟動 Shizuku™ 以使作業生效。</string>
 </resources>

--- a/manager/src/main/res/values/strings.xml
+++ b/manager/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name" translatable="false">Shizuku</string>
+    <string name="app_name" translatable="false">Shizuku™</string>
 
     <!-- To translators: you can leave your here -->
     <string name="translation_contributors" />
@@ -12,7 +12,7 @@
 
     <!-- Home - Adb -->
     <string name="home_adb_title"><![CDATA[Start by connecting to a computer]]></string>
-    <string name="home_adb_description"><![CDATA[For devices without root, you need to use adb to start Shizuku (requires computer connection). This process needs to be repeated every time the device is restarted. Please <b><a href=\"%1$s\">read the help</a></b>.]]></string>
+    <string name="home_adb_description"><![CDATA[For devices without root, you need to use adb to start Shizuku™ (requires computer connection). This process needs to be repeated every time the device is restarted. Please <b><a href=\"%1$s\">read the help</a></b>.]]></string>
     <string name="home_adb_button_view_help">Read help</string>
     <string name="home_adb_button_view_command">View command</string>
     <string name="home_adb_dialog_view_command_message"><![CDATA[<font face="monospace">%1$s</font><br><br>* There are some other considerations, please confirm that you have read the help first.]]></string>
@@ -21,13 +21,13 @@
 
     <!-- Home - Wireless Adb -->
     <string name="home_wireless_adb_title"><![CDATA[Start via Wireless debugging]]></string>
-    <string name="home_wireless_adb_description"><![CDATA[On Android 11 or above, you can enable Wireless debugging and start Shizuku directly from your device, without connecting to a computer.<p>Please view the step-by-step guide first.]]></string>
+    <string name="home_wireless_adb_description"><![CDATA[On Android 11 or above, you can enable Wireless debugging and start Shizuku™ directly from your device, without connecting to a computer.<p>Please view the step-by-step guide first.]]></string>
     <string name="home_wireless_adb_description_pre_11"><![CDATA[Before Android 11, connecting to a computer is required to enable Wireless debugging.]]></string>
     <string name="home_wireless_adb_view_guide_button">Step-by-step guide</string>
 
     <!-- Adb -->
     <string name="dialog_adb_discovery">Searching for wireless debugging service</string>
-    <string name="dialog_adb_discovery_message">Please enable \"Wireless debugging\" in \"Developer options\". \"Wireless debugging\" is automatically disabled when network changes.\n\nNote, do not disable \"Developer options\" or \"USB debugging\", or Shizuku will be stopped.</string>
+    <string name="dialog_adb_discovery_message">Please enable \"Wireless debugging\" in \"Developer options\". \"Wireless debugging\" is automatically disabled when network changes.\n\nNote, do not disable \"Developer options\" or \"USB debugging\", or Shizuku™ will be stopped.</string>
     <string name="dialog_adb_discovery_message_toggle_wireless_debugging">Please try to disable and enable \"Wireless debugging\" if it keeps searching.</string>
     <string name="dialog_adb_port">Port</string>
     <string name="dialog_adb_invalid_port">Port is an integer ranging from 1 to 65535.</string>
@@ -45,22 +45,22 @@
     <string name="adb_pair_required">Please go through the pairing step first.</string>
     <string name="development_settings">Developer options</string>
     <string name="notification_settings">Notification options</string>
-    <string name="adb_pairing_tutorial_title">Pair Shizuku with your device</string>
-    <string name="adb_pairing_tutorial_content_notification">A notification from Shizuku will help you complete the pairing.</string>
+    <string name="adb_pairing_tutorial_title">Pair Shizuku™ with your device</string>
+    <string name="adb_pairing_tutorial_content_notification">A notification from Shizuku™ will help you complete the pairing.</string>
     <string name="adb_pairing_tutorial_content_steps">Enter \"Developer options\" - \"Wireless debugging\". Tap \"Pair device with pairing code\", you will see a six-digit code.</string>
     <string name="adb_pairing_tutorial_content_enter_pairing_code">Enter the code in the notification to complete pairing.</string>
-    <string name="adb_pairing_tutorial_content_notification_blocked">The pairing process needs you to interact with a notification from Shizuku. Please allow Shizuku to post notifications.</string>
+    <string name="adb_pairing_tutorial_content_notification_blocked">The pairing process needs you to interact with a notification from Shizuku™. Please allow Shizuku™ to post notifications.</string>
     <string name="adb_pairing_tutorial_content_miui">MIUI users may need to switch notification style to \"Android\" from \"Notification\" - \"Notification shade\" in system settings.</string>
     <string name="adb_pairing_tutorial_content_miui_2">Otherwise, you may not able to enter paring code from the notification.</string>
     <string name="adb_pairing_tutorial_content_left_is_clickable">Please note, left part of the \"Wireless debugging\" option is clickable, tapping it will open a new page. Only turing on the switch on the right is incorrect.</string>
-    <string name="adb_pairing_tutorial_content_finish">Back to Shizuku and start Shizuku.</string>
-    <string name="adb_pairing_tutorial_content_network">Shizuku needs to access local network. It is controlled by the network permission.</string>
+    <string name="adb_pairing_tutorial_content_finish">Back to Shizuku™ and start Shizuku™.</string>
+    <string name="adb_pairing_tutorial_content_network">Shizuku™ needs to access local network. It is controlled by the network permission.</string>
     <string name="adb_pairing_tutorial_content_network_limation_not_foreground">Some systems (such as MIUI) disallow apps to access the network when they are not visible, even if the app uses foreground service as standard. Please disable battery optimization features for Shizuku on such systems.</string>
 
     <!-- Home - Root -->
     <string name="home_root_title"><![CDATA[Start (for rooted devices)]]></string>
-    <string name="home_root_description"><![CDATA[In addition, Shizuku can be started automatically on boot. If not, please check if your system or third-party tools have restricted Shizuku.<br>You can refer to %s.]]></string>
-    <string name="home_root_description_sui"><![CDATA[If you are using Magisk, you can try %1$s. For root users, it will eventually replace Shizuku. Note, existing applications needs to change a little to use %2$s.]]></string>
+    <string name="home_root_description"><![CDATA[In addition, Shizuku™ can be started automatically on boot. If not, please check if your system or third-party tools have restricted Shizuku™.<br>You can refer to %s.]]></string>
+    <string name="home_root_description_sui"><![CDATA[If you are using Magisk, you can try %1$s. For root users, it will eventually replace Shizuku™. Note, existing applications needs to change a little to use %2$s.]]></string>
     <string name="home_root_button_start">Start</string>
     <string name="home_root_button_restart">Restart</string>
 
@@ -71,33 +71,33 @@
         <item quantity="other"><![CDATA[Authorized %d applications]]></item>
     </plurals>
     <string name="home_app_management_view_authorized_apps"><![CDATA[Tap to manage authorized apps]]></string>
-    <string name="home_app_management_empty">Apps that has requested or declared Shizuku will show here.</string>
+    <string name="home_app_management_empty">Apps that has requested or declared Shizuku™ will show here.</string>
 
     <!-- Home - Learn more -->
-    <string name="home_learn_more_title">Learn Shizuku</string>
-    <string name="home_learn_more_description">Learn how to develop with Shizuku</string>
+    <string name="home_learn_more_title">Learn Shizuku™</string>
+    <string name="home_learn_more_description">Learn how to develop with Shizuku™</string>
 
     <!-- Home - Adb permissions limited -->
     <string name="home_adb_is_limited_title">You need to take an extra step</string>
-    <string name="home_adb_is_limited_description">Your device manufacturer has restricted adb permissions and apps using Shizuku will not work properly.\n\nUsually, this limitation can be lifted by adjusting some options in \"Developer options\". Please read the help for details on how to do this.\n\nYou may need to restart Shizuku for the operation to take effect.</string>
+    <string name="home_adb_is_limited_description">Your device manufacturer has restricted adb permissions and apps using Shizuku™ will not work properly.\n\nUsually, this limitation can be lifted by adjusting some options in \"Developer options\". Please read the help for details on how to do this.\n\nYou may need to restart Shizuku for the operation to take effect.</string>
 
     <!-- Application management -->
     <string name="app_management_dialog_adb_is_limited_title">The permission of adb is limited</string>
     <string name="app_management_dialog_adb_is_limited_message"><![CDATA[It\'s highly possible that your device manufacturer limits the permission of adb.<p>There may be a solution for your system in <b><a href=\"%1$s\">this document</a></b>.]]></string>
-    <string name="app_management_item_summary_requires_root">* requires Shizuku runs with root</string>
+    <string name="app_management_item_summary_requires_root">* requires Shizuku™ runs with root</string>
 
     <!-- Terminal -->
-    <string name="home_terminal_title">Use Shizuku in terminal apps</string>
-    <string name="home_terminal_description">Run commands through Shizuku in terminal apps you like</string>
+    <string name="home_terminal_title">Use Shizuku™ in terminal apps</string>
+    <string name="home_terminal_description">Run commands through Shizuku™ in terminal apps you like</string>
     <string name="terminal_tutorial_1">First, Export files to any where you want. You will find two files, %1$s and %2$s.</string>
     <string name="terminal_tutorial_1_description">If there are files with the same name in the selected folder, they will be deleted.\n\nThe export function uses SAF (Storage Access Framework). It\'s reported that MIUI breaks the functions of SAF. If you are using MIUI, you may have to extract the file from Shizuku\'s apk or download from GitHub.</string>
     <string name="terminal_export_files">Export files</string>
     <string name="terminal_tutorial_2">Then, use any text editor to open and edit %1$s.</string>
-    <string name="terminal_tutorial_2_description">For example, if you want to use Shizuku in %1$s, you should replace %2$s with %3$s (%4$s is the package name of %1$s).</string>
-    <string name="terminal_tutorial_3">Finally, move the files to somewhere where your terminal app can access, you will be able to use %1$s to run commands through Shizuku.</string>
+    <string name="terminal_tutorial_2_description">For example, if you want to use Shizuku™ in %1$s, you should replace %2$s with %3$s (%4$s is the package name of %1$s).</string>
+    <string name="terminal_tutorial_3">Finally, move the files to somewhere where your terminal app can access, you will be able to use %1$s to run commands through Shizuku™.</string>
     <string name="terminal_tutorial_3_description">Some tips: grant execute permission to %1$s and add it to %2$s, you will able to use %1$s directly.</string>
     <string name="rish_description"><![CDATA[
-With %1$s, in any terminal app, you can connect to and interact with the shell runs by Shizuku.
+With %1$s, in any terminal app, you can connect to and interact with the shell runs by Shizuku™.
 <p>About the detailed usage %1$s, tap to view the document.
     ]]></string>
 
@@ -112,7 +112,7 @@ With %1$s, in any terminal app, you can connect to and interact with the shell r
     <string name="settings_translation">Participate in translation</string>
     <string name="settings_translation_summary">Help us translate %s into your language</string>
     <string name="settings_start_on_boot">Start on boot (root)</string>
-    <string name="settings_start_on_boot_summary">For rooted devices, Shizuku is able to start automatically on boot</string>
+    <string name="settings_start_on_boot_summary">For rooted devices, Shizuku™ is able to start automatically on boot</string>
     <string name="settings_use_system_color">Use system theme color</string>
 
     <!-- About -->
@@ -120,13 +120,13 @@ With %1$s, in any terminal app, you can connect to and interact with the shell r
     <string name="about_view_source_code"><![CDATA[View source code at %s]]></string>
 
     <!-- Stop -->
-    <string name="action_stop">Stop Shizuku</string>
-    <string name="dialog_stop_message">Shizuku service will be stopped.</string>
+    <string name="action_stop">Stop Shizuku™</string>
+    <string name="dialog_stop_message">Shizuku™ service will be stopped.</string>
 
     <!-- Notification -->
     <string name="notification_channel_service_status">Service start status</string>
-    <string name="notification_service_starting">Shizuku service is starting…</string>
-    <string name="notification_service_start_failed">Start Shizuku service failed.</string>
+    <string name="notification_service_starting">Shizuku™ service is starting…</string>
+    <string name="notification_service_start_failed">Start Shizuku™ service failed.</string>
     <string name="notification_service_start_no_root">Failed to request root permission.</string>
     <string name="notification_working">Working…</string>
     <string name="notification_channel_adb_pairing">Wireless debugging pairing</string>
@@ -136,15 +136,15 @@ With %1$s, in any terminal app, you can connect to and interact with the shell r
     <string name="notification_adb_pairing_stop_searching">Stop searching</string>
     <string name="notification_adb_pairing_working_title">Pairing in progress</string>
     <string name="notification_adb_pairing_succeed_title">Pairing successful</string>
-    <string name="notification_adb_pairing_succeed_text">You can start Shizuku service now.</string>
+    <string name="notification_adb_pairing_succeed_text">You can start Shizuku™ service now.</string>
     <string name="notification_adb_pairing_failed_title">Pairing failed</string>
     <string name="notification_adb_pairing_retry">Retry</string>
 
     <!-- Permission related, appears in system permission UI -->
-    <string name="permission_group_label" translatable="false">Shizuku</string>
+    <string name="permission_group_label" translatable="false">Shizuku™</string>
     <string name="permission_group_description" translatable="false">@string/permission_label</string>
-    <string name="permission_label">access Shizuku</string>
-    <string name="permission_description">Allow the app to use Shizuku.</string>
+    <string name="permission_label">access Shizuku™</string>
+    <string name="permission_description">Allow the app to use Shizuku™.</string>
     <string name="permission_warning_template"><![CDATA[Allow <b>%1$s</b> to %2$s?]]></string>
     <string name="grant_dialog_button_allow_always">Allow all the time</string>
     <string name="grant_dialog_button_deny">"Deny"</string>
@@ -160,10 +160,10 @@ With %1$s, in any terminal app, you can connect to and interact with the shell r
     <string name="toast_copied_to_clipboard_with_text"><![CDATA[<b>%s</b> has been copied to clipboard.]]></string>
 
     <!-- Messages for legacy -->
-    <string name="dialog_legacy_not_support_title">%1$s does not support modern Shizuku</string>
-    <string name="dialog_legacy_not_support_message"><![CDATA[Legacy Shizuku has been deprecated since March 2019. Also, legacy Shizuku does not work on newer Android systems.<p>Please ask the developer of <b>%1$s</b> to update.]]></string>
+    <string name="dialog_legacy_not_support_title">%1$s does not support modern Shizuku™</string>
+    <string name="dialog_legacy_not_support_message"><![CDATA[Legacy Shizuku™ has been deprecated since March 2019. Also, legacy Shizuku™ does not work on newer Android systems.<p>Please ask the developer of <b>%1$s</b> to update.]]></string>
     <string name="dialog_requesting_legacy_title">%1$s is requesting legacy Shizuku</string>
-    <string name="dialog_requesting_legacy_message"><![CDATA[<b>%1$s</b> has modern Shizuku support, but it\'s requesting legacy Shizuku. This could because Shizuku is not running, please check in Shizuku app.<p>Legacy Shizuku has been deprecated since March 2019.]]></string>
-    <string name="dialog_requesting_legacy_button_open_shizuku">Open Shizuku</string>
+    <string name="dialog_requesting_legacy_message"><![CDATA[<b>%1$s</b> has modern Shizuku™ support, but it\'s requesting legacy Shizuku™. This could because Shizuku™ is not running, please check in Shizuku™ app.<p>Legacy Shizuku™ has been deprecated since March 2019.]]></string>
+    <string name="dialog_requesting_legacy_button_open_shizuku">Open Shizuku™</string>
 
 </resources>

--- a/shell/src/main/java/rikka/shizuku/shell/ShizukuShellLoader.java
+++ b/shell/src/main/java/rikka/shizuku/shell/ShizukuShellLoader.java
@@ -89,7 +89,7 @@ public class ShizukuShellLoader {
                             .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                             .addFlags(Intent.FLAG_ACTIVITY_NEW_DOCUMENT)
                             .putExtra("data", data),
-                    "Request binder from Shizuku"
+                    "Request binder from Shizuku™"
             );
 
             am.startActivityAsUser(null, callingPackage, activityIntent, null, null, null, 0, 0, null, null, Os.getuid() / 100000);
@@ -111,7 +111,7 @@ public class ShizukuShellLoader {
                     .invoke(null, args, callingPackage, binder, handler);
         } catch (ClassNotFoundException tr) {
             System.err.println("Class not found");
-            System.err.println("Make sure you have Shizuku v12.0.0 or above installed");
+            System.err.println("Make sure you have Shizuku™ v12.0.0 or above installed");
             System.err.flush();
             System.exit(1);
         } catch (Throwable tr) {
@@ -154,8 +154,8 @@ public class ShizukuShellLoader {
 
         handler.postDelayed(() -> abort(
                 String.format(
-                        "Request timeout. The connection between the current app (%1$s) and Shizuku app may be blocked by your system. " +
-                                "Please disable all battery optimization features for both current app (%1$s) and Shizuku app.",
+                        "Request timeout. The connection between the current app (%1$s) and Shizuku™ app may be blocked by your system. " +
+                                "Please disable all battery optimization features for both current app (%1$s) and Shizuku™ app.",
                         packageName)
         ), 5000);
 


### PR DESCRIPTION
NOTE: I am NOT a lawyer. This isn't legal advice.

This clarifies the new restrictions as per Apache section 6, adds the unregistered trademark symbol everywhere that Shizuku is used in a user-facing manner, and adds the logo to the README in order to make it even more obviously part of the project's branding.