### PR TITLE
Add Start Shizuku menu option

### DIFF
--- a/manager/src/main/java/moe/shizuku/manager/home/AdbDialogFragment.kt
+++ b/manager/src/main/java/moe/shizuku/manager/home/AdbDialogFragment.kt
@@ -82,9 +82,14 @@ class AdbDialogFragment : DialogFragment() {
             startAndDismiss(EnvironmentUtils.getAdbTcpPort())
         }
 
-        port.observe(this) {
-            if (it > 65535 || it < 1) return@observe
-            startAndDismiss(it)
+        val packageManager = context.packageManager
+        val isTelevision = packageManager.hasSystemFeature(PackageManager.FEATURE_LEANBACK)
+
+        if (!isTelevision) {
+            port.observe(this) {
+                if (it > 65535 || it < 1) return@observe
+                startAndDismiss(it)
+            }
         }
     }
 

--- a/manager/src/main/java/moe/shizuku/manager/home/AdbDialogFragment.kt
+++ b/manager/src/main/java/moe/shizuku/manager/home/AdbDialogFragment.kt
@@ -1,6 +1,7 @@
 package moe.shizuku.manager.home
 
 import android.Manifest.permission.WRITE_SECURE_SETTINGS
+import android.app.ActivityThread
 import android.app.Dialog
 import android.content.ActivityNotFoundException
 import android.content.DialogInterface
@@ -82,10 +83,7 @@ class AdbDialogFragment : DialogFragment() {
             startAndDismiss(EnvironmentUtils.getAdbTcpPort())
         }
 
