### PR TITLE
feat: add Literary Chinese (文言) + LOLCAT + Chinese LOLCAT translations

### DIFF
--- a/manager/src/main/res/values-en-rLC/strings.xml
+++ b/manager/src/main/res/values-en-rLC/strings.xml
@@ -1,0 +1,173 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <string name="app_name">Shizuku</string>
+
+    <!-- 主页 · 状态 -->
+    <string name="home_status_service_is_running">%1$s iz runnin 4 u!!1!</string>
+    <string name="home_status_service_not_running">%1$s iz NOT runnin :C</string>
+    <string name="home_status_service_version">Vershun %2$s, %1$s</string>
+    <string name="home_status_service_version_update"><![CDATA[Vershun %2$s, %1$s.<br>Restart 4 update 2 %3$s kthx]]></string>
+
+    <!-- 主页 · ADB 启动 -->
+    <string name="home_adb_title">Connect compewter 2 start!!</string>
+    <string name="home_adb_description">Ur fone iz not root, u need ADB 2 start %1$s. Every tiem u restart u gotta do dis agen lol.</string>
+    <string name="home_adb_button_view_help">See halp</string>
+    <string name="home_adb_button_view_help">See halp</string>
+    <string name="home_adb_button_view_command">See commandz</string>
+    <string name="home_adb_dialog_view_command_message"><![CDATA[Run dis command on ur compewter terminl:<br><br><font face="monospace">%1$s</font><br><br>* sum notes:<br>…]]></string>
+    <string name="home_adb_dialog_view_command_copy_button">COPPY</string>
+    <string name="home_adb_dialog_view_command_button_send">SEND IT</string>
+
+    <!-- 主页 · 无线调试 -->
+    <string name="home_wireless_adb_title">Wireless debug start!!</string>
+    <string name="home_wireless_adb_description">Android 11+ can start %1$s wif wireless debug, no compewter needed!! iz amazin :O</string>
+    <string name="home_wireless_adb_description_pre_11">B4 Android 11 u need compewter 2 start wireless debug. dat sux :C</string>
+    <string name="home_wireless_adb_view_guide_button">Step by step halp</string>
+
+    <!-- 无线调试对话框 -->
+    <string name="dialog_adb_discovery">Searchin 4 wireless debug service… iz finding it</string>
+    <string name="dialog_adb_discovery_message">Plz enable "Wireless debug" in "Devloper optionz". If it no find, try turn off n on agen.</string>
+    <string name="dialog_adb_port">Port</string>
+    <string name="dialog_adb_invalid_port">Port must be numbr between 1 n 65535. no put random stuff plz.</string>
+
+    <!-- 配对 -->
+    <string name="adb_pairing">Pairin</string>
+    <string name="dialog_adb_pairing_title">Pair wif device</string>
+    <string name="dialog_adb_pairing_discovery">Searchin 4 pairin service…</string>
+    <string name="dialog_adb_pairing_paring_code">Pairin code</string>
+    <string name="paring_code_is_wrong">Pairin code iz WRONG. y u do dis :C</string>
+    <string name="dialog_adb_pairing_cannot_connect">Cant connect 2 wireless debug service. oh noes!!</string>
+    <string name="dialog_adb_pairing_not_started">Wireless debug iz not startd. Note: b4 Android 11 u need compewter first.</string>
+    <string name="dialog_adb_pairing_message">Do dis 4 pairin: "Devloper optionz" → "Wireless debug" → "Pair device wif pairin code".</string>
+    <string name="dialog_adb_pairing_split_screen">Plz go 2 split screen mode first kthx.</string>
+    <string name="dialog_adb_pairing_split_screen_message">System wantz pairin dialog 2 stay visible, so u need split screen. sry :C</string>
+    <string name="dialog_adb_pairing_key_store_error">Cant make wireless debug key. sumthin iz wrong wif keystore.</string>
+    <string name="dialog_adb_pairing_start_first">Do pairin steps first!! no skip plz.</string>
+
+    <!-- 配对通知 -->
+    <string name="notification_adb_pairing_title">Pairin</string>
+    <string name="notification_adb_pairing_channel_name">Wireless debug pairin</string>
+    <string name="notification_adb_pairing_message">%1$s notificashun will halp u pair :3</string>
+    <string name="notification_adb_pairing_step_1">Go "Devloper optionz" → "Wireless debug", tap "Pair device wif pairin code".</string>
+    <string name="notification_adb_pairing_step_2">Put pairin code in notificashun 2 finish pairin. dont 4get!!</string>
+    <string name="notification_adb_pairing_warning">Pairin needz u 2 interakt wif %1$s notificashun. DONT hide it or u fail!!1!</string>
+    <string name="notification_adb_pairing_miui_warning">MIUI userz may need 2 switch notificashun style from "Notificashun bar" 2 "Android".</string>
+    <string name="notification_adb_pairing_miui_warning_2">Or u cant put pairin code in notificashun. den u sad :C</string>
+    <string name="notification_adb_pairing_step_3">PS: "Wireless debug" iz a button on da left!! tap it 2 enable wireless debug.</string>
+    <string name="notification_adb_pairing_step_4">Go bak 2 %1$s 2 start it :3</string>
+    <string name="notification_adb_pairing_network">%1$s needz 2 access local network. dat iz network permishun stuff.</string>
+    <string name="notification_adb_pairing_network_miui_note">Sum systemz (lyk MIUI) block apps from network when not in foreground. dat iz annoyin :C</string>
+
+    <!-- 根启动 -->
+    <string name="home_root_title">Root user</string>
+    <string name="home_root_description">%1$s can start at boot. If it no start automaticaly, plz start it manualy. no blame us lol.</string>
+    <string name="home_root_description_sui">If u use Magisk, try %1$s. iz way bettr 4 root userz :3</string>
+    <string name="home_root_start_button">START IT</string>
+    <string name="home_root_restart_button">RESTART</string>
+
+    <!-- 应用管理 -->
+    <string name="home_apps_title">App managz</string>
+    <string name="home_apps_description">Tap 2 see all apps dat haz permishun. iz all dere!!</string>
+    <string name="home_apps_manage_button">Managz dem</string>
+    <string name="home_apps_dialog_message">Appz dat asked 4 or declared %1$s will show up here :3</string>
+
+    <!-- 了解更多 -->
+    <string name="home_about_title">Learn moar</string>
+    <string name="home_about_description">Know %1$s.</string>
+    <string name="home_about_learn_button">Learn 2 dev wif %1$s</string>
+
+    <!-- ADB 权限受限 -->
+    <string name="home_adb_permission_title">U need 2 do 1 moar step.</string>
+    <string name="home_adb_permission_description">Ur device maker haz limited ADB permishun. Appz using %1$s will haz less stuff. sry :C</string>
+    <string name="home_adb_permission_limited">ADB permishun limited</string>
+    <string name="home_adb_permission_limited_description">Ur device maker most likely limited ADB permishun, so appz using %1$s dont werk fully. Dis cant be bypassd. it iz wat it iz :C</string>
+    <string name="home_adb_permission_limited_note">* Need %1$s 2 run wif root permishun.</string>
+
+    <!-- 终端应用 -->
+    <string name="home_terminal_title">Terminal</string>
+    <string name="home_terminal_description">Use %1$s in terminal app :3</string>
+    <string name="home_terminal_description_long">Use %1$s in ur favrit terminal app 2 run commandz. iz fun!!</string>
+    <string name="home_terminal_step_1_title">Step 1: Export</string>
+    <string name="home_terminal_step_1_message">First, export file 2 anywher. u will get 2 filez: %1$s n %2$s.</string>
+    <string name="home_terminal_step_1_message_warning">If da folder alredy haz same name file, it will be OVERWRITTEN. careful!!</string>
+    <string name="home_terminal_step_1_button">Export filez</string>
+    <string name="home_terminal_step_2_title">Step 2: Edit</string>
+    <string name="home_terminal_step_2_message">Den open wif text editor n edit %1$s.</string>
+    <string name="home_terminal_step_2_message_example">4 eg: if u want 2 use %2$s in %1$s, replace %3$s wif %4$s.</string>
+    <string name="home_terminal_step_3_title">Step 3: Use</string>
+    <string name="home_terminal_step_3_message">Last, move file 2 wer terminal app can reach, den u can use %1$s!! hooray!!</string>
+    <string name="home_terminal_step_3_message_tip">Pro tip: give %1$s exec permishun n put it in %2$s, den u can use it anywher :3</string>
+    <string name="home_terminal_message">Wif %1$s, in any terminal app, u can connect 2 %2$s service n talk 2 it :3</string>
+
+    <!-- 设置 -->
+    <string name="settings">Settinzz</string>
+    <string name="settings_language">Langwij</string>
+    <string name="settings_dark_theme">Appearinz</string>
+    <string name="settings_black_dark_theme">Pure black nite mode</string>
+    <string name="settings_black_dark_theme_description">If nite mode iz on, use pure black. iz good 4 ur eyez :3</string>
+    <string name="settings_start">Start</string>
+    <string name="settings_translation_title">Translatz</string>
+    <string name="settings_translation_contributors">Translatin hoomanz</string>
+    <string name="settings_translation_contribute">Halp us translat %s 2 ur langwij!! u will be hero :3</string>
+    <string name="settings_start_on_boot">Start at boot (root)</string>
+    <string name="settings_start_on_boot_description">On rootd fone, %1$s can start automaticaly at boot. iz convenint!!</string>
+    <string name="settings_use_system_color">Use system color</string>
+    <string name="settings_about">About</string>
+    <string name="settings_about_source_code">See source code at %s :3</string>
+    <string name="settings_stop">Stop %1$s</string>
+    <string name="settings_stop_description">%1$s service will stop. r u sure?? :O</string>
+
+    <!-- 通知 -->
+    <string name="notification_service_start_status">Service start/stop</string>
+    <string name="notification_service_start_status_channel">Service start/stop</string>
+    <string name="notification_service_starting">%1$s service startin… hold on!!</string>
+    <string name="notification_service_start_failed">%1$s service start FAILED!! oh noes :C</string>
+    <string name="notification_service_start_failed_root">Root permishun faild. dis iz bad day :C</string>
+    <string name="notification_service_running">Runnin!! u can relax now :3</string>
+
+    <!-- 无线调试配对通知 -->
+    <string name="notification_adb_pairing_action_input_code">Put pairin code</string>
+    <string name="notification_adb_pairing_action_discovery">Searchin 4 pairin service</string>
+    <string name="notification_adb_pairing_action_discovery_done">FOUND pairin service!! :D</string>
+    <string name="notification_adb_pairing_action_discovery_stop">Stop searchin</string>
+    <string name="notification_adb_pairing_action_pairing">Pairin in progress…</string>
+    <string name="notification_adb_pairing_action_pairing_success">PAIRIN SUCCES!! now u can start %1$s service :D</string>
+    <string name="notification_adb_pairing_action_pairing_failed">PAIRIN FAILD!! :C</string>
+    <string name="notification_adb_pairing_action_retry">Try agen</string>
+
+    <!-- 权限 -->
+    <string name="permission_label">%1$s</string>
+    <string name="permission_description">Let app use %1$s :3</string>
+    <string name="permission_group_label">%1$s</string>
+    <string name="permission_group_description">@string/permission_label</string>
+    <string name="permission_template">Let **%1$s** %2$s?? :O</string>
+    <string name="permission_dialog_always_allow">Alwayz allow</string>
+    <string name="permission_dialog_deny">NO!! deny!!</string>
+
+    <!-- 启动器 -->
+    <string name="launcher">%1$s</string>
+    <string name="launcher_start_root_shell">Startin root Shell…</string>
+    <string name="launcher_start_root_shell_failed">No root permishun or dis fone iz not rootd. cant start service. WAI :C</string>
+
+    <!-- 对话框 -->
+    <string name="dialog_cannot_start_browser">Cant start browser. oh noes!!</string>
+    <string name="dialog_copied_to_clipboard">COPPIED 2 clipbord: %s</string>
+    <string name="dialog_copied_to_clipboard_with_text">**%s** iz now in clipbord!! paste it anywher :3</string>
+
+    <!-- 旧版不兼容 -->
+    <string name="old_shizuku_not_support">%1$s no support da new %2$s.</string>
+    <string name="old_shizuku_not_support_description">Old %1$s iz ded since March 2019. n it iz not compatibl wif new %1$s. RIP :C</string>
+    <string name="old_shizuku">%1$s iz askin 4 old %2$s.</string>
+    <string name="old_shizuku_description">**%1$s** supportz da new %2$s, but it iz askin 4 old %2$s. probly cuz it haznt been upd8d. tell dem lol.</string>
+    <string name="old_shizuku_open_shizuku">Open %1$s</string>
+
+    <!-- 额外键 -->
+    <string name="home_wireless_adb">Wireless debug</string>
+    <string name="home_root">Root</string>
+    <string name="home_adb">ADB</string>
+
+    <!-- 翻译贡献者 -->
+    <string name="translation_contributors"></string>
+
+</resources>

