### PR TITLE
Starts automatically even if Wi-Fi is not turned on at boot root-less

### DIFF
--- a/manager/src/main/AndroidManifest.xml
+++ b/manager/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission
         android:name="android.permission.WRITE_SECURE_SETTINGS"
         tools:ignore="ProtectedPermissions" />
@@ -143,6 +144,8 @@
             android:exported="false"
             android:foregroundServiceType="shortService" />
 
+        <service android:name=".service.AdbStartService" />
+
         <receiver
             android:name=".receiver.BootCompleteReceiver"
             android:directBootAware="true"
@@ -150,8 +153,6 @@
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.LOCKED_BOOT_COMPLETED" />
-            </intent-filter>
-            <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
             </intent-filter>
         </receiver>

--- a/manager/src/main/AndroidManifest.xml
+++ b/manager/src/main/AndroidManifest.xml
@@ -151,7 +151,7 @@
             android:name=".service.AdbStartService"
             android:foregroundServiceType="specialUse">
             <property android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
-                android:value="Starting Shizuku"/>
+                android:value="Required for starting the service at startup"/>
         </service>
 
         <receiver

--- a/manager/src/main/AndroidManifest.xml
+++ b/manager/src/main/AndroidManifest.xml
@@ -7,6 +7,9 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
+
     <uses-permission
         android:name="android.permission.WRITE_SECURE_SETTINGS"
         tools:ignore="ProtectedPermissions" />
@@ -144,7 +147,12 @@
             android:exported="false"
             android:foregroundServiceType="shortService" />
 
-        <service android:name=".service.AdbStartService" />
+        <service
+            android:name=".service.AdbStartService"
+            android:foregroundServiceType="specialUse">
+            <property android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+                android:value="Starting Shizuku"/>
+        </service>
 
         <receiver
             android:name=".receiver.BootCompleteReceiver"

--- a/manager/src/main/java/moe/shizuku/manager/receiver/BootCompleteReceiver.kt
+++ b/manager/src/main/java/moe/shizuku/manager/receiver/BootCompleteReceiver.kt
@@ -6,25 +6,15 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Build
-import android.provider.Settings
 import android.util.Log
-import androidx.annotation.RequiresApi
 import com.topjohnwu.superuser.Shell
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 import moe.shizuku.manager.AppConstants
 import moe.shizuku.manager.ShizukuSettings
 import moe.shizuku.manager.ShizukuSettings.LaunchMethod
-import moe.shizuku.manager.adb.AdbClient
-import moe.shizuku.manager.adb.AdbKey
-import moe.shizuku.manager.adb.AdbMdns
-import moe.shizuku.manager.adb.PreferenceAdbKeyStore
+import moe.shizuku.manager.service.AdbStartService
 import moe.shizuku.manager.starter.Starter
 import moe.shizuku.manager.utils.UserHandleCompat
 import rikka.shizuku.Shizuku
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
 
 class BootCompleteReceiver : BroadcastReceiver() {
 
@@ -38,10 +28,12 @@ class BootCompleteReceiver : BroadcastReceiver() {
 
         if (ShizukuSettings.getLastLaunchMode() == LaunchMethod.ROOT) {
             rootStart(context)
+        } else if (Intent.ACTION_LOCKED_BOOT_COMPLETED == intent.action) {
+            return
         } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU // https://r.android.com/2128832
             && context.checkSelfPermission(WRITE_SECURE_SETTINGS) == PackageManager.PERMISSION_GRANTED
             && ShizukuSettings.getLastLaunchMode() == LaunchMethod.ADB) {
-            adbStart(context)
+            context.startService(Intent(context, AdbStartService::class.java))
         } else {
             Log.w(AppConstants.TAG, "No support start on boot")
         }
@@ -55,36 +47,5 @@ class BootCompleteReceiver : BroadcastReceiver() {
         }
 
         Shell.cmd(Starter.internalCommand).exec()
-    }
-
-    @RequiresApi(Build.VERSION_CODES.TIRAMISU)
-    private fun adbStart(context: Context) {
-        val cr = context.contentResolver
-        Settings.Global.putInt(cr, "adb_wifi_enabled", 1)
-        Settings.Global.putInt(cr, Settings.Global.ADB_ENABLED, 1)
-        Settings.Global.putLong(cr, "adb_allowed_connection_time", 0L)
-        val pending = goAsync()
-        CoroutineScope(Dispatchers.IO).launch {
-            val latch = CountDownLatch(1)
-            val adbMdns = AdbMdns(context, AdbMdns.TLS_CONNECT) { port ->
-                if (port <= 0) return@AdbMdns
-                try {
-                    val keystore = PreferenceAdbKeyStore(ShizukuSettings.getPreferences())
-                    val key = AdbKey(keystore, "shizuku")
-                    val client = AdbClient("127.0.0.1", port, key)
-                    client.connect()
-                    client.shellCommand(Starter.internalCommand, null)
-                    client.close()
-                } catch (_: Exception) {
-                }
-                latch.countDown()
-            }
-            if (Settings.Global.getInt(cr, "adb_wifi_enabled", 0) == 1) {
-                adbMdns.start()
-                latch.await(3, TimeUnit.SECONDS)
-                adbMdns.stop()
-            }
-            pending.finish()
-        }
     }
 }

