### PR TITLE
Add accessibility service for PIN read

### DIFF
--- a/manager/src/main/AndroidManifest.xml
+++ b/manager/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.BIND_ACCESSIBILITY_SERVICE" />
     <uses-permission
         android:name="android.permission.WRITE_SECURE_SETTINGS"
         tools:ignore="ProtectedPermissions" />
@@ -86,6 +87,10 @@
             android:name=".adb.AdbPairingTutorialActivity"
             android:label="@string/adb_pairing" />
         <activity
+            android:name=".accessibility.AccessibilitySettingsActivity"
+            android:label="@string/accessibility_service_title"
+            android:exported="false" />
+        <activity
             android:name=".shell.ShellTutorialActivity"
             android:label="@string/home_terminal_title" />
         <activity
@@ -142,6 +147,27 @@
             android:enabled="true"
             android:exported="false"
             android:foregroundServiceType="shortService" />
+
+        <service
+            android:name=".accessibility.PairingCodeAccessibilityService"
+            android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.accessibilityservice.AccessibilityService" />
+            </intent-filter>
+            <meta-data
+                android:name="android.accessibilityservice"
+                android:resource="@xml/accessibility_service_config" />
+        </service>
+
+        <receiver
+            android:name=".accessibility.PairingCodeReceiver"
+            android:enabled="true"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="moe.shizuku.manager.PAIRING_CODE_FOUND" />
+            </intent-filter>
+        </receiver>
 
         <receiver
             android:name=".receiver.BootCompleteReceiver"

--- a/manager/src/main/java/moe/shizuku/manager/accessibility/AccessibilitySettingsActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/accessibility/AccessibilitySettingsActivity.kt
@@ -1,0 +1,34 @@
+package moe.shizuku.manager.accessibility
+
+import android.os.Bundle
+import androidx.preference.PreferenceFragmentCompat
+import androidx.preference.SwitchPreference
+import moe.shizuku.manager.R
+import moe.shizuku.manager.app.AppBarActivity
+
+class AccessibilitySettingsActivity : AppBarActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.accessibility_settings_activity)
+        
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        
+        if (savedInstanceState == null) {
+            supportFragmentManager
+                .beginTransaction()
+                .replace(R.id.settings_container, AccessibilitySettingsFragment())
+                .commit()
+        }
+    }
+    
+    class AccessibilitySettingsFragment : PreferenceFragmentCompat() {
+        
+        override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+            setPreferencesFromResource(R.xml.accessibility_preferences, rootKey)
+            
+            val enabledPref = findPreference<SwitchPreference>("accessibility_enabled")
+            enabledPref?.summary = getString(R.string.accessibility_service_setting_description)
+        }
+    }
+}

--- a/manager/src/main/java/moe/shizuku/manager/accessibility/AccessibilityUtils.kt
+++ b/manager/src/main/java/moe/shizuku/manager/accessibility/AccessibilityUtils.kt
@@ -1,0 +1,36 @@
+package moe.shizuku.manager.accessibility
+
+import android.accessibilityservice.AccessibilityServiceInfo
+import android.content.Context
+import android.content.Intent
+import android.provider.Settings
+import android.view.accessibility.AccessibilityManager
+
+object AccessibilityUtils {
+    
+    fun isAccessibilityServiceEnabled(context: Context): Boolean {
+        val accessibilityManager = context.getSystemService(Context.ACCESSIBILITY_SERVICE) as AccessibilityManager
+        val enabledServices = accessibilityManager.getEnabledAccessibilityServiceList(AccessibilityServiceInfo.FEEDBACK_ALL_MASK)
+        
+        val targetService = "${context.packageName}/${PairingCodeAccessibilityService::class.java.name}"
+        
+        return enabledServices.any { service ->
+            service.resolveInfo.serviceInfo.name == PairingCodeAccessibilityService::class.java.name &&
+            service.resolveInfo.serviceInfo.packageName == context.packageName
+        }
+    }
+    
+    fun openAccessibilitySettings(context: Context) {
+        val intent = Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS)
+        intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+        context.startActivity(intent)
+    }
+    
+    fun openAppAccessibilitySettings(context: Context) {
+        val intent = Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS)
+        intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+        // Try to directly open the service settings if possible
+        intent.putExtra(":settings:fragment_args_key", "${context.packageName}/${PairingCodeAccessibilityService::class.java.name}")
+        context.startActivity(intent)
+    }
+}