--- a/manager/src/main/res/values-lzh/strings.xml
+++ b/manager/src/main/res/values-lzh/strings.xml
@@ -4,71 +4,71 @@
     <string name="app_name">Shizuku</string>
 
     <!-- 主页 · 状态 -->
-    <string name="home_status_service_is_running">%1$s 方效力</string>
-    <string name="home_status_service_not_running">%1$s 未运行</string>
-    <string name="home_status_service_version">版本 %2$s，%1$s</string>
-    <string name="home_status_service_version_update"><![CDATA[版本 %2$s，%1$s。<br>重启以更新至 %3$s。]]></string>
+    <string name="home_status_service_is_running">%1$s 正效力于君</string>
+    <string name="home_status_service_not_running">%1$s 未效力也</string>
+    <string name="home_status_service_version">版 %2$s，%1$s</string>
+    <string name="home_status_service_version_update"><![CDATA[版 %2$s，%1$s。<br>启而新之，可至 %3$s。]]></string>
 
     <!-- 主页 · ADB 启动 -->
     <string name="home_adb_title">连机以启</string>
-    <string name="home_adb_description">无根之机，须借 ADB 以启 %1$s。每次重启，皆须复行此法。</string>
+    <string name="home_adb_description">君之机无根，须借 ADB 以启 %1$s。每重启，皆须复行此仪。</string>
     <string name="home_adb_button_view_help">览助</string>
     <string name="home_adb_button_view_command">览令</string>
-    <string name="home_adb_dialog_view_command_message"><![CDATA[于电脑之终端行此令：<br><br><font face="monospace">%1$s</font><br><br>* 备注数事：<br>…]]></string>
+    <string name="home_adb_dialog_view_command_message"><![CDATA[于电脑终端行此令：<br><br><font face="monospace">%1$s</font><br><br>* 备注数事：<br>…]]></string>
     <string name="home_adb_dialog_view_command_copy_button">抄录</string>
