### PR TITLE
README.md: clarify trademark policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ The `:manager:assembleDebug` task generates a debuggable server. You can attach 
 
 All code files in this project are licensed under Apache 2.0
 
-Under Apache 2.0 section 6, specifically:
+Under Apache 2.0 section 6, relating to trademarks, you are **FORBIDDEN** from using Shizuku trademarks unless displaying Shizuki itself, specifically:
 
-* You are **FORBIDDEN** to use `manager/src/main/res/mipmap*/ic_launcher*.png` image files, unless for displaying Shizuku itself.
+* `manager/src/main/res/mipmap*/ic_launcher*.png` image files.
 
-* You are **FORBIDDEN** to use `Shizuku` as app name or use `moe.shizuku.privileged.api` as application id or declare `moe.shizuku.manager.permission.*` permission.
+* `Shizuku` as app name or use `moe.shizuku.privileged.api` as Application ID.


### PR DESCRIPTION
As far as I can tell, in the "License" section, the exceptions are related to trademark rather than copyright.  I made a quick attempt at clarifying that, but I am not a lawyer.  If the goal is to make Shizuku free software, but control the brand, then you want a trademark policy for that, while licensing all files as Apache-2.0.  If those "FORBIDDEN" clauses are part of the license, then this is not free software.

Here are some example trademark policies from free software projects:

* https://www.debian.org/trademark
* https://www.mozilla.org/en-US/foundation/trademarks/policy/
* https://www.debian.org/trademark