--- a/manager/src/main/java/moe/shizuku/manager/accessibility/PairingCodeAccessibilityService.kt
+++ b/manager/src/main/java/moe/shizuku/manager/accessibility/PairingCodeAccessibilityService.kt
@@ -1,0 +1,270 @@
+package moe.shizuku.manager.accessibility
+
+import android.accessibilityservice.AccessibilityService
+import android.annotation.SuppressLint
+import android.content.Intent
+import android.os.Build
+import android.util.Log
+import android.view.accessibility.AccessibilityEvent
+import android.view.accessibility.AccessibilityNodeInfo
+import androidx.annotation.RequiresApi
+import java.util.regex.Pattern
+
+@SuppressLint("AccessibilityPolicy")
+@RequiresApi(Build.VERSION_CODES.R)
+class PairingCodeAccessibilityService : AccessibilityService() {
+
+    companion object {
+        private const val TAG = "PairingAccessibility"
+        private const val SYSTEM_UI_PACKAGE = "com.android.systemui"
+        private const val SETTINGS_PACKAGE = "com.android.settings"
+        
+        // Pattern to match 6-digit pairing codes
+        private val PIN_PATTERN = Pattern.compile("\\b\\d{6}\\b")
+        
+        // Possible text patterns that might contain the PIN
+        private val PIN_KEYWORDS = arrayOf(
+            "pairing code",
+            "pair device",
+            "wireless debugging",
+            "adb",
+            "debugging",
+            "code",
+            "pairing",
+            "pair with device"
+        )
+        
+        // Rate limiting and duplicate prevention
+        private const val PIN_SEND_COOLDOWN_MS = 2000L // 2 seconds between sends
+        private const val MAX_SAME_PIN_SENDS = 3 // Max times to send same PIN
+    }
+    
+    private var lastPinSent: String? = null
+    private var lastPinSentTime = 0L
+    private var samePinSendCount = 0
+    private var lastProcessedEventTime = 0L
+    private var isProcessingPin = false
+
+    override fun onAccessibilityEvent(event: AccessibilityEvent?) {
+        if (event == null || isProcessingPin) return
+
+        // Only process events from system UI and Settings
+        val packageName = event.packageName?.toString()
+        if (packageName != SYSTEM_UI_PACKAGE && packageName != SETTINGS_PACKAGE) {
+            return
+        }
+
+        // Throttle event processing to reduce spam
+        val currentTime = System.currentTimeMillis()
+        if (currentTime - lastProcessedEventTime < 500) { // 500ms throttle
+            return
+        }
+        lastProcessedEventTime = currentTime
+
+        Log.d(TAG, "Processing accessibility event from $packageName, type: ${event.eventType}")
+
+        // Focus on content change and window state change events
+        when (event.eventType) {
+            AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED,
+            AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED -> {
+                // Check if this is a window state change that might indicate dialog closed
+                if (event.eventType == AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED) {
+                    val className = event.className?.toString()
+                    Log.d(TAG, "Window state changed: $className")
+                    
+                    // Reset PIN tracking when dialogs are closed
+                    if (className?.contains("Dialog") == false && className?.contains("Activity") == true) {
+                        Log.d(TAG, "Dialog likely closed, resetting PIN tracking")
+                        resetPinTracking()
+                    }
+                }
+                
+                searchForPairingCode(event)
+            }
+            AccessibilityEvent.TYPE_VIEW_TEXT_CHANGED -> {
+                searchForPairingCode(event)
+            }
+        }
+    }
+    
+    private fun resetPinTracking() {
+        lastPinSent = null
+        lastPinSentTime = 0L
+        samePinSendCount = 0
+        isProcessingPin = false
+        Log.d(TAG, "PIN tracking reset")
+    }
+
+    private fun searchForPairingCode(event: AccessibilityEvent) {
+        if (isProcessingPin) return
+        
+        try {
+            isProcessingPin = true
+            Log.d(TAG, "Searching for pairing code in event")
+            
+            // Search for PIN in the current event text first
+            event.text?.forEach { text ->
+                if (!text.isNullOrEmpty()) {
+                    Log.d(TAG, "Event text: $text")
+                    val pin = extractPinFromText(text.toString())
+                    if (pin != null) {
+                        Log.i(TAG, "Found PIN in event text: $pin")
+                        sendPinToAdbService(pin)
+                        return
+                    }
+                }
+            }
+
+            // Search recursively through all nodes
+            val rootNode = rootInActiveWindow
+            if (rootNode != null) {
+                Log.d(TAG, "Searching through node tree")
+                searchNodeTreeForPin(rootNode)
+            } else {
+                Log.d(TAG, "No root node available")
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Error searching for pairing code", e)
+        } finally {
+            isProcessingPin = false
+        }
+    }
+
+    private fun searchNodeTreeForPin(node: AccessibilityNodeInfo?) {
+        if (node == null) return
+
+        try {
+            // Check current node text
+            val nodeText = node.text?.toString()
+            if (!nodeText.isNullOrEmpty()) {
+                val pin = extractPinFromText(nodeText)
+                if (pin != null) {
+                    Log.i(TAG, "Found PIN in node text: $pin")
+                    sendPinToAdbService(pin)
+                    return
+                }
+            }
+
+            // Check content description
+            val contentDesc = node.contentDescription?.toString()
+            if (!contentDesc.isNullOrEmpty()) {
+                val pin = extractPinFromText(contentDesc)
+                if (pin != null) {
+                    Log.i(TAG, "Found PIN in content description: $pin")
+                    sendPinToAdbService(pin)
+                    return
+                }
+            }
+
+            // Recursively check child nodes
+            for (i in 0 until node.childCount) {
+                val child = node.getChild(i)
+                if (child != null) {
+                    searchNodeTreeForPin(child)
+                }
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Error searching node tree", e)
+        }
+    }
+
+    private fun extractPinFromText(text: String): String? {
+        if (text.isEmpty()) return null
+
+        Log.d(TAG, "Analyzing text for PIN: '$text'")
+
+        // Look for 6-digit patterns
+        val matcher = PIN_PATTERN.matcher(text)
+        while (matcher.find()) {
+            val match = matcher.group()
+            
+            // First check if the text contains any PIN-related keywords
+            val lowerText = text.lowercase()
+            val containsKeyword = PIN_KEYWORDS.any { lowerText.contains(it) }
+            
+            if (containsKeyword) {
+                Log.i(TAG, "Found PIN with keyword context: $match")
+                return match
+            }
+            
+            // Also check for standalone 6-digit numbers in dialog contexts
+            // Verify it's likely a PIN (not a time, phone number, etc.)
+            val beforeChar = if (matcher.start() > 0) text[matcher.start() - 1] else ' '
+            val afterChar = if (matcher.end() < text.length) text[matcher.end()] else ' '
+            
+            // If it's exactly 6 digits and surrounded by spaces, punctuation, or at boundaries
+            if (!beforeChar.isDigit() && !afterChar.isDigit()) {
+                // Additional heuristic: avoid common false positives like times (125959)
+                val matchInt = match.toIntOrNull()
+                if (matchInt != null && matchInt >= 100000 && matchInt <= 999999) {
+                    // Avoid sequences that look like times (hours > 23 are unlikely to be time)
+                    val firstTwo = matchInt / 10000
+                    val middleTwo = (matchInt / 100) % 100
+                    val lastTwo = matchInt % 100
+                    
+                    // If it doesn't look like HHMMSS format, it's probably a PIN
+                    if (firstTwo > 23 || middleTwo > 59 || lastTwo > 59) {
+                        Log.i(TAG, "Found potential PIN: $match")
+                        return match
+                    }
+                }
+            }
+        }
+
+        return null
+    }
+
+    private fun sendPinToAdbService(pin: String) {
+        try {
+            val currentTime = System.currentTimeMillis()
+            
+            // Check if this is the same PIN we recently sent
+            if (pin == lastPinSent) {
+                // Check cooldown period
+                if (currentTime - lastPinSentTime < PIN_SEND_COOLDOWN_MS) {
+                    return
+                }
+                
+                // Check max send count for same PIN
+                if (samePinSendCount >= MAX_SAME_PIN_SENDS) {
+                    return
+                }
+                
+                samePinSendCount++
+            } else {
+                // New PIN, reset counters
+                samePinSendCount = 1
+                lastPinSent = pin
+            }
+            
+            lastPinSentTime = currentTime
+            
+            Log.i(TAG, "Sending PIN to ADB service: $pin (attempt #$samePinSendCount)")
+            
+            // Find the port from ADB service if it's running
+            // For now, we'll use a broadcast to communicate the PIN
+            val intent = Intent("moe.shizuku.manager.PAIRING_CODE_FOUND").apply {
+                putExtra("pin", pin)
+                setPackage(packageName)
+            }
+            sendBroadcast(intent)
+            
+        } catch (e: Exception) {
+            Log.e(TAG, "Error sending PIN to ADB service", e)
+        }
+    }
+
+    override fun onInterrupt() {
+        Log.i(TAG, "Accessibility service interrupted")
+    }
+
+    override fun onServiceConnected() {
+        super.onServiceConnected()
+        Log.i(TAG, "Accessibility service connected")
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        Log.i(TAG, "Accessibility service destroyed")
+    }
+}

--- a/manager/src/main/java/moe/shizuku/manager/accessibility/PairingCodeReceiver.kt
+++ b/manager/src/main/java/moe/shizuku/manager/accessibility/PairingCodeReceiver.kt
@@ -1,0 +1,47 @@
+package moe.shizuku.manager.accessibility
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.util.Log
+import moe.shizuku.manager.adb.AdbPairingService
+
+class PairingCodeReceiver : BroadcastReceiver() {
+
+    companion object {
+        private const val TAG = "PairingCodeReceiver"
+        const val ACTION_PAIRING_CODE_FOUND = "moe.shizuku.manager.PAIRING_CODE_FOUND"
+        const val EXTRA_PIN = "pin"
+        
+        fun createIntentFilter(): IntentFilter {
+            return IntentFilter(ACTION_PAIRING_CODE_FOUND)
+        }
+    }
+
+    override fun onReceive(context: Context?, intent: Intent?) {
+        if (context == null || intent == null) return
+
+        if (intent.action == ACTION_PAIRING_CODE_FOUND) {
+            val pin = intent.getStringExtra(EXTRA_PIN)
+            if (!pin.isNullOrEmpty() && pin.length == 6 && pin.all { it.isDigit() }) {
+                Log.i(TAG, "Received valid PIN from accessibility service")
+                
+                // Create intent to send PIN to ADB pairing service
+                val serviceIntent = Intent(context, AdbPairingService::class.java).apply {
+                    action = "auto_pair"
+                    putExtra("auto_pin", pin)
+                }
+                
+                try {
+                    context.startForegroundService(serviceIntent)
+                    Log.i(TAG, "Started ADB pairing service with auto-detected PIN")
+                } catch (e: Exception) {
+                    Log.e(TAG, "Failed to start ADB pairing service with PIN", e)
+                }
+            } else {
+                Log.w(TAG, "Invalid PIN received: $pin")
+            }
+        }
+    }
+}

--- a/manager/src/main/java/moe/shizuku/manager/adb/AdbPairingService.kt
+++ b/manager/src/main/java/moe/shizuku/manager/adb/AdbPairingService.kt
@@ -4,9 +4,12 @@ import android.annotation.TargetApi
 import android.app.*
 import android.content.Context
 import android.content.Intent
+import android.content.IntentFilter
 import android.content.pm.ServiceInfo
 import android.os.Build
 import android.os.IBinder
+import moe.shizuku.manager.starter.StarterActivity
+import moe.shizuku.manager.utils.EnvironmentUtils
 import android.util.Log
 import androidx.lifecycle.Observer
 import kotlinx.coroutines.Dispatchers
@@ -14,6 +17,8 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import moe.shizuku.manager.R
 import moe.shizuku.manager.ShizukuSettings
+import moe.shizuku.manager.accessibility.PairingCodeReceiver
+import moe.shizuku.manager.accessibility.AccessibilityUtils
 import rikka.core.ktx.unsafeLazy
 import java.net.ConnectException
 
@@ -33,8 +38,10 @@ class AdbPairingService : Service() {
         private const val startAction = "start"
         private const val stopAction = "stop"
         private const val replyAction = "reply"
+        private const val autoPairAction = "auto_pair"
         private const val remoteInputResultKey = "paring_code"
         private const val portKey = "paring_code"
+        private const val autoPinKey = "auto_pin"
 
         fun startIntent(context: Context): Intent {
             return Intent(context, AdbPairingService::class.java).setAction(startAction)
@@ -50,16 +57,32 @@ class AdbPairingService : Service() {
     }
 
     private var adbMdns: AdbMdns? = null
+    private var adbConnectMdns: AdbMdns? = null
+    private var lastDiscoveredPort: Int = -1
+    private var discoveredAdbPort: Int = -1
+    private var pairingCodeReceiver: PairingCodeReceiver? = null
+    private var isPairingInProgress = false
+    private var lastPairingAttemptTime = 0L
+    private val pairingCooldownMs = 3000L // 3 seconds between pairing attempts
 
     private val observer = Observer<Int> { port ->
         Log.i(tag, "Pairing service port: $port")
         if (port <= 0) return@Observer
+        
+        lastDiscoveredPort = port
 
         // Since the service could be killed before user finishing input,
         // we need to put the port into Intent
         val notification = createInputNotification(port)
 
         getSystemService(NotificationManager::class.java).notify(notificationId, notification)
+    }
+    
+    private val adbConnectObserver = Observer<Int> { port ->
+        Log.i(tag, "ADB connection port discovered: $port")
+        if (port > 0) {
+            discoveredAdbPort = port
+        }
     }
 
     private var started = false
@@ -93,6 +116,32 @@ class AdbPairingService : Service() {
                     onStart()
                 }
             }
+            autoPairAction -> {
+                val pin = intent.getStringExtra(autoPinKey)
+                if (!pin.isNullOrEmpty() && lastDiscoveredPort > 0) {
+                    val currentTime = System.currentTimeMillis()
+                    
+                    // Check if pairing is already in progress
+                    if (isPairingInProgress) {
+                        Log.d(tag, "Pairing already in progress, ignoring auto-pair request")
+                        return START_NOT_STICKY
+                    }
+                    
+                    // Check cooldown period
+                    if (currentTime - lastPairingAttemptTime < pairingCooldownMs) {
+                        Log.d(tag, "Pairing cooldown active, ignoring auto-pair request")
+                        return START_NOT_STICKY
+                    }
+                    
+                    Log.i(tag, "Auto-pairing with PIN: $pin and port: $lastDiscoveredPort")
+                    lastPairingAttemptTime = currentTime
+                    isPairingInProgress = true
+                    onInput(pin, lastDiscoveredPort)
+                } else {
+                    Log.w(tag, "Auto-pair action called but PIN or port not available")
+                    onStart()
+                }
+            }
             stopAction -> {
                 stopForeground(STOP_FOREGROUND_REMOVE)
                 stopSelf()
@@ -121,13 +170,39 @@ class AdbPairingService : Service() {
     private fun startSearch() {
         if (started) return
         started = true
+        
+        // Register receiver for auto-detected pairing codes
+        if (pairingCodeReceiver == null) {
+            pairingCodeReceiver = PairingCodeReceiver()
+            val intentFilter = PairingCodeReceiver.createIntentFilter()
+            
+            // Use appropriate flags for Android 14+ (API 34+)
+            if (Build.VERSION.SDK_INT >= 34) {
+                registerReceiver(pairingCodeReceiver, intentFilter, Context.RECEIVER_NOT_EXPORTED)
+            } else {
+                registerReceiver(pairingCodeReceiver, intentFilter)
+            }
+        }
+        
         adbMdns = AdbMdns(this, AdbMdns.TLS_PAIRING, observer).apply { start() }
     }
 
     private fun stopSearch() {
         if (!started) return
         started = false
+        
+        // Unregister receiver
+        pairingCodeReceiver?.let { 
+            try {
+                unregisterReceiver(it)
+            } catch (e: Exception) {
+                Log.w(tag, "Failed to unregister pairing code receiver", e)
+            }
+            pairingCodeReceiver = null
+        }
+        
         adbMdns?.stop()
+        stopAdbPortDiscovery()
     }
 
     override fun onDestroy() {
@@ -171,12 +246,18 @@ class AdbPairingService : Service() {
 
         if (success) {
             Log.i(tag, "Pair succeed")
+            isPairingInProgress = false // Reset pairing state on success
 
-            title = getString(R.string.notification_adb_pairing_succeed_title)
-            text = getString(R.string.notification_adb_pairing_succeed_text)
+            title = "Pairing succeeded!"
+            text = "Trying to auto-start Shizuku now..."
 
             stopSearch()
+            
+            // Auto-start Shizuku after successful pairing with delay to ensure readiness
+            startShizukuDelayed()
         } else {
+            isPairingInProgress = false // Reset pairing state on failure
+            
             title = getString(R.string.notification_adb_pairing_failed_title)
 
             text = when (exception) {
@@ -308,12 +389,26 @@ class AdbPairingService : Service() {
     }
 
     private fun createInputNotification(port: Int): Notification {
-        return Notification.Builder(this, notificationChannel)
+        val isAccessibilityEnabled = AccessibilityUtils.isAccessibilityServiceEnabled(this)
+        
+        val title = if (isAccessibilityEnabled) {
+            "Pairing service found - Auto-pairing enabled"
+        } else {
+            getString(R.string.notification_adb_pairing_service_found_title)
+        }
+        
+        val builder = Notification.Builder(this, notificationChannel)
             .setColor(getColor(R.color.notification))
-            .setContentTitle(getString(R.string.notification_adb_pairing_service_found_title))
+            .setContentTitle(title)
             .setSmallIcon(R.drawable.ic_system_icon)
-            .addAction(replyNotificationAction(port))
-            .build()
+            
+        if (isAccessibilityEnabled) {
+            builder.setContentText("Trying to read PIN and connect to wireless debugging...")
+        } else {
+            builder.addAction(replyNotificationAction(port))
+        }
+        
+        return builder.build()
     }
 
     private val workingNotification by unsafeLazy {
@@ -322,6 +417,88 @@ class AdbPairingService : Service() {
             .setContentTitle(getString(R.string.notification_adb_pairing_working_title))
             .setSmallIcon(R.drawable.ic_system_icon)
             .build()
+    }
+
+    private fun startShizukuDelayed() {
+        try {
+            Log.i(tag, "Scheduling auto-start of Shizuku after successful pairing")
+            
+            // Start discovering ADB connection port
+            startAdbPortDiscovery()
+            
+            // Use a handler to delay the start by 2 seconds to ensure ADB is ready
+            android.os.Handler(android.os.Looper.getMainLooper()).postDelayed({
+                startShizuku()
+            }, 2000L) // 2 second delay (reduced from 5)
+        } catch (e: Exception) {
+            Log.w(tag, "Failed to schedule auto-start of Shizuku", e)
+        }
+    }
+    
+    private fun startAdbPortDiscovery() {
+        try {
+            Log.i(tag, "Starting ADB port discovery for auto-start")
+            adbConnectMdns = AdbMdns(this, AdbMdns.TLS_CONNECT, adbConnectObserver).apply { 
+                start() 
+            }
+        } catch (e: Exception) {
+            Log.w(tag, "Failed to start ADB port discovery", e)
+        }
+    }
+    
+    private fun stopAdbPortDiscovery() {
+        try {
+            adbConnectMdns?.stop()
+            adbConnectMdns = null
+        } catch (e: Exception) {
+            Log.w(tag, "Failed to stop ADB port discovery", e)
+        }
+    }
+
+    private fun startShizuku() {
+        try {
+            Log.i(tag, "Auto-starting Shizuku after successful pairing")
+            
+            // Stop ADB port discovery
+            stopAdbPortDiscovery()
+            
+            // Try discovered ADB port first, then fallback to system property
+            var adbPort = discoveredAdbPort
+            if (adbPort <= 0) {
+                adbPort = EnvironmentUtils.getAdbTcpPort()
+                Log.i(tag, "Using system ADB TCP port: $adbPort")
+            } else {
+                Log.i(tag, "Using discovered ADB port: $adbPort")
+            }
+            
+            if (adbPort <= 0) {
+                Log.w(tag, "ADB TCP port not available, cannot auto-start Shizuku")
+                return
+            }
+            
+            // Launch StarterActivity with ADB mode
+            val intent = Intent(this, StarterActivity::class.java).apply {
+                putExtra(StarterActivity.EXTRA_IS_ROOT, false)
+                putExtra(StarterActivity.EXTRA_HOST, "127.0.0.1")
+                putExtra(StarterActivity.EXTRA_PORT, adbPort)
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+            }
+            startActivity(intent)
+            
+            // Send broadcast to dismiss tutorial after a short delay to ensure tutorial is ready
+            android.os.Handler(android.os.Looper.getMainLooper()).postDelayed({
+                try {
+                    val notifyIntent = Intent("moe.shizuku.manager.SHIZUKU_AUTO_STARTED")
+                    sendBroadcast(notifyIntent)
+                    Log.i(tag, "Sent auto-start broadcast to dismiss tutorial (delayed)")
+                } catch (e: Exception) {
+                    Log.w(tag, "Failed to send delayed broadcast", e)
+                }
+            }, 1000L) // 1 second delay
+            
+        } catch (e: Exception) {
+            Log.w(tag, "Failed to auto-start Shizuku", e)
+        }
     }
 
     override fun onBind(intent: Intent?): IBinder? {

--- a/manager/src/main/java/moe/shizuku/manager/adb/AdbPairingTutorialActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/adb/AdbPairingTutorialActivity.kt
@@ -3,8 +3,7 @@ package moe.shizuku.manager.adb
 import android.app.AppOpsManager
 import android.app.ForegroundServiceStartNotAllowedException
 import android.app.NotificationManager
-import android.content.ActivityNotFoundException
-import android.content.Intent
+import android.content.*
 import android.os.Build
 import android.os.Bundle
 import android.provider.Settings
@@ -13,7 +12,10 @@ import android.widget.Toast
 import androidx.annotation.RequiresApi
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import moe.shizuku.manager.AppConstants
+import moe.shizuku.manager.R
+import moe.shizuku.manager.accessibility.AccessibilityUtils
 import moe.shizuku.manager.app.AppBarActivity
 import moe.shizuku.manager.databinding.AdbPairingTutorialActivityBinding
 import rikka.compatibility.DeviceCompatibility
@@ -24,6 +26,28 @@ class AdbPairingTutorialActivity : AppBarActivity() {
     private lateinit var binding: AdbPairingTutorialActivityBinding
 
     private var notificationEnabled: Boolean = false
+    private var accessibilityEnabled: Boolean = false
+    
+    private val shizukuAutoStartReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent?) {
+            Log.i("AdbPairingTutorial", "Broadcast received in tutorial: ${intent?.action}")
+            if (intent?.action == "moe.shizuku.manager.SHIZUKU_AUTO_STARTED") {
+                Log.i("AdbPairingTutorial", "Shizuku auto-started, finishing tutorial")
+                try {
+                    runOnUiThread {
+                        if (!isFinishing && !isDestroyed) {
+                            Log.i("AdbPairingTutorial", "Tutorial activity finishing normally")
+                            finish()
+                        } else {
+                            Log.w("AdbPairingTutorial", "Tutorial activity already finishing/destroyed")
+                        }
+                    }
+                } catch (e: Exception) {
+                    Log.e("AdbPairingTutorial", "Error finishing tutorial", e)
+                }
+            }
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -34,13 +58,24 @@ class AdbPairingTutorialActivity : AppBarActivity() {
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
 
         notificationEnabled = isNotificationEnabled()
+        accessibilityEnabled = AccessibilityUtils.isAccessibilityServiceEnabled(this)
 
         if (notificationEnabled) {
             startPairingService()
         }
+        
+        // Register receiver for Shizuku auto-start notifications
+        val filter = IntentFilter("moe.shizuku.manager.SHIZUKU_AUTO_STARTED")
+        if (Build.VERSION.SDK_INT >= 34) {
+            registerReceiver(shizukuAutoStartReceiver, filter, Context.RECEIVER_NOT_EXPORTED)
+        } else {
+            registerReceiver(shizukuAutoStartReceiver, filter)
+        }
+        Log.i("AdbPairingTutorial", "Auto-start receiver registered for tutorial auto-exit")
 
         binding.apply {
             syncNotificationEnabled()
+            syncAccessibilityEnabled()
 
             if (DeviceCompatibility.isMiui()) {
                 miui.isVisible = true
@@ -64,6 +99,10 @@ class AdbPairingTutorialActivity : AppBarActivity() {
                 } catch (e: ActivityNotFoundException) {
                 }
             }
+            
+            accessibilityOptions.setOnClickListener {
+                showAccessibilityPermissionDialog()
+            }
         }
     }
 
@@ -75,6 +114,13 @@ class AdbPairingTutorialActivity : AppBarActivity() {
             network.isVisible = notificationEnabled
             notification.isVisible = notificationEnabled
             notificationDisabled.isGone = notificationEnabled
+        }
+    }
+    
+    private fun syncAccessibilityEnabled() {
+        binding.apply {
+            accessibilityEnabled.isVisible = this@AdbPairingTutorialActivity.accessibilityEnabled
+            accessibilityDisabled.isGone = this@AdbPairingTutorialActivity.accessibilityEnabled
         }
     }
 
@@ -91,6 +137,8 @@ class AdbPairingTutorialActivity : AppBarActivity() {
         super.onResume()
 
         val newNotificationEnabled = isNotificationEnabled()
+        val newAccessibilityEnabled = AccessibilityUtils.isAccessibilityServiceEnabled(this)
+        
         if (newNotificationEnabled != notificationEnabled) {
             notificationEnabled = newNotificationEnabled
             syncNotificationEnabled()
@@ -98,6 +146,11 @@ class AdbPairingTutorialActivity : AppBarActivity() {
             if (newNotificationEnabled) {
                 startPairingService()
             }
+        }
+        
+        if (newAccessibilityEnabled != accessibilityEnabled) {
+            accessibilityEnabled = newAccessibilityEnabled
+            syncAccessibilityEnabled()
         }
     }
 
@@ -118,6 +171,26 @@ class AdbPairingTutorialActivity : AppBarActivity() {
                 }
                 startService(intent)
             }
+        }
+    }
+    
+    private fun showAccessibilityPermissionDialog() {
+        MaterialAlertDialogBuilder(this)
+            .setTitle(R.string.accessibility_permission_required_title)
+            .setMessage(R.string.accessibility_permission_required_message)
+            .setPositiveButton(R.string.accessibility_permission_button) { _, _ ->
+                AccessibilityUtils.openAppAccessibilitySettings(this)
+            }
+            .setNegativeButton(android.R.string.cancel, null)
+            .show()
+    }
+    
+    override fun onDestroy() {
+        super.onDestroy()
+        try {
+            unregisterReceiver(shizukuAutoStartReceiver)
+        } catch (e: Exception) {
+            Log.w("AdbPairingTutorial", "Failed to unregister receiver", e)
         }
     }
 }

--- a/manager/src/main/java/moe/shizuku/manager/home/HomeActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/home/HomeActivity.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.os.Process
 import android.text.method.LinkMovementMethod
+import android.util.Log
 import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.Menu
@@ -30,11 +31,13 @@ import rikka.shizuku.Shizuku
 abstract class HomeActivity : AppBarActivity() {
 
     private val binderReceivedListener = Shizuku.OnBinderReceivedListener {
+        Log.d("HomeActivity", "Binder received - refreshing status")
         checkServerStatus()
         appsModel.load()
     }
 
     private val binderDeadListener = Shizuku.OnBinderDeadListener {
+        Log.d("HomeActivity", "Binder dead - refreshing status")
         checkServerStatus()
     }
 
@@ -73,10 +76,12 @@ abstract class HomeActivity : AppBarActivity() {
 
     override fun onResume() {
         super.onResume()
+        Log.d("HomeActivity", "onResume - refreshing status")
         checkServerStatus()
     }
 
     private fun checkServerStatus() {
+        Log.d("HomeActivity", "checkServerStatus called - reloading model")
         homeModel.reload()
     }
 

--- a/manager/src/main/java/moe/shizuku/manager/home/HomeAdapter.kt
+++ b/manager/src/main/java/moe/shizuku/manager/home/HomeAdapter.kt
@@ -60,7 +60,7 @@ class HomeAdapter(private val homeModel: HomeViewModel, private val appsModel: A
             }
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R || EnvironmentUtils.getAdbTcpPort() > 0) {
-                addItem(StartWirelessAdbViewHolder.CREATOR, null, ID_START_WADB)
+                addItem(StartWirelessAdbViewHolder.CREATOR, status, ID_START_WADB)
             }
 
             addItem(StartAdbViewHolder.CREATOR, null, ID_START_ADB)

--- a/manager/src/main/java/moe/shizuku/manager/home/StartWirelessAdbViewHolder.kt
+++ b/manager/src/main/java/moe/shizuku/manager/home/StartWirelessAdbViewHolder.kt
@@ -5,9 +5,11 @@ import android.content.Intent
 import android.os.Build
 import android.os.SystemProperties
 import android.text.method.LinkMovementMethod
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.annotation.RequiresApi
 import androidx.core.view.isVisible
 import androidx.fragment.app.FragmentActivity
@@ -16,7 +18,9 @@ import moe.shizuku.manager.R
 import moe.shizuku.manager.adb.AdbPairingTutorialActivity
 import moe.shizuku.manager.databinding.HomeItemContainerBinding
 import moe.shizuku.manager.databinding.HomeStartWirelessAdbBinding
+import moe.shizuku.manager.home.WadbNotEnabledDialogFragment
 import moe.shizuku.manager.ktx.toHtml
+import moe.shizuku.manager.model.ServiceStatus
 import moe.shizuku.manager.starter.StarterActivity
 import moe.shizuku.manager.utils.CustomTabsHelper
 import moe.shizuku.manager.utils.EnvironmentUtils
@@ -26,11 +30,11 @@ import rikka.recyclerview.BaseViewHolder
 import rikka.recyclerview.BaseViewHolder.Creator
 import java.net.Inet4Address
 
-class StartWirelessAdbViewHolder(binding: HomeStartWirelessAdbBinding, root: View) :
-    BaseViewHolder<Any?>(root) {
+class StartWirelessAdbViewHolder(private val binding: HomeStartWirelessAdbBinding, root: View) :
+    BaseViewHolder<ServiceStatus?>(root) {
 
     companion object {
-        val CREATOR = Creator<Any> { inflater: LayoutInflater, parent: ViewGroup? ->
+        val CREATOR = Creator<ServiceStatus?> { inflater: LayoutInflater, parent: ViewGroup? ->
             val outer = HomeItemContainerBinding.inflate(inflater, parent, false)
             val inner = HomeStartWirelessAdbBinding.inflate(inflater, outer.root, true)
             StartWirelessAdbViewHolder(inner, outer.root)
@@ -62,9 +66,33 @@ class StartWirelessAdbViewHolder(binding: HomeStartWirelessAdbBinding, root: Vie
 
     override fun onBind(payloads: MutableList<Any>) {
         super.onBind(payloads)
+        
+        // Update button states based on Shizuku status
+        val isShizukuRunning = data?.isRunning == true
+        Log.d("StartWirelessAdb", "onBind called - isShizukuRunning: $isShizukuRunning, status: ${data}")
+        Log.d("StartWirelessAdb", "Button state before: enabled=${binding.button1.isEnabled}, alpha=${binding.button1.alpha}")
+        
+        // Disable start button if Shizuku is already running
+        binding.button1.isEnabled = !isShizukuRunning
+        binding.button1.alpha = if (isShizukuRunning) 0.5f else 1.0f
+        
+        Log.d("StartWirelessAdb", "Button state after: enabled=${binding.button1.isEnabled}, alpha=${binding.button1.alpha}")
+        
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            // Keep pairing button enabled even if Shizuku is running
+            // (user might want to pair for other purposes)
+            binding.button2.isEnabled = true
+            binding.button3.isEnabled = true
+        }
     }
 
     private fun onAdbClicked(context: Context) {
+        // Check if Shizuku is already running
+        if (data?.isRunning == true) {
+            Toast.makeText(context, R.string.home_status_service_is_running, Toast.LENGTH_SHORT).show()
+            return
+        }
+        
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             AdbDialogFragment().show(context.asActivity<FragmentActivity>().supportFragmentManager)
             return

--- a/manager/src/main/res/layout/accessibility_settings_activity.xml
+++ b/manager/src/main/res/layout/accessibility_settings_activity.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/settings_container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" />

--- a/manager/src/main/res/layout/adb_pairing_tutorial_activity.xml
+++ b/manager/src/main/res/layout/adb_pairing_tutorial_activity.xml
@@ -110,6 +110,93 @@
         </com.google.android.material.card.MaterialCardView>
 
         <com.google.android.material.card.MaterialCardView
+            android:id="@+id/accessibility_enabled"
+            style="@style/FilledCard"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp">
+
+            <ImageView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="-8dp"
+                android:layout_marginTop="4dp"
+                android:importantForAccessibility="no"
+                android:src="@drawable/ic_server_ok_24dp"
+                android:tint="?colorOnSecondaryContainer"
+                android:tintMode="src_in" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:layout_marginStart="36dp"
+                android:orientation="vertical">
+
+                <TextView
+                    style="@style/TerminalTutorialText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/accessibility_permission_granted"
+                    android:textAppearance="?textAppearanceBodyMedium"
+                    android:textColor="?colorOnSecondaryContainer" />
+
+            </LinearLayout>
+
+        </com.google.android.material.card.MaterialCardView>
+
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/accessibility_disabled"
+            style="@style/FilledCard"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            app:cardBackgroundColor="?colorSecondaryContainer">
+
+            <ImageView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="-8dp"
+                android:layout_marginTop="4dp"
+                android:importantForAccessibility="no"
+                android:src="@drawable/ic_outline_info_24"
+                android:tint="?colorOnSecondaryContainer"
+                android:tintMode="src_in" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:layout_marginStart="36dp"
+                android:orientation="vertical">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:lineSpacingExtra="2sp"
+                    android:text="@string/accessibility_permission_denied"
+                    android:textAppearance="?textAppearanceBodyMedium"
+                    android:textColor="?colorOnSecondaryContainer" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/accessibility_options"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:layout_marginBottom="-8dp"
+                    android:text="@string/accessibility_permission_button"
+                    android:textColor="?colorOnSecondary"
+                    app:backgroundTint="?colorSecondary"
+                    app:iconTint="?colorOnSecondary"
+                    app:iconTintMode="src_in"
+                    app:icon="@drawable/ic_outline_open_in_new_24"
+                    app:iconPadding="16dp" />
+
+            </LinearLayout>
+
+        </com.google.android.material.card.MaterialCardView>
+
+        <com.google.android.material.card.MaterialCardView
             android:id="@+id/network"
             style="@style/FilledCard"
             android:layout_width="match_parent"

--- a/manager/src/main/res/values/strings.xml
+++ b/manager/src/main/res/values/strings.xml
@@ -159,6 +159,17 @@ With %1$s, in any terminal app, you can connect to and interact with the shell r
     <string name="toast_copied_to_clipboard">%s\nhas been copied to clipboard.</string>
     <string name="toast_copied_to_clipboard_with_text"><![CDATA[<b>%s</b> has been copied to clipboard.]]></string>
 
+    <!-- Accessibility Service -->
+    <string name="accessibility_service_title">Auto-detect pairing code</string>
+    <string name="accessibility_service_description">Automatically detects the 6-digit pairing code from the system wireless debugging dialog and uses it for ADB pairing</string>
+    <string name="accessibility_service_setting_title">Enable automatic PIN detection</string>
+    <string name="accessibility_service_setting_description">Allow Shizuku to automatically detect and use pairing codes from the system wireless debugging dialog</string>
+    <string name="accessibility_permission_required_title">Accessibility Permission Required</string>
+    <string name="accessibility_permission_required_message">To automatically detect pairing codes, Shizuku needs accessibility permission. This allows Shizuku to read the 6-digit code from the system wireless debugging dialog.</string>
+    <string name="accessibility_permission_button">Grant Permission</string>
+    <string name="accessibility_permission_granted">Accessibility permission is granted</string>
+    <string name="accessibility_permission_denied">Accessibility permission is required for automatic pairing</string>
+
     <!-- Messages for legacy -->
     <string name="dialog_legacy_not_support_title">%1$s does not support modern Shizuku</string>
     <string name="dialog_legacy_not_support_message"><![CDATA[Legacy Shizuku has been deprecated since March 2019. Also, legacy Shizuku does not work on newer Android systems.<p>Please ask the developer of <b>%1$s</b> to update.]]></string>

--- a/manager/src/main/res/xml/accessibility_preferences.xml
+++ b/manager/src/main/res/xml/accessibility_preferences.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+    
+    <SwitchPreference
+        android:key="accessibility_enabled"
+        android:title="@string/accessibility_service_setting_title"
+        android:summary="@string/accessibility_service_setting_description"
+        android:defaultValue="false" />
+        
+</PreferenceScreen>

--- a/manager/src/main/res/xml/accessibility_service_config.xml
+++ b/manager/src/main/res/xml/accessibility_service_config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
+    android:accessibilityEventTypes="typeWindowContentChanged|typeWindowStateChanged"
+    android:accessibilityFeedbackType="feedbackGeneric"
+    android:accessibilityFlags="flagDefault|flagRetrieveInteractiveWindows"
+    android:canRetrieveWindowContent="true"
+    android:notificationTimeout="300"
+    android:description="@string/accessibility_service_description"
+    android:packageNames="com.android.systemui,com.android.settings"
+    android:settingsActivity="moe.shizuku.manager.accessibility.AccessibilitySettingsActivity" />


### PR DESCRIPTION
 - Read PIN from settings page
 - Auto start Shizuku
 
This change creates an accessibility service that helps to read the pin and enter it automatically for the ADB wireless debugging to connect. 

On my phone (Pixel 8a A16) when the notification pops to enter the PIN, the heads up notification closes immediately when I press a number & keyboard dismisses. Won't come back. And the heads up notification dies then keyboard doesn't work on notification panel as it's the topmost layer. I tried to fix that but it seemed like lot of extra steps anyway and I couldn't figure the fix out. 

So I implemented this instead. 