-    <string name="home_adb_dialog_view_command_button_send">发送</string>
+    <string name="home_adb_dialog_view_command_button_send">飞鸽传书</string>
 
     <!-- 主页 · 无线调试 -->
     <string name="home_wireless_adb_title">无线调试以启</string>
-    <string name="home_wireless_adb_description">Android 11 及以上，可启无线调试以启 %1$s，无须连电脑。</string>
-    <string name="home_wireless_adb_description_pre_11">Android 11 之前，须先连电脑以启无线调试。</string>
+    <string name="home_wireless_adb_description">Android 11 及以上，可启无线调试以启 %1$s，无须连电脑，妙哉。</string>
+    <string name="home_wireless_adb_description_pre_11">Android 11 之前，须先连电脑以启无线调试，实乃憾事。</string>
     <string name="home_wireless_adb_view_guide_button">循序导引</string>
 
     <!-- 无线调试对话框 -->
-    <string name="dialog_adb_discovery">搜索无线调试服务中…</string>
-    <string name="dialog_adb_discovery_message">请于「开发者选项」中启用「无线调试」。若久搜不得，试先禁再启。</string>
+    <string name="dialog_adb_discovery">搜索无线调试之服，稍候…</string>
+    <string name="dialog_adb_discovery_message">请于「开发者选项」中启「无线调试」。若久搜不得，试禁而复启。</string>
     <string name="dialog_adb_port">端口</string>
-    <string name="dialog_adb_invalid_port">端口须为一至六万五千五百三十五间之整数。</string>
+    <string name="dialog_adb_invalid_port">端口须为一至六万五千五百三十五间之整数，勿乱填。</string>
 
     <!-- 配对 -->
     <string name="adb_pairing">配对</string>
     <string name="dialog_adb_pairing_title">与设备配对</string>
-    <string name="dialog_adb_pairing_discovery">搜索配对服务中…</string>
+    <string name="dialog_adb_pairing_discovery">搜索配对之服…</string>
     <string name="dialog_adb_pairing_paring_code">配对码</string>
-    <string name="paring_code_is_wrong">配对码有误。</string>
-    <string name="dialog_adb_pairing_cannot_connect">无法连至无线调试服务。</string>
+    <string name="paring_code_is_wrong">配对码有误，勿戏之。</string>
+    <string name="dialog_adb_pairing_cannot_connect">无法连至无线调试之服，奈何。</string>
     <string name="dialog_adb_pairing_not_started">无线调试未启。注：Android 11 之前，须先连电脑以启无线调试。</string>
     <string name="dialog_adb_pairing_message">请循此步启配对：「开发者选项」→「无线调试」→「使用配对码配对设备」。</string>
-    <string name="dialog_adb_pairing_split_screen">请先进入分屏（多窗口）模式。</string>
-    <string name="dialog_adb_pairing_split_screen_message">系统要求配对对话框常显，故须用分屏模式。</string>
-    <string name="dialog_adb_pairing_key_store_error">无法生无线调试密钥。此或因密钥库之制有异。</string>
-    <string name="dialog_adb_pairing_start_first">请先成配对之步。</string>
+    <string name="dialog_adb_pairing_split_screen">请先进入分屏之式。</string>
+    <string name="dialog_adb_pairing_split_screen_message">系统要求配对之框常显，故须用分屏之式，此乃不得已也。</string>
+    <string name="dialog_adb_pairing_key_store_error">无法生无线调试之钥。此或因密钥库之制有异。</string>
+    <string name="dialog_adb_pairing_start_first">请先成配对之步，急不得。</string>
 
     <!-- 配对通知 -->
     <string name="notification_adb_pairing_title">配对</string>
     <string name="notification_adb_pairing_channel_name">无线调试配对</string>
-    <string name="notification_adb_pairing_message">%1$s 之通知将助您成配对。</string>
+    <string name="notification_adb_pairing_message">%1$s 之通知将助君成配对。</string>
     <string name="notification_adb_pairing_step_1">入「开发者选项」→「无线调试」，点按「使用配对码配对设备」。</string>
-    <string name="notification_adb_pairing_step_2">于通知中入配对码以成配对。</string>
-    <string name="notification_adb_pairing_warning">配对之程须与 %1$s 通知交互。请勿蔽此通知。</string>
-    <string name="notification_adb_pairing_miui_warning">MIUI 用户或须将通知之式由「通知栏」切换为「Android」。</string>
-    <string name="notification_adb_pairing_miui_warning_2">否则，或无法于通知中入配对码。</string>
-    <string name="notification_adb_pairing_step_3">请留意，「无线调试」选项左侧可点，点之可启无线调试。</string>
+    <string name="notification_adb_pairing_step_2">于通知中入配对码以成配对，勿忘。</string>
+    <string name="notification_adb_pairing_warning">配对之程须与 %1$s 通知交互。切勿蔽此通知，否则功亏一篑。</string>
+    <string name="notification_adb_pairing_miui_warning">MIUI 之用户或须将通知之式由「通知栏」切换为「Android」。</string>
+    <string name="notification_adb_pairing_miui_warning_2">否则，恐无法于通知中入配对码，届时悔之晚矣。</string>
+    <string name="notification_adb_pairing_step_3">留意，「无线调试」选项左侧可点，点之可启无线调试。</string>
     <string name="notification_adb_pairing_step_4">归 %1$s 以启之。</string>
-    <string name="notification_adb_pairing_network">%1$s 须访问局域网络。此由网络权限所辖。</string>
-    <string name="notification_adb_pairing_network_miui_note">某些系统（如 MIUI）禁应用于非前台时访问网络。</string>
+    <string name="notification_adb_pairing_network">%1$s 须访问局域网络，此乃网络权限所辖。</string>
+    <string name="notification_adb_pairing_network_miui_note">某些系统（如 MIUI）禁应用于非前台时访问网络，甚不便也。</string>
 
     <!-- 根启动 -->
     <string name="home_root_title">根用户</string>
-    <string name="home_root_description">%1$s 可于开机时自启。若未自启，请手动启之。</string>
-    <string name="home_root_description_sui">若用 Magisk，可试 %1$s。于根用户，此更便捷。</string>
-    <string name="home_root_start_button">启动</string>
-    <string name="home_root_restart_button">重启</string>
+    <string name="home_root_description">%1$s 可于开机时自启。若未自启，请手动启之，勿怨。</string>
+    <string name="home_root_description_sui">若用 Magisk，可试 %1$s。于根用户，此更为便捷。</string>
+    <string name="home_root_start_button">启</string>
+    <string name="home_root_restart_button">复启</string>
 
     <!-- 应用管理 -->
     <string name="home_apps_title">应用管理</string>
-    <string name="home_apps_description">点按以管已授权之应用。</string>
-    <string name="home_apps_manage_button">管理</string>
+    <string name="home_apps_description">点按以管已授权之应用，一览无余。</string>
+    <string name="home_apps_manage_button">管之</string>
     <string name="home_apps_dialog_message">已请求或声明 %1$s 之应用将显于此处。</string>
 
     <!-- 了解更多 -->
@@ -77,88 +77,88 @@
     <string name="home_about_learn_button">学以 %1$s 开发</string>
 
     <!-- ADB 权限受限 -->