--- a/manager/src/main/java/moe/shizuku/manager/receiver/BootCompleteReceiver.kt
+++ b/manager/src/main/java/moe/shizuku/manager/receiver/BootCompleteReceiver.kt
@@ -33,7 +33,7 @@ class BootCompleteReceiver : BroadcastReceiver() {
         } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU // https://r.android.com/2128832
             && context.checkSelfPermission(WRITE_SECURE_SETTINGS) == PackageManager.PERMISSION_GRANTED
             && ShizukuSettings.getLastLaunchMode() == LaunchMethod.ADB) {
-            context.startService(Intent(context, AdbStartService::class.java))
+            context.startForegroundService(Intent(context, AdbStartService::class.java))
         } else {
             Log.w(AppConstants.TAG, "No support start on boot")
         }

--- a/manager/src/main/java/moe/shizuku/manager/service/AdbStartService.kt
+++ b/manager/src/main/java/moe/shizuku/manager/service/AdbStartService.kt
@@ -114,11 +114,8 @@ class AdbStartService : Service() {
             }
             if (Settings.Global.getInt(cr, "adb_wifi_enabled", 0) == 1) {
                 adbMdns.start()
-                latch.await(15, TimeUnit.SECONDS)
+                if (!latch.await(15, TimeUnit.SECONDS)) toast.show()
                 adbMdns.stop()
-
-
-                toast.show()
             }
         }
     }

--- a/manager/src/main/java/moe/shizuku/manager/service/AdbStartService.kt
+++ b/manager/src/main/java/moe/shizuku/manager/service/AdbStartService.kt
@@ -72,7 +72,7 @@ class AdbStartService : Service() {
                     }
                     if (Settings.Global.getInt(cr, "adb_wifi_enabled", 0) == 1) {
                         adbMdns.start()
-                        latch.await(3, TimeUnit.SECONDS)
+                        latch.await(5, TimeUnit.SECONDS)
                         adbMdns.stop()
                     }
                 }

--- a/manager/src/main/java/moe/shizuku/manager/service/AdbStartService.kt
+++ b/manager/src/main/java/moe/shizuku/manager/service/AdbStartService.kt
@@ -1,20 +1,25 @@
 package moe.shizuku.manager.service
 
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
 import android.app.Service
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.content.pm.ServiceInfo
 import android.net.ConnectivityManager
-import android.net.Network
 import android.net.NetworkCapabilities
-import android.net.NetworkRequest
 import android.net.wifi.WifiManager
 import android.os.Build
 import android.os.IBinder
 import android.provider.Settings
+import android.util.Log
 import android.widget.Toast
 import androidx.annotation.RequiresApi