-        val packageManager = context.packageManager
-        val isTelevision = packageManager.hasSystemFeature(PackageManager.FEATURE_LEANBACK)
-
-        if (!isTelevision) {
+        if (!(EnvironmentUtils.isTelevision(ActivityThread.currentActivityThread().application))) {
             port.observe(this) {
                 if (it > 65535 || it < 1) return@observe
                 startAndDismiss(it)

--- a/manager/src/main/java/moe/shizuku/manager/home/AdbDialogFragment.kt
+++ b/manager/src/main/java/moe/shizuku/manager/home/AdbDialogFragment.kt
@@ -83,10 +83,19 @@ class AdbDialogFragment : DialogFragment() {
             startAndDismiss(EnvironmentUtils.getAdbTcpPort())
         }
 
-        if (!(EnvironmentUtils.isTelevision(ActivityThread.currentActivityThread().application))) {
+        if (!(EnvironmentUtils.isTelevision(ActivityThread.currentActivityThread().application))){
             port.observe(this) {
                 if (it > 65535 || it < 1) return@observe
                 startAndDismiss(it)
+            }
+        }
+
+        if (EnvironmentUtils.isTelevision(ActivityThread.currentActivityThread().application)) {
+            if (EnvironmentUtils.getAdbTcpPort() != 5555) {
+                port.observe(this) {
+                    if (it > 65535 || it < 1) return@observe
+                    startAndDismiss(it)
+                }
             }
         }
     }

--- a/manager/src/main/java/moe/shizuku/manager/home/HomeActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/home/HomeActivity.kt
@@ -14,6 +14,7 @@ import androidx.fragment.app.FragmentActivity
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import moe.shizuku.manager.R
 import moe.shizuku.manager.ShizukuSettings
+import moe.shizuku.manager.adb.AdbPairingTutorialActivity
 import moe.shizuku.manager.app.AppBarActivity
 import moe.shizuku.manager.databinding.AboutDialogBinding
 import moe.shizuku.manager.databinding.HomeActivityBinding
@@ -154,6 +155,19 @@ abstract class HomeActivity : AppBarActivity() {
                     }
                     .setNegativeButton(android.R.string.cancel, null)
                     .show()
+                true
+            }
+            R.id.action_pair -> {
+                val context = this
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && (context.display?.displayId ?: -1) > 0) {
+                    // Running in a multi-display environment (e.g., Windows Subsystem for Android),
+                    // pairing dialog can be displayed simultaneously with Shizuku.
+                    // Input from notification is harder to use under this situation.
+                    AdbPairDialogFragment().show(context.asActivity<FragmentActivity>().supportFragmentManager)
+                } else {
+                    context.startActivity(Intent(context, AdbPairingTutorialActivity::class.java))
+                }
+
                 true
             }
             R.id.action_settings -> {

--- a/manager/src/main/java/moe/shizuku/manager/home/HomeActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/home/HomeActivity.kt
@@ -2,6 +2,7 @@ package moe.shizuku.manager.home
 
 import android.content.DialogInterface
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
 import android.os.Process
 import android.text.method.LinkMovementMethod
@@ -9,6 +10,7 @@ import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.Menu
 import android.view.MenuItem
+import androidx.fragment.app.FragmentActivity
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import moe.shizuku.manager.R
 import moe.shizuku.manager.ShizukuSettings
@@ -18,7 +20,10 @@ import moe.shizuku.manager.databinding.HomeActivityBinding
 import moe.shizuku.manager.ktx.toHtml
 import moe.shizuku.manager.management.appsViewModel
 import moe.shizuku.manager.settings.SettingsActivity
+import moe.shizuku.manager.starter.StarterActivity
 import moe.shizuku.manager.utils.AppIconCache
+import moe.shizuku.manager.utils.EnvironmentUtils
+import rikka.core.content.asActivity
 import rikka.core.ktx.unsafeLazy
 import rikka.lifecycle.Status
 import rikka.lifecycle.viewModels
@@ -112,6 +117,27 @@ abstract class HomeActivity : AppBarActivity() {
                 MaterialAlertDialogBuilder(this)
                     .setView(binding.root)
                     .show()
+                true
+            }
+            R.id.action_start -> {
+                val context = this
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                    AdbDialogFragment().show(context.asActivity<FragmentActivity>().supportFragmentManager)
+                    return true
+                }
+
+                val port = EnvironmentUtils.getAdbTcpPort()
+                if (port > 0) {
+                    val host = "127.0.0.1"
+                    val intent = Intent(context, StarterActivity::class.java).apply {
+                        putExtra(StarterActivity.EXTRA_IS_ROOT, false)
+                        putExtra(StarterActivity.EXTRA_HOST, host)
+                        putExtra(StarterActivity.EXTRA_PORT, port)
+                    }
+                    context.startActivity(intent)
+                } else {
+                    WadbNotEnabledDialogFragment().show(context.asActivity<FragmentActivity>().supportFragmentManager)
+                }
                 true
             }
             R.id.action_stop -> {

--- a/manager/src/main/java/moe/shizuku/manager/utils/EnvironmentUtils.kt
+++ b/manager/src/main/java/moe/shizuku/manager/utils/EnvironmentUtils.kt
@@ -2,6 +2,7 @@ package moe.shizuku.manager.utils
 
 import android.app.UiModeManager
 import android.content.Context
+import android.content.pm.PackageManager
 import android.content.res.Configuration
 import android.os.SystemProperties
 import java.io.File
@@ -12,6 +13,11 @@ object EnvironmentUtils {
     fun isWatch(context: Context): Boolean {
         return (context.getSystemService(UiModeManager::class.java).currentModeType
                 == Configuration.UI_MODE_TYPE_WATCH)
+    }
+
+    fun isTelevision(context: Context): Boolean {
+        val packageManager = context.packageManager
+        return packageManager.hasSystemFeature(PackageManager.FEATURE_LEANBACK)
     }
 
     fun isRooted(): Boolean {

--- a/manager/src/main/res/menu/main.xml
+++ b/manager/src/main/res/menu/main.xml
@@ -19,6 +19,11 @@
         android:showAsAction="never"/>
 
     <item
+        android:id="@+id/action_pair"
+        android:title="@string/action_pair"
+        android:showAsAction="never"/>
+
+    <item
         android:id="@+id/action_about"
         android:title="@string/action_about"
         android:showAsAction="never"/>

--- a/manager/src/main/res/menu/main.xml
+++ b/manager/src/main/res/menu/main.xml
@@ -8,6 +8,12 @@
         android:showAsAction="ifRoom"/>
 
     <item
+        android:id="@+id/action_start"
+        android:title="@string/action_start"
+        android:showAsAction="never"/>
+
+
+    <item
         android:id="@+id/action_stop"
         android:title="@string/action_stop"
         android:showAsAction="never"/>

--- a/manager/src/main/res/values/strings.xml
+++ b/manager/src/main/res/values/strings.xml
@@ -126,6 +126,9 @@ With %1$s, in any terminal app, you can connect to and interact with the shell r
     <string name="action_stop">Stop Shizuku</string>
     <string name="dialog_stop_message">Shizuku service will be stopped.</string>
 
+    <!-- Pair -->
+    <string name="action_pair">Pair WADB</string>
+
     <!-- Notification -->
     <string name="notification_channel_service_status">Service start status</string>
     <string name="notification_service_starting">Shizuku service is starting…</string>

--- a/manager/src/main/res/values/strings.xml
+++ b/manager/src/main/res/values/strings.xml
@@ -119,6 +119,9 @@ With %1$s, in any terminal app, you can connect to and interact with the shell r
     <string name="action_about">About</string>
     <string name="about_view_source_code"><![CDATA[View source code at %s]]></string>
 
+    <!-- Start -->
+    <string name="action_start">Start Shizuku</string>
+
     <!-- Stop -->
     <string name="action_stop">Stop Shizuku</string>
     <string name="dialog_stop_message">Shizuku service will be stopped.</string>


### PR DESCRIPTION
Added a Start Shizuku option to the three dot menu for the ability to start Shizuku with just a remote on Android TV devices. Addresses issues #255 & #368. Tested on my Shield TV and confirmed working on my end after sideloading the apk.

I wasn't sure what would be the best way to launch the start activity so I just copied the onAdbClicked() function from StartWirelessAdbViewHolder.kt. It seems to work fine, but please let me know if there's a proper alternative.