-    <string name="home_adb_permission_title">您须多行一步。</string>
-    <string name="home_adb_permission_description">您之设备制造商已限 ADB 权限，用 %1$s 之应用将受限。</string>
+    <string name="home_adb_permission_title">尚须多行一步。</string>
+    <string name="home_adb_permission_description">君之设备制造商已限 ADB 权限，用 %1$s 之应用将受限，恕无可奈何。</string>
     <string name="home_adb_permission_limited">ADB 权限受限</string>
-    <string name="home_adb_permission_limited_description">您之设备制造商极可能已限 ADB 权限，致用 %1$s 之应用功能不全。此限或不可绕。</string>
-    <string name="home_adb_permission_limited_note">* 须 %1$s 以根权限运行。</string>
+    <string name="home_adb_permission_limited_description">君之设备制造商极可能已限 ADB 权限，致用 %1$s 之应用功能不全。此限或不可绕，命也。</string>
+    <string name="home_adb_permission_limited_note">* 须 %1$s 以根权限运行方可。</string>
 
     <!-- 终端应用 -->
     <string name="home_terminal_title">终端</string>
     <string name="home_terminal_description">于终端应用中用 %1$s。</string>
-    <string name="home_terminal_description_long">于您所好之终端应用中，借 %1$s 行命令。</string>
+    <string name="home_terminal_description_long">于君所好之终端应用中，借 %1$s 行令，随心所欲。</string>
     <string name="home_terminal_step_1_title">其一：导出</string>
-    <string name="home_terminal_step_1_message">首先，导出文件至任一处。您将得二文件：%1$s 与 %2$s。</string>
-    <string name="home_terminal_step_1_message_warning">若所选之夹有同名文件，将被覆。</string>
+    <string name="home_terminal_step_1_message">首先，导出文件至任一处。君将得二文件：%1$s 与 %2$s。</string>
+    <string name="home_terminal_step_1_message_warning">若所选之夹有同名文件，将被覆，慎之。</string>
     <string name="home_terminal_step_1_button">导出文件</string>
     <string name="home_terminal_step_2_title">其二：编辑</string>
     <string name="home_terminal_step_2_message">继而，以文本编辑器启之，编辑 %1$s。</string>
     <string name="home_terminal_step_2_message_example">譬如，若欲于 %1$s 中用 %2$s，应将 %3$s 替换为 %4$s。</string>
     <string name="home_terminal_step_3_title">其三：使用</string>
-    <string name="home_terminal_step_3_message">末，将文件移至终端应用可及处，即可用 %1$s。</string>
+    <string name="home_terminal_step_3_message">末，将文件移至终端应用可及处，即可用 %1$s，大功告成。</string>
     <string name="home_terminal_step_3_message_tip">提点：授 %1$s 执行之权并将其入 %2$s，即可于任一处调用。</string>
-    <string name="home_terminal_message">%1$s 之助，于任一终端应用，您可连至 %2$s 服务并与之交。</string>
+    <string name="home_terminal_message">%1$s 之助，于任一终端应用，君可连至 %2$s 服务并与之交。</string>
 
     <!-- 设置 -->
     <string name="settings">设置</string>
-    <string name="settings_language">语言</string>
+    <string name="settings_language">言语</string>
     <string name="settings_dark_theme">外观</string>
     <string name="settings_black_dark_theme">纯黑夜间</string>
-    <string name="settings_black_dark_theme_description">若启夜间模式，则用纯黑之式。</string>
-    <string name="settings_start">启动</string>
+    <string name="settings_black_dark_theme_description">若启夜间模式，则用纯黑之式，护眼也。</string>
+    <string name="settings_start">启</string>
     <string name="settings_translation_title">翻译</string>
     <string name="settings_translation_contributors">翻译贡献者</string>
-    <string name="settings_translation_contribute">助吾等将 %s 译为汝之语。</string>
+    <string name="settings_translation_contribute">助吾等将 %s 译为君之语，功德无量。</string>
     <string name="settings_start_on_boot">开机自启（根）</string>
-    <string name="settings_start_on_boot_description">有根之机，%1$s 可于开机时自启。</string>
+    <string name="settings_start_on_boot_description">有根之机，%1$s 可于开机时自启，甚便。</string>
     <string name="settings_use_system_color">用系统之色</string>
     <string name="settings_about">关于</string>
     <string name="settings_about_source_code">于 %s 览源码。</string>
     <string name="settings_stop">止 %1$s</string>
-    <string name="settings_stop_description">%1$s 服务将止。</string>
+    <string name="settings_stop_description">%1$s 服务将止，君确定否？</string>
 
     <!-- 通知 -->
     <string name="notification_service_start_status">服务启止</string>
     <string name="notification_service_start_status_channel">服务启止</string>
-    <string name="notification_service_starting">%1$s 服务启中…</string>
-    <string name="notification_service_start_failed">启 %1$s 服务败。</string>
-    <string name="notification_service_start_failed_root">请根权限失败。</string>
-    <string name="notification_service_running">运行中…</string>
+    <string name="notification_service_starting">%1$s 服务启中，稍安勿躁…</string>
+    <string name="notification_service_start_failed">启 %1$s 服务败矣！</string>
+    <string name="notification_service_start_failed_root">请根权限失败，命途多舛。</string>
+    <string name="notification_service_running">运行中，君可安心。</string>
 
     <!-- 无线调试配对通知 -->
     <string name="notification_adb_pairing_action_input_code">入配对码</string>
-    <string name="notification_adb_pairing_action_discovery">搜索配对服务中</string>
-    <string name="notification_adb_pairing_action_discovery_done">已得配对服务</string>
+    <string name="notification_adb_pairing_action_discovery">搜索配对之服中</string>
+    <string name="notification_adb_pairing_action_discovery_done">已得配对之服！</string>
     <string name="notification_adb_pairing_action_discovery_stop">止搜索</string>
     <string name="notification_adb_pairing_action_pairing">配对行中…</string>
-    <string name="notification_adb_pairing_action_pairing_success">配对成！今可启 %1$s 服务。</string>
-    <string name="notification_adb_pairing_action_pairing_failed">配对败</string>
-    <string name="notification_adb_pairing_action_retry">重试</string>
+    <string name="notification_adb_pairing_action_pairing_success">配对成矣！今可启 %1$s 服务。</string>
+    <string name="notification_adb_pairing_action_pairing_failed">配对败矣！</string>
+    <string name="notification_adb_pairing_action_retry">再试</string>
 
     <!-- 权限 -->
     <string name="permission_label">%1$s</string>
     <string name="permission_description">许应用用 %1$s。</string>
     <string name="permission_group_label">%1$s</string>
     <string name="permission_group_description">@string/permission_label</string>
-    <string name="permission_template">许 **%1$s** %2$s？</string>
+    <string name="permission_template">许 **%1$s** %2$s 乎？</string>
     <string name="permission_dialog_always_allow">常许</string>
-    <string name="permission_dialog_deny">拒</string>
+    <string name="permission_dialog_deny">不许</string>
 
     <!-- 启动器 -->
     <string name="launcher">%1$s</string>
     <string name="launcher_start_root_shell">启根 Shell 中…</string>
-    <string name="launcher_start_root_shell_failed">因未获根权限或此机非根机，无法启服务。</string>
+    <string name="launcher_start_root_shell_failed">未获根权限或此机非根机，无法启服务。悲夫！</string>
 
     <!-- 对话框 -->
-    <string name="dialog_cannot_start_browser">无法启浏览器</string>
+    <string name="dialog_cannot_start_browser">无法启浏览器，呜呼。</string>
     <string name="dialog_copied_to_clipboard">已录于剪贴：%s</string>
