### PR TITLE
fix: add isInMultiWindowMode to improve multi-window detection

### DIFF
--- a/manager/src/main/java/moe/shizuku/manager/home/StartWirelessAdbViewHolder.kt
+++ b/manager/src/main/java/moe/shizuku/manager/home/StartWirelessAdbViewHolder.kt
@@ -86,7 +86,7 @@ class StartWirelessAdbViewHolder(binding: HomeStartWirelessAdbBinding, root: Vie
 
     @RequiresApi(Build.VERSION_CODES.R)
     private fun onPairClicked(context: Context) {
-        if ((context.display?.displayId ?: -1) > 0) {
+        if ((context.display?.displayId ?: -1) > 0 || context.asActivity<FragmentActivity>()?.isInMultiWindowMode == true) {
             // Running in a multi-display environment (e.g., Windows Subsystem for Android),
             // pairing dialog can be displayed simultaneously with Shizuku.
             // Input from notification is harder to use under this situation.


### PR DESCRIPTION
Some devices do not create a new DisplayId in freeform/split-screen mode, so add the `Activity#isInMultiWindowMode` check to ensure correct recognition in multi-window scenarios.
部分机型小窗/分屏不会创建新的 DisplayId，因此增加` Activity#isInMultiWindowMode` 判断，确保多窗口场景能正确识别