+import androidx.core.app.NotificationCompat
+import androidx.core.app.ServiceCompat
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -29,7 +34,9 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
 class AdbStartService : Service() {
-    lateinit var cm: ConnectivityManager
+
+    lateinit var notification: Notification
+    var receiver: BroadcastReceiver? = null
 
     override fun onBind(intent: Intent?): IBinder? {
         return null
@@ -39,34 +46,44 @@ class AdbStartService : Service() {
     override fun onCreate() {
         super.onCreate()
 
-        cm = getSystemService(ConnectivityManager::class.java)
+        Log.d(TAG, "onCreate")
 
-        if (checkWifiConnected()) {
-            startShizuku(applicationContext)
-            return
-        }
-
-        val receiver = object : BroadcastReceiver() {
+        receiver = object : BroadcastReceiver() {
+            @RequiresApi(Build.VERSION_CODES.TIRAMISU)
             override fun onReceive(context: Context?, intent: Intent?) {
+
                 if (context == null) return
 
                 if (checkWifiConnected()) {
                     startShizuku(context)
-                    unregisterReceiver(this)
                 }
             }
         }
+
         val intentFilter = IntentFilter(WifiManager.NETWORK_STATE_CHANGED_ACTION)
 
-        applicationContext.registerReceiver(receiver, intentFilter)
+        this.registerReceiver(receiver, intentFilter)
+
+        // this is after registering the receiver, so in case it fails, so the receiver is still active
+        if (checkWifiConnected()) startShizuku(this)
     }
+
+
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         return START_STICKY
     }
 
+    override fun onDestroy() {
+        Log.d(TAG, "onDestroy")
+        receiver?.let { unregisterReceiver(it) }
+        super.onDestroy()
+    }
+
     @RequiresApi(Build.VERSION_CODES.TIRAMISU)
     private fun startShizuku(context: Context) {
+
+        Log.d(TAG, "startShizuku")
         Toast.makeText(context, R.string.notification_service_starting, Toast.LENGTH_SHORT).show()
 
         val cr = context.contentResolver
@@ -82,6 +99,7 @@ class AdbStartService : Service() {
                     val keystore = PreferenceAdbKeyStore(ShizukuSettings.getPreferences())
                     val key = AdbKey(keystore, "shizuku")
                     val client = AdbClient("127.0.0.1", port, key)
+
                     client.connect()
                     client.shellCommand(Starter.internalCommand, null)
                     client.close()
@@ -102,7 +120,14 @@ class AdbStartService : Service() {
     }
 
     private fun checkWifiConnected() : Boolean {
+        val cm = getSystemService(ConnectivityManager::class.java)
         return cm.getNetworkCapabilities(cm.activeNetwork)
             ?.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) == true
+    }
+
+    companion object {
+        const val TAG = "AdbStartService"
+        const val NOTIFICATION_CHANNEL = "wadb_service"
+        const val SERVICE_ID = 1447
     }
 }

--- a/manager/src/main/java/moe/shizuku/manager/service/AdbStartService.kt
+++ b/manager/src/main/java/moe/shizuku/manager/service/AdbStartService.kt
@@ -1,0 +1,96 @@
+package moe.shizuku.manager.service
+
+import android.app.Service
+import android.content.Intent
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+import android.os.Build
+import android.os.IBinder
+import android.provider.Settings
+import android.util.Log
+import android.widget.Toast
+import androidx.annotation.RequiresApi
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import moe.shizuku.manager.R
+import moe.shizuku.manager.ShizukuSettings
+import moe.shizuku.manager.adb.AdbClient
+import moe.shizuku.manager.adb.AdbKey
+import moe.shizuku.manager.adb.AdbMdns
+import moe.shizuku.manager.adb.PreferenceAdbKeyStore
+import moe.shizuku.manager.starter.Starter
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+class AdbStartService : Service() {
+    lateinit var networkCallback: ConnectivityManager.NetworkCallback
+
+    override fun onBind(intent: Intent?): IBinder? {
+        return null
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+
+        val networkRequest = NetworkRequest.Builder()
+            .addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
+            .build()
+
+        networkCallback = object : ConnectivityManager.NetworkCallback() {
+            @RequiresApi(Build.VERSION_CODES.TIRAMISU)
+            override fun onAvailable(network: Network) {
+                super.onAvailable(network)
+
+                Toast.makeText(applicationContext, R.string.notification_service_starting, Toast.LENGTH_SHORT).show()
+
+                val cr = applicationContext.contentResolver
+                Settings.Global.putInt(cr, "adb_wifi_enabled", 1)
+                Settings.Global.putInt(cr, Settings.Global.ADB_ENABLED, 1)
+                Settings.Global.putLong(cr, "adb_allowed_connection_time", 0L)
+                CoroutineScope(Dispatchers.IO).launch {
+                    val latch = CountDownLatch(1)
+                    val adbMdns = AdbMdns(applicationContext, AdbMdns.TLS_CONNECT) { port ->
+                        if (port <= 0) return@AdbMdns
+                        try {
+
+                            val keystore = PreferenceAdbKeyStore(ShizukuSettings.getPreferences())
+                            val key = AdbKey(keystore, "shizuku")
+                            val client = AdbClient("127.0.0.1", port, key)
+                            client.connect()
+                            client.shellCommand(Starter.internalCommand, null)
+                            client.close()
+
+                            Settings.Global.putInt(cr, "adb_wifi_enabled", 0)
+
+                            stopSelf()
+
+                        } catch (_: Exception) {}
+                        latch.countDown()
+                    }
+                    if (Settings.Global.getInt(cr, "adb_wifi_enabled", 0) == 1) {
+                        adbMdns.start()
+                        latch.await(3, TimeUnit.SECONDS)
+                        adbMdns.stop()
+                    }
+                }
+            }
+        }
+
+        val cm = getSystemService(ConnectivityManager::class.java)
+        cm.registerNetworkCallback(networkRequest, networkCallback)
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        return START_STICKY
+    }
+
+    override fun onDestroy() {
+        val cm = getSystemService(ConnectivityManager::class.java)
+        cm.unregisterNetworkCallback(networkCallback)
+
+        super.onDestroy()
+    }
+}

--- a/manager/src/main/java/moe/shizuku/manager/service/AdbStartService.kt
+++ b/manager/src/main/java/moe/shizuku/manager/service/AdbStartService.kt
@@ -1,15 +1,18 @@
 package moe.shizuku.manager.service
 
 import android.app.Service
+import android.content.BroadcastReceiver
+import android.content.Context
 import android.content.Intent
+import android.content.IntentFilter
 import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkCapabilities
 import android.net.NetworkRequest
+import android.net.wifi.WifiManager
 import android.os.Build
 import android.os.IBinder
 import android.provider.Settings
-import android.util.Log
 import android.widget.Toast
 import androidx.annotation.RequiresApi
 import kotlinx.coroutines.CoroutineScope
@@ -26,71 +29,80 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
 class AdbStartService : Service() {
-    lateinit var networkCallback: ConnectivityManager.NetworkCallback
+    lateinit var cm: ConnectivityManager
 
     override fun onBind(intent: Intent?): IBinder? {
         return null
     }
 
+    @RequiresApi(Build.VERSION_CODES.TIRAMISU)
     override fun onCreate() {
         super.onCreate()
 
-        val networkRequest = NetworkRequest.Builder()
-            .addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
-            .build()
+        cm = getSystemService(ConnectivityManager::class.java)
 
-        networkCallback = object : ConnectivityManager.NetworkCallback() {
-            @RequiresApi(Build.VERSION_CODES.TIRAMISU)
-            override fun onAvailable(network: Network) {
-                super.onAvailable(network)
+        if (checkWifiConnected()) {
+            startShizuku(applicationContext)
+            return
+        }
 
-                Toast.makeText(applicationContext, R.string.notification_service_starting, Toast.LENGTH_SHORT).show()
+        val receiver = object : BroadcastReceiver() {
+            override fun onReceive(context: Context?, intent: Intent?) {
+                if (context == null) return
 
-                val cr = applicationContext.contentResolver
-                Settings.Global.putInt(cr, "adb_wifi_enabled", 1)
-                Settings.Global.putInt(cr, Settings.Global.ADB_ENABLED, 1)
-                Settings.Global.putLong(cr, "adb_allowed_connection_time", 0L)
-                CoroutineScope(Dispatchers.IO).launch {
-                    val latch = CountDownLatch(1)
-                    val adbMdns = AdbMdns(applicationContext, AdbMdns.TLS_CONNECT) { port ->
-                        if (port <= 0) return@AdbMdns
-                        try {
-
-                            val keystore = PreferenceAdbKeyStore(ShizukuSettings.getPreferences())
-                            val key = AdbKey(keystore, "shizuku")
-                            val client = AdbClient("127.0.0.1", port, key)
-                            client.connect()
-                            client.shellCommand(Starter.internalCommand, null)
-                            client.close()
-
-                            Settings.Global.putInt(cr, "adb_wifi_enabled", 0)
-
-                            stopSelf()
-
-                        } catch (_: Exception) {}
-                        latch.countDown()
-                    }
-                    if (Settings.Global.getInt(cr, "adb_wifi_enabled", 0) == 1) {
-                        adbMdns.start()
-                        latch.await(5, TimeUnit.SECONDS)
-                        adbMdns.stop()
-                    }
+                if (checkWifiConnected()) {
+                    startShizuku(context)
+                    unregisterReceiver(this)
                 }
             }
         }
+        val intentFilter = IntentFilter(WifiManager.NETWORK_STATE_CHANGED_ACTION)
 
-        val cm = getSystemService(ConnectivityManager::class.java)
-        cm.registerNetworkCallback(networkRequest, networkCallback)
+        applicationContext.registerReceiver(receiver, intentFilter)
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         return START_STICKY
     }
 
-    override fun onDestroy() {
-        val cm = getSystemService(ConnectivityManager::class.java)
-        cm.unregisterNetworkCallback(networkCallback)
+    @RequiresApi(Build.VERSION_CODES.TIRAMISU)
+    private fun startShizuku(context: Context) {
+        Toast.makeText(context, R.string.notification_service_starting, Toast.LENGTH_SHORT).show()
 
-        super.onDestroy()
+        val cr = context.contentResolver
+        Settings.Global.putInt(cr, "adb_wifi_enabled", 1)
+        Settings.Global.putInt(cr, Settings.Global.ADB_ENABLED, 1)
+        Settings.Global.putLong(cr, "adb_allowed_connection_time", 0L)
+        CoroutineScope(Dispatchers.IO).launch {
+            val latch = CountDownLatch(1)
+            val adbMdns = AdbMdns(context, AdbMdns.TLS_CONNECT) { port ->
+                if (port <= 0) return@AdbMdns
+                try {
+
+                    val keystore = PreferenceAdbKeyStore(ShizukuSettings.getPreferences())
+                    val key = AdbKey(keystore, "shizuku")
+                    val client = AdbClient("127.0.0.1", port, key)
+                    client.connect()
+                    client.shellCommand(Starter.internalCommand, null)
+                    client.close()
+
+                    Settings.Global.putInt(cr, "adb_wifi_enabled", 0)
+
+                    stopSelf()
+
+                } catch (_: Exception) {}
+                latch.countDown()
+            }
+            if (Settings.Global.getInt(cr, "adb_wifi_enabled", 0) == 1) {
+                adbMdns.start()
+                latch.await(5, TimeUnit.SECONDS)
+                adbMdns.stop()
+            }
+        }
+    }
+
+    private fun checkWifiConnected() : Boolean {
+        return cm.getNetworkCapabilities(cm.activeNetwork)
+            ?.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) == true
     }
 }

--- a/manager/src/main/res/values-fr/strings.xml
+++ b/manager/src/main/res/values-fr/strings.xml
@@ -43,7 +43,7 @@
     <string name="action_stop">Arrêter Shizuku</string>
     <string name="about_view_source_code">Voir le code source sur %s</string>
     <string name="action_about">À propos</string>
-    <string name="settings_start_on_boot_summary">Pour les appareils rootés, Shizuku peut se lancer automatiquement au démarrage</string>
+    <string name="settings_start_on_boot_summary">Pour les appareils rootés ou sous Android 11+ ou plus, Shizuku peut se lancer automatiquement au démarrage</string>
     <string name="settings_start_on_boot">Lancer au démarrage de l\'appareil (root)</string>
     <string name="settings_translation_summary">Aidez-nous à traduire %s dans votre langue</string>
     <string name="settings_translation">Participer à la traduction</string>

--- a/manager/src/main/res/values-fr/strings.xml
+++ b/manager/src/main/res/values-fr/strings.xml
@@ -131,4 +131,5 @@
     <string name="home_app_management_empty">Les applications qui ont demandé ou déclaré l\'accès à Shizuku apparaîtront ici.</string>
     <string name="dialog_adb_discovery_message_toggle_wireless_debugging">Merci d\'essayer de désactiver et de réactiver le \"Débogage sans-fil\" si ça continue à chercher.</string>
     <string name="wadb_notification_title">Shizuku est en cours de démarrage...</string>
+    <string name="wadb_notification_attempt_now">Tenter maintenant</string>
 </resources>

--- a/manager/src/main/res/values-fr/strings.xml
+++ b/manager/src/main/res/values-fr/strings.xml
@@ -14,6 +14,8 @@
     <string name="toast_copied_to_clipboard_with_text"><b>%s</b> a bien été copié dans le presse papier.</string>
     <string name="toast_copied_to_clipboard">%s
 \na bien été copié dans le presse papier.</string>
+    <string name="wadb_notification_content">En attente d\'une connection Wi-Fi avant de procéder</string>
+    <string name="wadb_notification_channel">Service de démarrage automatique par ADB</string>
     <string name="dialog_cannot_open_browser_title">Impossible de lancer le navigateur</string>
     <string name="start_with_root_failed">Impossible de lancer le service parce que la permission root n\'est pas accordée ou que cet appareil n\'est pas rooté.</string>
     <string name="starter">Démarreur</string>
@@ -128,4 +130,5 @@
     <string name="home_adb_is_limited_title">Une étape supplémentaire est nécessaire</string>
     <string name="home_app_management_empty">Les applications qui ont demandé ou déclaré l\'accès à Shizuku apparaîtront ici.</string>
     <string name="dialog_adb_discovery_message_toggle_wireless_debugging">Merci d\'essayer de désactiver et de réactiver le \"Débogage sans-fil\" si ça continue à chercher.</string>
+    <string name="wadb_notification_title">Shizuku est en cours de démarrage...</string>
 </resources>

--- a/manager/src/main/res/values/strings.xml
+++ b/manager/src/main/res/values/strings.xml
@@ -112,7 +112,7 @@ With %1$s, in any terminal app, you can connect to and interact with the shell r
     <string name="settings_translation">Participate in translation</string>
     <string name="settings_translation_summary">Help us translate %s into your language</string>
     <string name="settings_start_on_boot">Start on boot</string>
-    <string name="settings_start_on_boot_summary">For rooted devices or devices on Android 13+, Shizuku is able to start automatically on boot</string>
+    <string name="settings_start_on_boot_summary">For rooted devices or devices on Android 11+, Shizuku is able to start automatically on boot</string>
     <string name="settings_use_system_color">Use system theme color</string>
 
     <!-- About -->

--- a/manager/src/main/res/values/strings.xml
+++ b/manager/src/main/res/values/strings.xml
@@ -170,5 +170,6 @@ With %1$s, in any terminal app, you can connect to and interact with the shell r
     <string name="dialog_requesting_legacy_title">%1$s is requesting legacy Shizuku</string>
     <string name="dialog_requesting_legacy_message"><![CDATA[<b>%1$s</b> has modern Shizuku support, but it\'s requesting legacy Shizuku. This could because Shizuku is not running, please check in Shizuku app.<p>Legacy Shizuku has been deprecated since March 2019.]]></string>
     <string name="dialog_requesting_legacy_button_open_shizuku">Open Shizuku</string>
+    <string name="wadb_notification_attempt_now">Attempt now</string>
 
 </resources>

--- a/manager/src/main/res/values/strings.xml
+++ b/manager/src/main/res/values/strings.xml
@@ -111,8 +111,8 @@ With %1$s, in any terminal app, you can connect to and interact with the shell r
     <string name="settings_translation_contributors">Translation contributors</string>
     <string name="settings_translation">Participate in translation</string>
     <string name="settings_translation_summary">Help us translate %s into your language</string>
-    <string name="settings_start_on_boot">Start on boot (root)</string>
-    <string name="settings_start_on_boot_summary">For rooted devices, Shizuku is able to start automatically on boot</string>
+    <string name="settings_start_on_boot">Start on boot</string>
+    <string name="settings_start_on_boot_summary">For rooted devices or devices on Android 13+, Shizuku is able to start automatically on boot</string>
     <string name="settings_use_system_color">Use system theme color</string>
 
     <!-- About -->

--- a/manager/src/main/res/values/strings.xml
+++ b/manager/src/main/res/values/strings.xml
@@ -154,6 +154,11 @@ With %1$s, in any terminal app, you can connect to and interact with the shell r
     <string name="starting_root_shell" translatable="false">Starting root shell…</string>
     <string name="start_with_root_failed">Can\'t start service because root permission is not granted or this device is not rooted.</string>
 
+    <!-- WADB Starter -->
+    <string name="wadb_notification_title">Starting Shizuku…</string>
+    <string name="wadb_notification_content">Awaiting Wi-Fi connection before proceeding</string>
+    <string name="wadb_notification_channel">ADB auto-start service</string>
+
     <!-- Misc -->
     <string name="dialog_cannot_open_browser_title">Can\'t start browser</string>
     <string name="toast_copied_to_clipboard">%s\nhas been copied to clipboard.</string>


### PR DESCRIPTION
Uses a foreground service with a network callback to start shizuku whenever its connected a WiFi network.
Tested on Pixel 7 pro/A16, haven't been any API changes around services since A14, so it should work there too.

To whoever's in charge of submitting to GP: 
To submit the app to google play you will need to specify the FGS to the play console and answer some questions as well as submit a clip (from what i've read online). 
I don't have the exact questions, but the key points you need to say are:
 - The FGS addresses a core issue that has been requested by users 
 - If the task is deferred, the main service won't work until the task is run, which is required for other app's core functionalities.
 - It uses a very small amount of battery (>1% over tests of a few hours)
 - Users can cancel it at any time from the notification and opt out from the settings
 