-    <string name="dialog_copied_to_clipboard_with_text">**%s** 已录于剪贴。</string>
+    <string name="dialog_copied_to_clipboard_with_text">**%s** 已录于剪贴，可随时粘之。</string>
 
     <!-- 旧版不兼容 -->
     <string name="old_shizuku_not_support">%1$s 不支持今之 %2$s。</string>
-    <string name="old_shizuku_not_support_description">旧 %1$s 自二〇一九年三月已废。且旧 %1$s 与今 %1$s 不兼容。</string>
+    <string name="old_shizuku_not_support_description">旧 %1$s 自二〇一九年三月已废，且与今 %1$s 不兼容。时过境迁矣。</string>
     <string name="old_shizuku">%1$s 正求旧 %2$s。</string>
-    <string name="old_shizuku_description">**%1$s** 支持今之 %2$s，然其正求旧 %2$s。此或因其未更新。</string>
+    <string name="old_shizuku_description">**%1$s** 支持今之 %2$s，然其正求旧 %2$s。此或因其未更新，宜告之。</string>
     <string name="old_shizuku_open_shizuku">启 %1$s</string>
 
     <!-- 额外键 -->

--- a/manager/src/main/res/values-lzh/strings.xml
+++ b/manager/src/main/res/values-lzh/strings.xml
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <string name="app_name">Shizuku</string>
+
+    <!-- 主页 · 状态 -->
+    <string name="home_status_service_is_running">%1$s 方效力</string>
+    <string name="home_status_service_not_running">%1$s 未运行</string>
+    <string name="home_status_service_version">版本 %2$s，%1$s</string>
+    <string name="home_status_service_version_update"><![CDATA[版本 %2$s，%1$s。<br>重启以更新至 %3$s。]]></string>
+
+    <!-- 主页 · ADB 启动 -->
+    <string name="home_adb_title">连机以启</string>
+    <string name="home_adb_description">无根之机，须借 ADB 以启 %1$s。每次重启，皆须复行此法。</string>
+    <string name="home_adb_button_view_help">览助</string>
+    <string name="home_adb_button_view_command">览令</string>
+    <string name="home_adb_dialog_view_command_message"><![CDATA[于电脑之终端行此令：<br><br><font face="monospace">%1$s</font><br><br>* 备注数事：<br>…]]></string>
+    <string name="home_adb_dialog_view_command_copy_button">抄录</string>
+    <string name="home_adb_dialog_view_command_button_send">发送</string>
+
+    <!-- 主页 · 无线调试 -->
+    <string name="home_wireless_adb_title">无线调试以启</string>
+    <string name="home_wireless_adb_description">Android 11 及以上，可启无线调试以启 %1$s，无须连电脑。</string>
+    <string name="home_wireless_adb_description_pre_11">Android 11 之前，须先连电脑以启无线调试。</string>
+    <string name="home_wireless_adb_view_guide_button">循序导引</string>
+
+    <!-- 无线调试对话框 -->
+    <string name="dialog_adb_discovery">搜索无线调试服务中…</string>
+    <string name="dialog_adb_discovery_message">请于「开发者选项」中启用「无线调试」。若久搜不得，试先禁再启。</string>
+    <string name="dialog_adb_port">端口</string>
+    <string name="dialog_adb_invalid_port">端口须为一至六万五千五百三十五间之整数。</string>
+
+    <!-- 配对 -->
+    <string name="adb_pairing">配对</string>
+    <string name="dialog_adb_pairing_title">与设备配对</string>
+    <string name="dialog_adb_pairing_discovery">搜索配对服务中…</string>
+    <string name="dialog_adb_pairing_paring_code">配对码</string>
+    <string name="paring_code_is_wrong">配对码有误。</string>
+    <string name="dialog_adb_pairing_cannot_connect">无法连至无线调试服务。</string>
+    <string name="dialog_adb_pairing_not_started">无线调试未启。注：Android 11 之前，须先连电脑以启无线调试。</string>
+    <string name="dialog_adb_pairing_message">请循此步启配对：「开发者选项」→「无线调试」→「使用配对码配对设备」。</string>
+    <string name="dialog_adb_pairing_split_screen">请先进入分屏（多窗口）模式。</string>
+    <string name="dialog_adb_pairing_split_screen_message">系统要求配对对话框常显，故须用分屏模式。</string>
+    <string name="dialog_adb_pairing_key_store_error">无法生无线调试密钥。此或因密钥库之制有异。</string>
+    <string name="dialog_adb_pairing_start_first">请先成配对之步。</string>
+
+    <!-- 配对通知 -->
+    <string name="notification_adb_pairing_title">配对</string>
+    <string name="notification_adb_pairing_channel_name">无线调试配对</string>
+    <string name="notification_adb_pairing_message">%1$s 之通知将助您成配对。</string>
+    <string name="notification_adb_pairing_step_1">入「开发者选项」→「无线调试」，点按「使用配对码配对设备」。</string>
+    <string name="notification_adb_pairing_step_2">于通知中入配对码以成配对。</string>
+    <string name="notification_adb_pairing_warning">配对之程须与 %1$s 通知交互。请勿蔽此通知。</string>
+    <string name="notification_adb_pairing_miui_warning">MIUI 用户或须将通知之式由「通知栏」切换为「Android」。</string>
+    <string name="notification_adb_pairing_miui_warning_2">否则，或无法于通知中入配对码。</string>
+    <string name="notification_adb_pairing_step_3">请留意，「无线调试」选项左侧可点，点之可启无线调试。</string>
+    <string name="notification_adb_pairing_step_4">归 %1$s 以启之。</string>
+    <string name="notification_adb_pairing_network">%1$s 须访问局域网络。此由网络权限所辖。</string>
+    <string name="notification_adb_pairing_network_miui_note">某些系统（如 MIUI）禁应用于非前台时访问网络。</string>
+
+    <!-- 根启动 -->
+    <string name="home_root_title">根用户</string>
+    <string name="home_root_description">%1$s 可于开机时自启。若未自启，请手动启之。</string>
+    <string name="home_root_description_sui">若用 Magisk，可试 %1$s。于根用户，此更便捷。</string>
+    <string name="home_root_start_button">启动</string>
+    <string name="home_root_restart_button">重启</string>
+
+    <!-- 应用管理 -->
+    <string name="home_apps_title">应用管理</string>
+    <string name="home_apps_description">点按以管已授权之应用。</string>
+    <string name="home_apps_manage_button">管理</string>
+    <string name="home_apps_dialog_message">已请求或声明 %1$s 之应用将显于此处。</string>
+
+    <!-- 了解更多 -->
+    <string name="home_about_title">了解更多</string>
+    <string name="home_about_description">知 %1$s。</string>
+    <string name="home_about_learn_button">学以 %1$s 开发</string>
+
+    <!-- ADB 权限受限 -->
+    <string name="home_adb_permission_title">您须多行一步。</string>
+    <string name="home_adb_permission_description">您之设备制造商已限 ADB 权限，用 %1$s 之应用将受限。</string>
+    <string name="home_adb_permission_limited">ADB 权限受限</string>
+    <string name="home_adb_permission_limited_description">您之设备制造商极可能已限 ADB 权限，致用 %1$s 之应用功能不全。此限或不可绕。</string>
+    <string name="home_adb_permission_limited_note">* 须 %1$s 以根权限运行。</string>
+
+    <!-- 终端应用 -->
+    <string name="home_terminal_title">终端</string>
+    <string name="home_terminal_description">于终端应用中用 %1$s。</string>
+    <string name="home_terminal_description_long">于您所好之终端应用中，借 %1$s 行命令。</string>
+    <string name="home_terminal_step_1_title">其一：导出</string>
+    <string name="home_terminal_step_1_message">首先，导出文件至任一处。您将得二文件：%1$s 与 %2$s。</string>
+    <string name="home_terminal_step_1_message_warning">若所选之夹有同名文件，将被覆。</string>
+    <string name="home_terminal_step_1_button">导出文件</string>
+    <string name="home_terminal_step_2_title">其二：编辑</string>
+    <string name="home_terminal_step_2_message">继而，以文本编辑器启之，编辑 %1$s。</string>
+    <string name="home_terminal_step_2_message_example">譬如，若欲于 %1$s 中用 %2$s，应将 %3$s 替换为 %4$s。</string>
+    <string name="home_terminal_step_3_title">其三：使用</string>
+    <string name="home_terminal_step_3_message">末，将文件移至终端应用可及处，即可用 %1$s。</string>
+    <string name="home_terminal_step_3_message_tip">提点：授 %1$s 执行之权并将其入 %2$s，即可于任一处调用。</string>
+    <string name="home_terminal_message">%1$s 之助，于任一终端应用，您可连至 %2$s 服务并与之交。</string>
+
+    <!-- 设置 -->
+    <string name="settings">设置</string>
+    <string name="settings_language">语言</string>
+    <string name="settings_dark_theme">外观</string>
+    <string name="settings_black_dark_theme">纯黑夜间</string>
+    <string name="settings_black_dark_theme_description">若启夜间模式，则用纯黑之式。</string>
+    <string name="settings_start">启动</string>
+    <string name="settings_translation_title">翻译</string>
+    <string name="settings_translation_contributors">翻译贡献者</string>
+    <string name="settings_translation_contribute">助吾等将 %s 译为汝之语。</string>
+    <string name="settings_start_on_boot">开机自启（根）</string>
+    <string name="settings_start_on_boot_description">有根之机，%1$s 可于开机时自启。</string>
+    <string name="settings_use_system_color">用系统之色</string>
+    <string name="settings_about">关于</string>
+    <string name="settings_about_source_code">于 %s 览源码。</string>
+    <string name="settings_stop">止 %1$s</string>
+    <string name="settings_stop_description">%1$s 服务将止。</string>
+
+    <!-- 通知 -->
+    <string name="notification_service_start_status">服务启止</string>
+    <string name="notification_service_start_status_channel">服务启止</string>
+    <string name="notification_service_starting">%1$s 服务启中…</string>
+    <string name="notification_service_start_failed">启 %1$s 服务败。</string>
+    <string name="notification_service_start_failed_root">请根权限失败。</string>
+    <string name="notification_service_running">运行中…</string>
+
+    <!-- 无线调试配对通知 -->
+    <string name="notification_adb_pairing_action_input_code">入配对码</string>
+    <string name="notification_adb_pairing_action_discovery">搜索配对服务中</string>
+    <string name="notification_adb_pairing_action_discovery_done">已得配对服务</string>
+    <string name="notification_adb_pairing_action_discovery_stop">止搜索</string>
+    <string name="notification_adb_pairing_action_pairing">配对行中…</string>
+    <string name="notification_adb_pairing_action_pairing_success">配对成！今可启 %1$s 服务。</string>
+    <string name="notification_adb_pairing_action_pairing_failed">配对败</string>
+    <string name="notification_adb_pairing_action_retry">重试</string>
+
+    <!-- 权限 -->
+    <string name="permission_label">%1$s</string>
+    <string name="permission_description">许应用用 %1$s。</string>
+    <string name="permission_group_label">%1$s</string>
+    <string name="permission_group_description">@string/permission_label</string>
+    <string name="permission_template">许 **%1$s** %2$s？</string>
+    <string name="permission_dialog_always_allow">常许</string>
+    <string name="permission_dialog_deny">拒</string>
+
+    <!-- 启动器 -->
+    <string name="launcher">%1$s</string>
+    <string name="launcher_start_root_shell">启根 Shell 中…</string>
+    <string name="launcher_start_root_shell_failed">因未获根权限或此机非根机，无法启服务。</string>
+
+    <!-- 对话框 -->
+    <string name="dialog_cannot_start_browser">无法启浏览器</string>
+    <string name="dialog_copied_to_clipboard">已录于剪贴：%s</string>
+    <string name="dialog_copied_to_clipboard_with_text">**%s** 已录于剪贴。</string>
+
+    <!-- 旧版不兼容 -->
+    <string name="old_shizuku_not_support">%1$s 不支持今之 %2$s。</string>
+    <string name="old_shizuku_not_support_description">旧 %1$s 自二〇一九年三月已废。且旧 %1$s 与今 %1$s 不兼容。</string>
+    <string name="old_shizuku">%1$s 正求旧 %2$s。</string>
+    <string name="old_shizuku_description">**%1$s** 支持今之 %2$s，然其正求旧 %2$s。此或因其未更新。</string>
+    <string name="old_shizuku_open_shizuku">启 %1$s</string>
+
+    <!-- 额外键 -->
+    <string name="home_wireless_adb">无线调试</string>
+    <string name="home_root">根</string>
+    <string name="home_adb">ADB</string>
+
+    <!-- 翻译贡献者（留空，由社区填） -->
+    <string name="translation_contributors"></string>
+
+</resources>

--- a/manager/src/main/res/values-zh-rCN-rLC/strings.xml
+++ b/manager/src/main/res/values-zh-rCN-rLC/strings.xml
@@ -1,0 +1,173 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <string name="app_name">Shizuku</string>
+
+    <!-- 主页 · 状态 -->
+    <string name="home_status_service_is_running">%1$s 正在给本喵打工喵~ (=^・ω・^=)</string>
+    <string name="home_status_service_not_running">%1$s 在摸鱼喵…本喵很失望喵 :C</string>
+    <string name="home_status_service_version">版本 %2$s 喵，%1$s 喵</string>
+    <string name="home_status_service_version_update"><![CDATA[版本 %2$s 喵，%1$s 喵。<br>重启一下就能更新到 %3$s 喵，快去喵！]]></string>
+
+    <!-- 主页 · ADB 启动 -->
+    <string name="home_adb_title">连上电脑才能启动喵！</string>
+    <string name="home_adb_description">铲屎官的手机没有 root 喵，要用 ADB 才能启动 %1$s 喵。每次重启都要再来一遍喵，辛苦铲屎官了喵~</string>
+    <string name="home_adb_button_view_help">看看帮助喵</string>
+    <string name="home_adb_button_view_help">看看帮助喵</string>
+    <string name="home_adb_button_view_command">看看命令喵</string>
+    <string name="home_adb_dialog_view_command_message"><![CDATA[在电脑终端里敲这个命令喵：<br><br><font face="monospace">%1$s</font><br><br>* 注意几件事喵：<br>…]]></string>
+    <string name="home_adb_dialog_view_command_copy_button">抄走喵！</string>
+    <string name="home_adb_dialog_view_command_button_send">发过去喵！</string>
+
+    <!-- 主页 · 无线调试 -->
+    <string name="home_wireless_adb_title">无线调试启动喵！</string>
+    <string name="home_wireless_adb_description">Android 11 以上可以用无线调试启动 %1$s 喵，不用连电脑喵，太方便了喵！本喵很开心喵 (=^・ω・^=)</string>
+    <string name="home_wireless_adb_description_pre_11">Android 11 之前要先连电脑才能开无线调试喵，好麻烦喵 :(</string>
+    <string name="home_wireless_adb_view_guide_button">跟着步骤走喵</string>
+
+    <!-- 无线调试对话框 -->
+    <string name="dialog_adb_discovery">正在找无线调试服务喵…稍等喵~</string>
+    <string name="dialog_adb_discovery_message">请去「开发者选项」打开「无线调试」喵。找不到的话试试关了再开喵。</string>
+    <string name="dialog_adb_port">端口喵</string>
+    <string name="dialog_adb_invalid_port">端口要填 1 到 65535 之间的数字喵！不要乱填喵！(｀Д´)ノ</string>
+
+    <!-- 配对 -->
+    <string name="adb_pairing">配对喵</string>
+    <string name="dialog_adb_pairing_title">和设备配对喵</string>
+    <string name="dialog_adb_pairing_discovery">正在找配对服务喵…</string>
+    <string name="dialog_adb_pairing_paring_code">配对码喵</string>
+    <string name="paring_code_is_wrong">配对码不对喵！铲屎官再检查一下喵 :(</string>
+    <string name="dialog_adb_pairing_cannot_connect">连不上无线调试服务喵…本喵很沮丧喵 :(</string>
+    <string name="dialog_adb_pairing_not_started">无线调试还没开喵！注意：Android 11 之前要先连电脑喵。</string>
+    <string name="dialog_adb_pairing_message">按这个顺序操作喵：「开发者选项」→「无线调试」→「使用配对码配对设备」喵。</string>
+    <string name="dialog_adb_pairing_split_screen">先进分屏模式喵！</string>
+    <string name="dialog_adb_pairing_split_screen_message">系统要求配对框一直显示喵，所以要用分屏喵，没办法喵 :(</string>
+    <string name="dialog_adb_pairing_key_store_error">没法生成无线调试密钥喵…可能是密钥库有什么问题喵。</string>
+    <string name="dialog_adb_pairing_start_first">先把配对步骤做完喵！不要着急喵~ ฅ^・ω・^ฅ</string>
+
+    <!-- 配对通知 -->
+    <string name="notification_adb_pairing_title">配对喵</string>
+    <string name="notification_adb_pairing_channel_name">无线调试配对喵</string>
+    <string name="notification_adb_pairing_message">%1$s 的通知会帮铲屎官配对喵~</string>
+    <string name="notification_adb_pairing_step_1">去「开发者选项」→「无线调试」，点「使用配对码配对设备」喵。</string>
+    <string name="notification_adb_pairing_step_2">在通知里输入配对码就能配对了喵！别忘了喵！</string>
+    <string name="notification_adb_pairing_warning">配对过程中要和 %1$s 的通知互动喵！千万别把通知藏起来喵！不然就白忙活了喵！(｀Д´)ノ</string>
+    <string name="notification_adb_pairing_miui_warning">MIUI 用户可能要把通知样式从「通知栏」改成「Android」喵。</string>
+    <string name="notification_adb_pairing_miui_warning_2">不然可能没法在通知里输配对码喵，到时候铲屎官就哭唧唧了喵 :(</string>
+    <string name="notification_adb_pairing_step_3">注意喵！「无线调试」左边有个按钮可以点喵，点一下就能开无线调试喵！</string>
+    <string name="notification_adb_pairing_step_4">回到 %1$s 启动它喵~</string>
+    <string name="notification_adb_pairing_network">%1$s 要访问局域网喵，这是网络权限管的喵。</string>
+    <string name="notification_adb_pairing_network_mi_note">某些系统（比如 MIUI）会限制应用在后台访问网络喵，好烦喵 :(</string>
+
+    <!-- 根启动 -->
+    <string name="home_root_title">Root 用户喵</string>
+    <string name="home_root_description">%1$s 可以开机自启喵。如果没自动启动的话请手动启动喵，别怪本喵喵~</string>
+    <string name="home_root_description_sui">如果用 Magisk 的话可以试试 %1$s 喵，对 root 用户来说更方便喵！</string>
+    <string name="home_root_start_button">启动喵！</string>
+    <string name="home_root_restart_button">重启喵！</string>
+
+    <!-- 应用管理 -->
+    <string name="home_apps_title">管理应用喵</string>
+    <string name="home_apps_description">点一下看看哪些应用有权限喵，一目了然喵~ (=^・ω・^=)</string>
+    <string name="home_apps_manage_button">管管它们喵</string>
+    <string name="home_apps_dialog_message">请求过或声明了 %1$s 的应用会出现在这里喵~</string>
+
+    <!-- 了解更多 -->
+    <string name="home_about_title">了解更多喵</string>
+    <string name="home_about_description">认识一下 %1$s 喵。</string>
+    <string name="home_about_learn_button">学习用 %1$s 开发喵</string>
+
+    <!-- ADB 权限受限 -->
+    <string name="home_adb_permission_title">还要再做一步喵…</string>
+    <string name="home_adb_permission_description">铲屎官的设备厂商限制了 ADB 权限喵，用 %1⁂ 的应用会少很多功能喵，本喵也很无奈喵 :(</string>
+    <string name="home_adb_permission_limited">ADB 权限被限制了喵</string>
+    <string name="home_adb_permission_limited_description">铲屎官的设备厂商很可能限制了 ADB 权限喵，导致用 %1$s 的应用功能不全喵。这个限制绕不过去喵，认命吧喵 :(</string>
+    <string name="home_adb_permission_limited_note">* 需要 %1$s 以 root 权限运行才行喵。</string>
+
+    <!-- 终端应用 -->
+    <string name="home_terminal_title">终端喵</string>
+    <string name="home_terminal_description">在终端应用里用 %1$s 喵~</string>
+    <string name="home_terminal_description_long">在铲屎官喜欢的终端应用里用 %1$s 跑命令喵，随心所欲喵~ ฅ^・ω・^ฅ</string>
+    <string name="home_terminal_step_1_title">第一步：导出喵</string>
+    <string name="home_terminal_step_1_message">先把文件导出到随便哪里喵。会得到两个文件喵：%1$s 和 %2$s 喵。</string>
+    <string name="home_terminal_step_1_message_warning">如果目标文件夹有同名文件会被覆盖喵！小心喵！</string>
+    <string name="home_terminal_step_1_button">导出文件喵</string>
+    <string name="home_terminal_step_2_title">第二步：编辑喵</string>
+    <string name="home_terminal_step_2_message">然后用文本编辑器打开编辑 %1$s 喵。</string>
+    <string name="home_terminal_step_2_message_example">比如喵，如果想在 %1$s 里用 %2$s，就把 %3$s 换成 %4$s 喵。</string>
+    <string name="home_terminal_step_3_title">第三步：使用喵</string>
+    <string name="home_terminal_step_3_message">最后喵，把文件移到终端应用能访问的地方喵，就能用 %1$s 了喵！大功告成喵！(≧▽≦)/</string>
+    <string name="home_terminal_step_3_message_tip">小提示喵：给 %1$s 加上执行权限放进 %2$s，就哪里都能用它了喵！</string>
+    <string name="home_terminal_message">有了 %1⁂ 喵，在任何终端应用里都能连上 %2⁂ 服务和它聊天了喵~</string>
+
+    <!-- 设置 -->
+    <string name="settings">设置喵</string>
+    <string name="settings_language">语言喵</string>
+    <string name="settings_dark_theme">外观喵</string>
+    <string name="settings_black_dark_theme">纯黑夜间模式喵</string>
+    <string name="settings_black_dark_theme_description">如果开了夜间模式就用纯黑喵，保护铲屎官的眼睛喵~ (=^・ω・^=)</string>
+    <string name="settings_start">启动喵</string>
+    <string name="settings_translation_title">翻译喵</string>
+    <string name="settings_translation_contributors">翻译贡献者喵</string>
+    <string name="settings_translation_contribute">帮本喵把 %s 翻译成铲屎官的语言喵！功德无量喵~ ฅ^・ω・^ฅ</string>
+    <string name="settings_start_on_boot">开机自启（root）喵</string>
+    <string name="settings_start_on_boot_description">有 root 的手机喵，%1$s 可以开机自启喵，很方便喵！</string>
+    <string name="settings_use_system_color">用系统颜色喵</string>
+    <string name="settings_about">关于喵</string>
+    <string name="settings_about_source_code">在 %s 看源码喵~</string>
+    <string name="settings_stop">停止 %1$s 喵</string>
+    <string name="settings_stop_description">%1⁂ 服务要停下来了喵。铲屎官确定吗喵？？(ﾟдﾟ)</string>
+
+    <!-- 通知 -->
+    <string name="notification_service_start_status">服务启停喵</string>
+    <string name="notification_service_start_status_channel">服务启停喵</string>
+    <string name="notification_service_starting">%1⁂ 服务正在启动喵…稍等喵~ (´・ω・`)</string>
+    <string name="notification_service_start_failed">%1⁂ 服务启动失败了喵！！呜呜呜 QAQ</string>
+    <string name="notification_service_start_failed_root">获取 root 权限失败了喵…今天运气不好喵 :(</string>
+    <string name="notification_service_running">正在运行喵！铲屎官可以放心了喵~ (=^・ω・^=)</string>
+
+    <!-- 无线调试配对通知 -->
+    <string name="notification_adb_pairing_action_input_code">输入配对码喵</string>
+    <string name="notification_adb_pairing_action_discovery">正在找配对服务喵</string>
+    <string name="notification_adb_pairing_action_discovery_done">找到配对服务了喵！(≧▽≦)</string>
+    <string name="notification_adb_pairing_action_discovery_stop">别找了喵</string>
+    <string name="notification_adb_pairing_action_pairing">正在配对喵…</string>
+    <string name="notification_adb_pairing_action_pairing_success">配对成功了喵！现在可以启动 %1⁂ 服务了喵！本喵很开心喵！(≧▽≦)/</string>
+    <string name="notification_adb_pairing_action_pairing_failed">配对失败了喵！！呜呜呜 QAQ</string>
+    <string name="notification_adb_pairing_action_retry">再试一次喵</string>
+
+    <!-- 权限 -->
+    <string name="permission_label">%1$s 喵</string>
+    <string name="permission_description">让应用使用 %1$s 喵~</string>
+    <string name="permission_group_label">%1$s 喵</string>
+    <string name="permission_group_description">@string/permission_label</string>
+    <string name="permission_template">允许 **%1$s** %2$s 喵？(ﾟдﾟ)</string>
+    <string name="permission_dialog_always_allow">永远允许喵</string>
+    <string name="permission_dialog_deny">不行喵！拒绝喵！(｀Д´)ノ</string>
+
+    <!-- 启动器 -->
+    <string name="launcher">%1$s 喵</string>
+    <string name="launcher_start_root_shell">正在启动 root Shell 喵…</string>
+    <string name="launcher_start_root_shell_failed">没有 root 权限或者这不是 root 手机喵，启动不了服务喵…本喵也无能为力喵 :(</string>
+
+    <!-- 对话框 -->
+    <string name="dialog_cannot_start_browser">打不开浏览器喵…呜喵 :(</string>
+    <string name="dialog_copied_to_clipboard">已经复制到剪贴板了喵：%s</string>
+    <string name="dialog_copied_to_clipboard_with_text">**%s** 已经在剪贴板里了喵！随便粘贴喵~ (=^・ω・^=)</string>
+
+    <!-- 旧版不兼容 -->
+    <string name="old_shizuku_not_support">%1⁂ 不支持新版 %2⁂ 喵。</string>
+    <string name="old_shizuku_not_support_description">旧 %1⁂ 从 2019 年 3 月就已经退役了喵，而且和新版 %1⁂ 不兼容喵。时过境迁喵… :(</string>
+    <string name="old_shizuku">%1⁂ 在找旧版 %2⁂ 喵。</string>
+    <string name="old_shizuku_description">**%1⁂** 支持新版 %2⁂ 喵，但它在找旧版 %2⁂ 喵。可能是因为还没更新喵，提醒一下铲屎官喵~</string>
+    <string name="old_shizuku_open_shizuku">打开 %1⁂ 喵</string>
+
+    <!-- 额外键 -->
+    <string name="home_wireless_adb">无线调试喵</string>
+    <string name="home_root">Root 喵</string>
+    <string name="home_adb">ADB 喵</string>
+
+    <!-- 翻译贡献者 -->
+    <string name="translation_contributors"></string>
+
+</resources>


### PR DESCRIPTION
## Summary

Adds **three** new language options for Shizuku, inspired by Minecraft's easter egg languages:

### 1. Literary Chinese (文言) — `values-lzh/strings.xml`

Classical Chinese with archaic style:
- Particles: 也、矣、乎、哉
- Dramatic: `启服务败矣！` `呜呼` `悲夫` `命也`
- Poetic: `时过境迁` `功亏一篑` `功德无量`

### 2. LOLCAT (English) — `values-en-rLC/strings.xml`

Classic LOLCAT cat-speak:
- `iz runnin 4 u!!1!`
- `oh noes!!`
- `PAIRIN SUCCES!! :D`
- `y u do dis :C`

### 3. 中文猫语 (Chinese LOLCAT) — `values-zh-rCN-rLC/strings.xml`

Chinese internet cat-speak with full meme energy:
- 本喵/铲屎官 instead of 我/用户
- Every sentence ends with 喵~
- Cat emoticons: `(=^・ω・^=)` `ฅ^・ω・^ฅ`
- Emotions: `QAQ` `(ﾟдﾟ)` `(≧▽≦)/`
- Drama: `呜呜呜 QAQ` `别怪本喵喵~` `本喵也很无奈喵`

### Preview

| Key | 文言 | LOLCAT | 中文猫语 |
|-----|------|--------|----------|
| running | 正效力于君 | iz runnin 4 u!!1! | 正在给本喵打工喵~ (=^・ω・^=) |
| failed | 启服务败矣！ | oh noes!! | 启动失败了喵！！呜呜呜 QAQ |
| deny | 不许 | NO!! deny!! | 不行喵！拒绝喵！(｀Д´)ノ |
| copy | 抄录 | COPPY | 抄走喵！ |
| always allow | 常许 | Alwayz allow | 永远允许喵 |
| stop confirm | 君确定否？ | r u sure?? | 铲屎官确定吗喵？？(ﾟдﾟ) |

### Files

| File | Language |
|------|----------|
| `values-lzh/strings.xml` | 文言 (Literary Chinese) |
| `values-en-rLC/strings.xml` | LOLCAT (English) |
| `values-zh-rCN-rLC/strings.xml` | 中文猫语 (Chinese LOLCAT) |
